### PR TITLE
Fix For CheckTypeReferencesPass

### DIFF
--- a/src/Generator/Passes/CheckTypeReferencesPass.cs
+++ b/src/Generator/Passes/CheckTypeReferencesPass.cs
@@ -6,6 +6,12 @@
 
         public override bool VisitTranslationUnit(TranslationUnit unit)
         {
+            if (unit.Ignore)
+                return false;
+
+            if (unit.IsSystemHeader)
+                return false;
+
             typeRefs = new TypeRefsVisitor();
             return typeRefs.VisitTranslationUnit(unit);
         }


### PR DESCRIPTION
Fix for https://github.com/mono/CppSharp/issues/6.

CheckTypeReferencesPass was not skipping ignored source files causing it to process headers that were not able to be wrapped.  
