### PR TITLE
LLVM Fix

### DIFF
--- a/src/Parser/Parser.cpp
+++ b/src/Parser/Parser.cpp
@@ -2013,8 +2013,8 @@ ParserResultKind Parser::ParseSharedLib(llvm::StringRef File,
     for each(System::String^ LibDir in Opts->LibraryDirs)
     {
         auto DirName = clix::marshalString<clix::E_UTF8>(LibDir);
-        llvm::sys::Path Path(DirName);
-        Path.appendComponent(File);
+        llvm::SmallString<256> Path(DirName);
+        llvm::sys::path::append(Path, File);
 
         if (FileEntry = FM.getFile(Path.str()))
             break;

--- a/src/Parser/Parser.lua
+++ b/src/Parser/Parser.lua
@@ -59,6 +59,7 @@ project "Parser"
   {
     "LLVMSupport",
     "LLVMObject",
+    "LLVMOption",
     "LLVMAsmParser",
     "LLVMBitReader",
     "LLVMBitWriter",


### PR DESCRIPTION
Small fix to support LLVM as of r185136.
- LLVM changed to their new path API.
- LLVMOption.lib is now required to link.
