### PR TITLE
Unify debugging output

### DIFF
--- a/src/Core/Diagnostics.cs
+++ b/src/Core/Diagnostics.cs
@@ -141,6 +141,7 @@ namespace CppSharp
         public void Emit(DiagnosticInfo info)
         {
             Console.WriteLine(info.Message);
+            System.Diagnostics.Debug.WriteLine(info.Message);
         }
     }
 }

--- a/src/Generator/Driver.cs
+++ b/src/Generator/Driver.cs
@@ -272,26 +272,27 @@ namespace CppSharp
             var driver = new Driver(options, new TextDiagnosticPrinter());
             library.Setup(driver);
             driver.Setup();
+            var Log = driver.Diagnostics;
 
             if (!options.Quiet)
-                Console.WriteLine("Parsing libraries...");
+                Log.EmitMessage("Parsing libraries...");
 
             if (!driver.ParseLibraries())
                 return;
 
             if (!options.Quiet)
-                Console.WriteLine("Indexing library symbols...");
+                Log.EmitMessage("Indexing library symbols...");
 
             driver.Symbols.IndexSymbols();
 
-            if (!options.Quiet) 
-                Console.WriteLine("Parsing code...");
+            if (!options.Quiet)
+                Log.EmitMessage("Parsing code...");
 
             if (!driver.ParseCode())
                 return;
 
             if (!options.Quiet)
-                Console.WriteLine("Processing code...");
+                Log.EmitMessage("Processing code...");
 
             library.Preprocess(driver, driver.ASTContext);
 
@@ -301,7 +302,7 @@ namespace CppSharp
             library.Postprocess(driver, driver.ASTContext);
 
             if (!options.Quiet)
-                Console.WriteLine("Generating code...");
+                Log.EmitMessage("Generating code...");
 
             var outputs = driver.GenerateCode();
 

--- a/src/Generator/Generators/CLI/CLIHeadersTemplate.cs
+++ b/src/Generator/Generators/CLI/CLIHeadersTemplate.cs
@@ -371,7 +371,7 @@ namespace CppSharp.Generators.CLI
 
                 if (!baseClass.IsValueType || baseClass.Ignore)
                 {
-                    Console.WriteLine("Ignored base class of value type '{0}'",
+                    Log.EmitMessage("Ignored base class of value type '{0}'",
                         baseClass.Name);
                     continue;
                 }
@@ -612,7 +612,7 @@ namespace CppSharp.Generators.CLI
             }
             else
             {
-                Console.WriteLine("Unhandled typedef type: {0}", typedef);
+                Log.EmitMessage("Unhandled typedef type: {0}", typedef);
             }
 
             return false;

--- a/src/Generator/Generators/CSharp/CSharpTextTemplate.cs
+++ b/src/Generator/Generators/CSharp/CSharpTextTemplate.cs
@@ -2205,7 +2205,7 @@ namespace CppSharp.Generators.CSharp
             }
             else
             {
-                Console.WriteLine("Unhandled typedef type: {0}", typedef);
+                Log.EmitWarning("Unhandled typedef type: {0}", typedef);
                 return false;
             }
 

--- a/src/Generator/Generators/Template.cs
+++ b/src/Generator/Generators/Template.cs
@@ -216,6 +216,10 @@ namespace CppSharp.Generators
         public Driver Driver { get; private set; }
         public DriverOptions Options { get; private set; }
         public TranslationUnit TranslationUnit { get; private set; }
+        public IDiagnosticConsumer Log
+        {
+            get { return Driver.Diagnostics; }
+        }
 
         public Block RootBlock { get; private set; }
         public Block ActiveBlock { get; private set; }

