### PR TITLE
Qtcore hacks

### DIFF
--- a/src/AST/Enumeration.cs
+++ b/src/AST/Enumeration.cs
@@ -30,7 +30,11 @@ namespace CppSharp.AST
             public bool IsHexadecimal
             {
                 get
-                { 
+                {
+                    if (Expression == null)
+                    {
+                        return false;
+                    }
                     return Expression.Contains("0x") || Expression.Contains("0X");
                 }
             }

--- a/src/Generator/Generators/CSharp/CSharpTypePrinter.cs
+++ b/src/Generator/Generators/CSharp/CSharpTypePrinter.cs
@@ -96,9 +96,9 @@ namespace CppSharp.Generators.CSharp
             if (ContextKind == CSharpTypePrinterContextKind.Native &&
                 array.SizeType == ArrayType.ArraySize.Constant)
             {
-                PrimitiveType primitive;
-                if (!array.Type.Desugar().IsPrimitiveType(out primitive))
-                    throw new NotSupportedException();
+                //PrimitiveType primitive;
+                //if (!array.Type.Desugar().IsPrimitiveType(out primitive))
+                //    throw new NotSupportedException();
 
                 return new CSharpTypePrinterResult()
                 {

--- a/src/Generator/Types/CppTypePrinter.cs
+++ b/src/Generator/Types/CppTypePrinter.cs
@@ -118,7 +118,7 @@ namespace CppSharp.Types
         public string VisitTemplateParameterSubstitutionType(
             TemplateParameterSubstitutionType param, TypeQualifiers quals)
         {
-            throw new System.NotImplementedException();
+            return param.Replacement.Visit(this);
         }
 
         public string VisitInjectedClassNameType(InjectedClassNameType injected, TypeQualifiers quals)


### PR DESCRIPTION
3 hacks, explained in the commit message, needed to reach code generation for MinGW QtCore 5.1.0. Two of the hacks are workarounds for already reported issues.
