### PR TITLE
Fix for unhandled null pointer exception in VisitParameterDecl()

### DIFF
--- a/src/Parser/Parser.cpp
+++ b/src/Parser/Parser.cpp
@@ -2023,11 +2023,10 @@ ParserResultKind Parser::ParseSharedLib(llvm::StringRef File,
     for each(System::String^ LibDir in Opts->LibraryDirs)
     {
         auto DirName = clix::marshalString<clix::E_UTF8>(LibDir);
-
         llvm::SmallString<256> Path(DirName);
         llvm::sys::path::append(Path, File);
 
-        if (FileEntry = FM.getFile(P.str()))
+        if (FileEntry = FM.getFile(Path.str()))
             break;
     }
 


### PR DESCRIPTION
This got me past the unhandled exception, but is this null indicative of a problem elsewhere, which needs better error handling?

What does parameter.Type being null actually mean at this point in the flow?

This is the form of the parameter which the failure is happening on ...

char\* pArgv[]

... in a main()-style function prototype.
