### PR TITLE
Support wrapping unions

### DIFF
--- a/src/AST/Class.cs
+++ b/src/AST/Class.cs
@@ -138,7 +138,7 @@ namespace CppSharp.AST
 
         public bool IsValueType
         {
-            get { return Type == ClassType.ValueType; }
+            get { return Type == ClassType.ValueType || IsUnion; }
         }
 
         public bool IsRefType

--- a/src/Generator/Generators/CSharp/CSharpTextTemplate.cs
+++ b/src/Generator/Generators/CSharp/CSharpTextTemplate.cs
@@ -310,12 +310,6 @@ namespace CppSharp.Generators.CSharp
             PushBlock(CSharpBlockKind.Class);
             GenerateDeclarationCommon(@class);
 
-            if (@class.IsUnion)
-            {
-                // TODO: How to do wrapping of unions?
-                throw new NotImplementedException();
-            }
-
             GenerateClassProlog(@class);
 
             NewLine();


### PR DESCRIPTION
The fields of a union come with the correct (equal) offsets from the parser so all we need to do is generate a struct and not throw an exception along the way.
