### PR TITLE
Added global:: prefix to all System.IntPtr references in the C# code gen...

### DIFF
--- a/src/Generator/Generators/CSharp/CSharpMarshal.cs
+++ b/src/Generator/Generators/CSharp/CSharpMarshal.cs
@@ -201,7 +201,7 @@ namespace CppSharp.Generators.CSharp
             string instance = Context.ReturnVarName;
             if (ctx.Kind == CSharpMarshalKind.NativeField)
             {
-                instance = string.Format("new System.IntPtr(&{0})", instance);
+                instance = string.Format("new global::System.IntPtr(&{0})", instance);
             }
 
             Context.Return.Write("new {0}({1})", QualifiedIdentifier(@class),
@@ -306,7 +306,7 @@ namespace CppSharp.Generators.CSharp
                             Helpers.SafeIdentifier(Context.Parameter.Name));
                 }
 
-                Context.Return.Write("new System.IntPtr(&{0})",
+                Context.Return.Write("new global::System.IntPtr(&{0})",
                     Helpers.GeneratedIdentifier(Context.ArgName));
                 return true;
             }

--- a/src/Generator/Generators/CSharp/CSharpTextTemplate.cs
+++ b/src/Generator/Generators/CSharp/CSharpTextTemplate.cs
@@ -323,7 +323,7 @@ namespace CppSharp.Generators.CSharp
                 if (ShouldGenerateClassNativeField(@class))
                 {
                     PushBlock(CSharpBlockKind.Field);
-                    WriteLine("public System.IntPtr {0} {{ get; protected set; }}",
+                    WriteLine("public global::System.IntPtr {0} {{ get; protected set; }}",
                         Helpers.InstanceIdentifier);
                     PopBlock(NewLineKind.BeforeNextBlock);
                 }
@@ -1031,7 +1031,7 @@ namespace CppSharp.Generators.CSharp
             PushBlock(CSharpBlockKind.Method);
             WriteLine("internal {0}({1}.Internal* native)", SafeIdentifier(@class.Name),
                 @class.Name);
-            WriteLineIndent(": this(new System.IntPtr(native))");
+            WriteLineIndent(": this(new global::System.IntPtr(native))");
             WriteStartBraceIndent();
             WriteCloseBraceIndent();
             PopBlock(NewLineKind.BeforeNextBlock);
@@ -1045,7 +1045,7 @@ namespace CppSharp.Generators.CSharp
             PopBlock(NewLineKind.BeforeNextBlock);
 
             PushBlock(CSharpBlockKind.Method);
-            WriteLine("internal {0}(System.IntPtr native)", SafeIdentifier(@class.Name));
+            WriteLine("internal {0}(global::System.IntPtr native)", SafeIdentifier(@class.Name));
 
             var hasBaseClass = @class.HasBaseClass && @class.BaseClass.IsRefType;
             if (hasBaseClass)
@@ -1325,7 +1325,7 @@ namespace CppSharp.Generators.CSharp
 
             if (needsInstance)
             {
-                names.Insert(0, needsFixedThis ? string.Format("new System.IntPtr(&{0})",
+                names.Insert(0, needsFixedThis ? string.Format("new global::System.IntPtr(&{0})",
                     GeneratedIdentifier("instance")) : Helpers.InstanceIdentifier);
             }
 
@@ -1803,10 +1803,10 @@ namespace CppSharp.Generators.CSharp
             var method = function as Method;
             if (method != null && !method.IsStatic)
             {
-                @params.Add("System.IntPtr instance");
+                @params.Add("global::System.IntPtr instance");
 
                 if (method.IsConstructor && Options.IsMicrosoftAbi)
-                    retType = "System.IntPtr";
+                    retType = "global::System.IntPtr";
             }
 
             for (var i = 0; i < function.Parameters.Count; ++i)

--- a/src/Generator/Generators/CSharp/CSharpTypePrinter.cs
+++ b/src/Generator/Generators/CSharp/CSharpTypePrinter.cs
@@ -172,17 +172,17 @@ namespace CppSharp.Generators.CSharp
             var isManagedContext = ContextKind == CSharpTypePrinterContextKind.Managed;
 
             if (IsConstCharString(pointer))
-                return isManagedContext ? "string" : "System.IntPtr";
+                return isManagedContext ? "string" : "global::System.IntPtr";
 
             PrimitiveType primitive;
             if (pointee.Desugar().IsPrimitiveType(out primitive))
-                return "System.IntPtr";
+                return "global::System.IntPtr";
 
             Class @class;
             if (pointee.IsTagDecl(out @class)
                 && ContextKind == CSharpTypePrinterContextKind.Native)
             {
-                return "System.IntPtr";
+                return "global::System.IntPtr";
             }
 
             return pointee.Visit(this, quals);
@@ -225,7 +225,7 @@ namespace CppSharp.Generators.CSharp
             if (decl.Type.IsPointerTo<FunctionType>(out func))
             {
                 if (ContextKind == CSharpTypePrinterContextKind.Native)
-                    return "System.IntPtr";
+                    return "global::System.IntPtr";
                 // TODO: Use SafeIdentifier()
                 return VisitDeclaration(decl);
             }
@@ -314,7 +314,7 @@ namespace CppSharp.Generators.CSharp
                 case PrimitiveType.UInt64: return "ulong";
                 case PrimitiveType.Float: return "float";
                 case PrimitiveType.Double: return "double";
-                case PrimitiveType.IntPtr: return "System.IntPtr";
+                case PrimitiveType.IntPtr: return "global::System.IntPtr";
             }
 
             throw new NotSupportedException();


### PR DESCRIPTION
...erator.

Without this qualification it is possible for the generated code to have namespace clashes with nested System namespaces in the code being wrapped.
