### PR TITLE
We only handle functions and fields in property setters

### DIFF
--- a/src/Generator/Generators/CSharp/CSharpTextTemplate.cs
+++ b/src/Generator/Generators/CSharp/CSharpTextTemplate.cs
@@ -802,6 +802,11 @@ namespace CppSharp.Generators.CSharp
         private void GeneratePropertySetter<T>(QualifiedType returnType, T decl, Class @class)
             where T : Declaration, ITypedDecl
         {
+            if (!(decl is Function || decl is Field) )
+            {
+                return;
+            }
+
             PushBlock(CSharpBlockKind.Method);
             WriteLine("set");
 


### PR DESCRIPTION
This is a follow up to #86, this time to avoid a compile error in the generated code. If we can't generate a setter, we just return.
Perhaps there should be some logging? Or insert comments into the generated source?
