### PR TITLE
Restored the VS 2010 support. Added a test for operators outside types

### DIFF
--- a/build/GenerateProjects.bat
+++ b/build/GenerateProjects.bat
@@ -5,18 +5,24 @@ goto menu
 echo Build Project Generator:
 echo.
 echo [0] Clean
-echo [1] Visual C++ 2012
-echo [2] GNU Make
+echo [1] Visual C++ 2010
+echo [2] Visual C++ 2012
+echo [3] GNU Make
 echo.
 
 :choice
 set /P C="Choice: "
-if "%C%"=="2" goto gmake
-if "%C%"=="1" goto vs2012
+if "%C%"=="3" goto gmake
+if "%C%"=="2" goto vs2012
+if "%C%"=="1" goto vs2010
 if "%C%"=="0" goto clean
 
 :clean
 "premake4" --file=premake4.lua clean
+goto quit
+
+:vs2010
+"premake4" --file=premake4.lua vs2010
 goto quit
 
 :vs2012

--- a/tests/Basic/Basic.Tests.cs
+++ b/tests/Basic/Basic.Tests.cs
@@ -35,6 +35,11 @@ public class BasicTests
         var bar2 = new Bar2 { A = 4, B = 7, C = 3 };
         Assert.That(hello.AddBar2(bar2), Is.EqualTo(14));
 
+        Bar bar1 = new Bar { A = 5, B = 10 };
+        var barSum = bar + bar1;
+        Assert.That(barSum.A, Is.EqualTo(bar.A + bar1.A));
+        Assert.That(barSum.B, Is.EqualTo(bar.B + bar1.B));
+
         Assert.That(hello.RetEnum(Enum.A), Is.EqualTo(0));
         Assert.That(hello.RetEnum(Enum.B), Is.EqualTo(2));
         Assert.That(hello.RetEnum(Enum.C), Is.EqualTo(5));

--- a/tests/Basic/Basic.cpp
+++ b/tests/Basic/Basic.cpp
@@ -70,3 +70,11 @@ int Hello::RetEnum(Enum e)
 {
     return (int)e;
 }
+
+Bar operator&(const Bar& b1, const Bar& b2)
+{
+    Bar b;
+    b.A = b1.A + b2.A;
+    b.B = b1.B + b2.B;
+    return b;
+}

--- a/tests/Basic/Basic.h
+++ b/tests/Basic/Basic.h
@@ -61,3 +61,5 @@ public:
 
     int RetEnum(Enum);
 };
+
+DLL_API Bar operator+(const Bar &, const Bar &);


### PR DESCRIPTION
Warning: this commit causes the generation of an uncompilable test library because incorrect code is generated for such operators.
