### PR TITLE
Marshalled pointers to primitive types as such instead of using IntPtr

### DIFF
--- a/src/Generator/Generators/CSharp/CSharpMarshal.cs
+++ b/src/Generator/Generators/CSharp/CSharpMarshal.cs
@@ -382,7 +382,7 @@ namespace CppSharp.Generators.CSharp
                 type.IsPrimitiveType(PrimitiveType.WideChar)) &&
                 pointer.QualifiedPointee.Qualifiers.IsConst)
             {
-                Context.Return.Write(this.MarshalStringToUnmanaged(
+                Context.Return.Write(MarshalStringToUnmanaged(
                     Helpers.SafeIdentifier(Context.Parameter.Name)));
                 CSharpContext.Cleanup.WriteLine("Marshal.FreeHGlobal({0});",
                     Helpers.SafeIdentifier(Context.ArgName));
@@ -430,7 +430,7 @@ namespace CppSharp.Generators.CSharp
 
                     Context.SupportBefore.WriteLine("{0} _{1};", typeName,
                         Helpers.SafeIdentifier(param.Name));
-                    Context.Return.Write("new global::System.IntPtr(&_{0})", param.Name);
+                    Context.Return.Write("&_{0}", param.Name);
 
                 }
                 else

--- a/src/Generator/Generators/CSharp/CSharpTextTemplate.cs
+++ b/src/Generator/Generators/CSharp/CSharpTextTemplate.cs
@@ -794,8 +794,7 @@ namespace CppSharp.Generators.CSharp
             PrimitiveType primitiveType;
             if (type.IsPrimitiveType(out primitiveType))
             {
-                WriteLine("*({0}*) this[{1}] = *({0}*) value;",
-                    type.ToString(), function.Parameters[0].Name);
+                WriteLine("*this[{0}] = *value;", function.Parameters[0].Name);
             }
             else
             {
@@ -2002,7 +2001,7 @@ namespace CppSharp.Generators.CSharp
                 WriteLine("[UnmanagedFunctionPointerAttribute(CallingConvention.{0})]",
                     Helpers.ToCSharpCallConv(functionType.CallingConvention));
                 TypePrinter.PushContext(CSharpTypePrinterContextKind.Native);
-                WriteLine("{0} {1};",
+                WriteLine("{0} unsafe {1};",
                     typedef.Access == AccessSpecifier.Public ? "public" : "protected",
                     string.Format(TypePrinter.VisitDelegate(functionType).Type,
                         SafeIdentifier(typedef.Name)));

--- a/src/Generator/Generators/CSharp/CSharpTypePrinter.cs
+++ b/src/Generator/Generators/CSharp/CSharpTypePrinter.cs
@@ -10,7 +10,8 @@ namespace CppSharp.Generators.CSharp
     {
         Native,
         Managed,
-        ManagedPointer
+        ManagedPointer,
+        GenericDelegate
     }
 
     public class CSharpTypePrinterContext : TypePrinterContext
@@ -117,8 +118,12 @@ namespace CppSharp.Generators.CSharp
             var returnType = function.ReturnType;
             var args = string.Empty;
 
+            PushContext(CSharpTypePrinterContextKind.GenericDelegate);
+
             if (arguments.Count > 0)
                 args = VisitParameters(function.Parameters, hasNames: false).Type;
+
+            PopContext();
 
             if (ContextKind != CSharpTypePrinterContextKind.Managed)
                 return "global::System.IntPtr";
@@ -179,7 +184,9 @@ namespace CppSharp.Generators.CSharp
                     (Context.Parameter.IsOut || Context.Parameter.IsInOut))
                     return VisitPrimitiveType(primitive, quals);
 
-                return "global::System.IntPtr";
+                if (ContextKind == CSharpTypePrinterContextKind.GenericDelegate)
+                    return "global::System.IntPtr";
+                return VisitPrimitiveType(primitive, quals) + "*";
             }
 
             Class @class;

--- a/tests/CSharpTemp/CSharpTemp.Tests.cs
+++ b/tests/CSharpTemp/CSharpTemp.Tests.cs
@@ -13,11 +13,11 @@ public class CSharpTempTests
         var foo = new Foo();
 
         // TODO: Most of the ugliness below will disappear when pointers to simple types are represented by C#-pointers or ref modifiers instead of the nasty IntPtr
-        var value = *(int*) foo[0];
+        var value = *foo[0];
         Assert.That(value, Is.EqualTo(50));
         int x = 250;
-        foo[0] = new IntPtr(&x);
-        value = *(int*) foo[0];
+        foo[0] = &x;
+        value = *foo[0];
         Assert.That(value, Is.EqualTo(x));
 
         Assert.That(foo[(uint) 0], Is.EqualTo(15));


### PR DESCRIPTION
Signed-off-by: Dimitar Dobrev dpldobrev@yahoo.com
