### PR TITLE
Update to latest llvm/clang

### DIFF
--- a/src/CppParser/Parser.cpp
+++ b/src/CppParser/Parser.cpp
@@ -119,7 +119,6 @@ void Parser::SetupHeader()
     TargetOptions& TO = Inv->getTargetOpts();
     TargetABI = (Opts->Abi == CppAbi::Microsoft) ? TargetCXXABI::Microsoft
         : TargetCXXABI::GenericItanium;
-    TO.CXXABI = GetCXXABIString(TargetABI);
 
     TO.Triple = llvm::sys::getDefaultTargetTriple();
     if (!Opts->TargetTriple.empty())
@@ -1314,12 +1313,12 @@ Type* Parser::WalkType(clang::QualType QualType, clang::TypeLoc* TL,
             WalkType(FP->getResultType(), &RL));
         F->CallingConvention = ConvertCallConv(FP->getCallConv());
 
-        for (unsigned i = 0; i < FP->getNumArgs(); ++i)
+        for (unsigned i = 0; i < FP->getNumParams(); ++i)
         {
             auto FA = new Parameter();
             if (FTL)
             {
-                auto PVD = FTL.getArg(i);
+                auto PVD = FTL.getParam(i);
 
                 HandleDeclaration(PVD, FA);
 
@@ -1330,7 +1329,7 @@ Type* Parser::WalkType(clang::QualType QualType, clang::TypeLoc* TL,
             }
             else
             {
-                auto Arg = FP->getArgType(i);
+                auto Arg = FP->getParamType(i);
                 FA->Name = "";
                 FA->QualifiedType = GetQualifiedType(Arg, WalkType(Arg));
             }

--- a/src/Parser/Parser.cpp
+++ b/src/Parser/Parser.cpp
@@ -122,7 +122,6 @@ void Parser::SetupHeader()
     TargetOptions& TO = Inv->getTargetOpts();
     TargetABI = (Opts->Abi == CppAbi::Microsoft) ? TargetCXXABI::Microsoft
         : TargetCXXABI::GenericItanium;
-    TO.CXXABI = GetCXXABIString(TargetABI);
 
     TO.Triple = llvm::sys::getDefaultTargetTriple();
     if (!System::String::IsNullOrWhiteSpace(Opts->TargetTriple))
@@ -1424,12 +1423,12 @@ CppSharp::AST::Type^ Parser::WalkType(clang::QualType QualType, clang::TypeLoc* 
             WalkType(FP->getResultType(), &RL));
         F->CallingConvention = ConvertCallConv(FP->getCallConv());
 
-        for (unsigned i = 0; i < FP->getNumArgs(); ++i)
+		for (unsigned i = 0; i < FP->getNumParams(); ++i)
         {
             auto FA = gcnew CppSharp::AST::Parameter();
             if (FTL)
             {
-                auto PVD = FTL.getArg(i);
+                auto PVD = FTL.getParam(i);
 
                 HandleDeclaration(PVD, FA);
 
@@ -1440,7 +1439,7 @@ CppSharp::AST::Type^ Parser::WalkType(clang::QualType QualType, clang::TypeLoc* 
             }
             else
             {
-                auto Arg = FP->getArgType(i);
+                auto Arg = FP->getParamType(i);
                 FA->Name = "";
                 FA->QualifiedType = GetQualifiedType(Arg, WalkType(Arg));
             }


### PR DESCRIPTION
Changes to llvm and clang requiring and update:

Get rid of TargetOptions::CXXABI since it is no longer used.
http://llvm-reviews.chandlerc.com/D2545

Rename args to params
http://llvm-reviews.chandlerc.com/rL199686