--- a/src/Generator/Passes/CheckIgnoredDecls.cs
+++ b/src/Generator/Passes/CheckIgnoredDecls.cs
@@ -23,7 +23,7 @@ namespace CppSharp.Passes
             if (decl.IsDependent)
             {
                 decl.ExplicityIgnored = true;
-                Console.WriteLine("Decl '{0}' was ignored due to dependent context",
+                Log.EmitMessage("Decl '{0}' was ignored due to dependent context",
                     decl.Name);
             }
 
@@ -43,7 +43,7 @@ namespace CppSharp.Passes
 
             field.ExplicityIgnored = true;
 
-            Console.WriteLine("Field '{0}' was ignored due to {1} type",
+            Log.EmitMessage("Field '{0}' was ignored due to {1} type",
                 field.Name, msg);
 
             return true;
@@ -60,7 +60,7 @@ namespace CppSharp.Passes
             if (HasInvalidType(ret.Type, out msg))
             {
                 function.ExplicityIgnored = true;
-                Console.WriteLine("Function '{0}' was ignored due to {1} return decl",
+                Log.EmitMessage("Function '{0}' was ignored due to {1} return decl",
                     function.Name, msg);
                 return false;
             }
@@ -70,7 +70,7 @@ namespace CppSharp.Passes
                 if (HasInvalidDecl(param, out msg))
                 {
                     function.ExplicityIgnored = true;
-                    Console.WriteLine("Function '{0}' was ignored due to {1} param",
+                    Log.EmitMessage("Function '{0}' was ignored due to {1} param",
                         function.Name, msg);
                     return false;
                 }
@@ -78,7 +78,7 @@ namespace CppSharp.Passes
                 if (HasInvalidType(param.Type, out msg))
                 {
                     function.ExplicityIgnored = true;
-                    Console.WriteLine("Function '{0}' was ignored due to {1} param",
+                    Log.EmitMessage("Function '{0}' was ignored due to {1} param",
                         function.Name, msg);
                     return false;
                 }
@@ -182,7 +182,7 @@ namespace CppSharp.Passes
             if (HasInvalidType(typedef.Type, out msg))
             {
                 typedef.ExplicityIgnored = true;
-                Console.WriteLine("Typedef '{0}' was ignored due to {1} type",
+                Log.EmitMessage("Typedef '{0}' was ignored due to {1} type",
                     typedef.Name, msg);
                 return false;
             }
@@ -199,7 +199,7 @@ namespace CppSharp.Passes
             if (HasInvalidDecl(property, out msg))
             {
                 property.ExplicityIgnored = true;
-                Console.WriteLine("Property '{0}' was ignored due to {1} decl",
+                Log.EmitMessage("Property '{0}' was ignored due to {1} decl",
                     property.Name, msg);
                 return false;
             }
@@ -207,7 +207,7 @@ namespace CppSharp.Passes
             if (HasInvalidType(property.Type, out msg))
             {
                 property.ExplicityIgnored = true;
-                Console.WriteLine("Property '{0}' was ignored due to {1} type",
+                Log.EmitMessage("Property '{0}' was ignored due to {1} type",
                     property.Name, msg);
                 return false;
             }
@@ -215,7 +215,7 @@ namespace CppSharp.Passes
             if (property.GetMethod != null && !VisitFunctionDecl(property.GetMethod))
             {
                 property.ExplicityIgnored = true;
-                Console.WriteLine("Property '{0}' was ignored due to ignored getter",
+                Log.EmitMessage("Property '{0}' was ignored due to ignored getter",
                                   property.Name, msg);
                 return false;
             }
@@ -223,7 +223,7 @@ namespace CppSharp.Passes
             if (property.SetMethod != null && !VisitFunctionDecl(property.SetMethod))
             {
                 property.ExplicityIgnored = true;
-                Console.WriteLine("Property '{0}' was ignored due to ignored setter",
+                Log.EmitMessage("Property '{0}' was ignored due to ignored setter",
                                   property.Name, msg);
                 return false;
             }
@@ -240,7 +240,7 @@ namespace CppSharp.Passes
             if (HasInvalidDecl(variable, out msg))
             {
                 variable.ExplicityIgnored = true;
-                Console.WriteLine("Variable '{0}' was ignored due to {1} decl",
+                Log.EmitMessage("Variable '{0}' was ignored due to {1} decl",
                     variable.Name, msg);
                 return false;
             }
@@ -248,7 +248,7 @@ namespace CppSharp.Passes
             if (HasInvalidType(variable.Type, out msg))
             {
                 variable.ExplicityIgnored = true;
-                Console.WriteLine("Variable '{0}' was ignored due to {1} type",
+                Log.EmitMessage("Variable '{0}' was ignored due to {1} type",
                     variable.Name, msg);
                 return false;
             }
@@ -265,7 +265,7 @@ namespace CppSharp.Passes
             if (HasInvalidDecl(@event, out msg))
             {
                 @event.ExplicityIgnored = true;
-                Console.WriteLine("Event '{0}' was ignored due to {1} decl",
+                Log.EmitMessage("Event '{0}' was ignored due to {1} decl",
                     @event.Name, msg);
                 return false;
             }
@@ -275,7 +275,7 @@ namespace CppSharp.Passes
                 if (HasInvalidDecl(param, out msg))
                 {
                     @event.ExplicityIgnored = true;
-                    Console.WriteLine("Event '{0}' was ignored due to {1} param",
+                    Log.EmitMessage("Event '{0}' was ignored due to {1} param",
                         @event.Name, msg);
                     return false;
                 }
@@ -283,7 +283,7 @@ namespace CppSharp.Passes
                 if (HasInvalidType(param.Type, out msg))
                 {
                     @event.ExplicityIgnored = true;
-                    Console.WriteLine("Event '{0}' was ignored due to {1} param",
+                    Log.EmitMessage("Event '{0}' was ignored due to {1} param",
                         @event.Name, msg);
                     return false;
                 }

--- a/src/Generator/Passes/FunctionToInstanceMethodPass.cs
+++ b/src/Generator/Passes/FunctionToInstanceMethodPass.cs
@@ -64,7 +64,7 @@ namespace CppSharp.Passes
 
             @class.Methods.Add(method);
 
-            Console.WriteLine("Instance method: {0}::{1}", @class.Name,
+            Log.EmitMessage("Instance method: {0}::{1}", @class.Name,
                 function.Name);
 
             return true;

--- a/src/Generator/Passes/FunctionToStaticMethodPass.cs
+++ b/src/Generator/Passes/FunctionToStaticMethodPass.cs
@@ -51,7 +51,7 @@ namespace CppSharp.Passes
 
             @class.Methods.Add(method);
 
-            Console.WriteLine("Static method: {0}::{1}", @class.Name,
+            Log.EmitMessage("Static method: {0}::{1}", @class.Name,
                 function.Name);
 
             return true;

--- a/src/Generator/Passes/Pass.cs
+++ b/src/Generator/Passes/Pass.cs
@@ -11,6 +11,11 @@ namespace CppSharp.Passes
     {
         public Driver Driver { get; set; }
         public ASTContext AstContext { get; set; }
+        
+        public IDiagnosticConsumer Log
+        {
+            get { return Driver.Diagnostics; }
+        }
 
         public virtual bool VisitLibrary(ASTContext context)
         {

--- a/src/Generator/Utils/TestsUtils.cs
+++ b/src/Generator/Utils/TestsUtils.cs
@@ -62,7 +62,7 @@ namespace CppSharp.Utils
             options.Quiet = true;
             options.IgnoreParseWarnings = true;
 
-            Console.WriteLine("Generating bindings for {0} in {1} mode",
+            driver.Diagnostics.EmitMessage("Generating bindings for {0} in {1} mode",
                 options.LibraryName, options.GeneratorKind.ToString());
 
             // Workaround for CLR which does not check for .dll if the
@@ -74,7 +74,7 @@ namespace CppSharp.Utils
 
             options.IncludeDirs.Add(path);
 
-            Console.WriteLine("Looking for tests in: {0}", path);
+            driver.Diagnostics.EmitMessage("Looking for tests in: {0}", path);
             var files = Directory.EnumerateFiles(path, "*.h");
             foreach (var file in files)
                 options.Headers.Add(Path.GetFileName(file));


### PR DESCRIPTION
Route all debugging output through Driver.Diagnostics.

Additionally, if DEBUG is enabled, the messages go to the output window in msvc.
If file&line info is also provided, one can click on the messages to go to the source.

I used "Log" and properties for brevity. I don't know if this is good C# style!
