### PR TITLE
Add support for C mode parsing.

### DIFF
--- a/src/CppParser/Parser.cpp
+++ b/src/CppParser/Parser.cpp
@@ -684,6 +684,104 @@ void Parser::WalkRecordCXX(clang::CXXRecordDecl* Record, Class* RC)
         WalkVTable(Record, RC);
 }
 
+Class* Parser::WalkRecord(clang::RecordDecl* Record)
+{
+    using namespace clang;
+
+    auto NS = GetNamespace(Record);
+    assert(NS && "Expected a valid namespace");
+
+    bool isCompleteDefinition = Record->isCompleteDefinition();
+
+    Class* RC = nullptr;
+
+    auto Name = GetTagDeclName(Record);
+    auto HasEmptyName = Record->getDeclName().isEmpty();
+
+    if (HasEmptyName)
+    {
+        if (auto AR = NS->FindAnonymous((uint64_t) Record))
+            RC = static_cast<Class*>(AR);
+    }
+    else
+    {
+        RC = NS->FindClass(Name, isCompleteDefinition, /*Create=*/false);
+    }
+
+    if (RC)
+        return RC;
+
+    RC = NS->FindClass(Name, isCompleteDefinition, /*Create=*/true);
+    HandleDeclaration(Record, RC);
+
+    if (HasEmptyName)
+        NS->Anonymous[(uint64_t) Record] = RC;
+
+    if (!isCompleteDefinition)
+        return RC;
+
+    WalkRecord(Record, RC);
+
+    return RC;
+}
+
+void Parser::WalkRecord(clang::RecordDecl* Record, Class* RC)
+{
+    using namespace clang;
+
+    auto headStartLoc = GetDeclStartLocation(C.get(), Record);
+    auto headEndLoc = Record->getLocation(); // identifier location
+    auto bodyEndLoc = Record->getLocEnd();
+
+    auto headRange = clang::SourceRange(headStartLoc, headEndLoc);
+    auto bodyRange = clang::SourceRange(headEndLoc, bodyEndLoc);
+
+    HandlePreprocessedEntities(RC, headRange, MacroLocation::ClassHead);
+    HandlePreprocessedEntities(RC, bodyRange, MacroLocation::ClassBody);
+
+    auto &Sema = C->getSema();
+
+    RC->IsUnion = Record->isUnion();
+
+    bool hasLayout =  !Record->isInvalidDecl();
+
+    // Get the record layout information.
+    const ASTRecordLayout* Layout = 0;
+    if (hasLayout)
+    {
+        Layout = &C->getASTContext().getASTRecordLayout(Record);
+        RC->Layout->Alignment = (int) Layout->getAlignment().getQuantity();
+        RC->Layout->Size = (int) Layout->getSize().getQuantity();
+        RC->Layout->DataSize = (int) Layout->getDataSize().getQuantity();
+    }
+
+    for (auto it = Record->decls_begin(); it != Record->decls_end(); ++it)
+    {
+        auto D = *it;
+
+        switch (D->getKind())
+        {
+        case Decl::Field:
+        {
+            auto FD = cast<FieldDecl>(D);
+            auto Field = WalkFieldCXX(FD, RC);
+
+            if (Layout)
+                Field->Offset = Layout->getFieldOffset(FD->getFieldIndex());
+
+            break;
+        }
+        case Decl::IndirectField: // FIXME: Handle indirect fields
+            break;
+        default:
+        {
+            auto Decl = WalkDeclaration(D);
+            break;
+        }
+        }
+    }
+}
+
 //-----------------------------------//
 
 static TemplateSpecializationKind
@@ -1075,6 +1173,12 @@ DeclarationContext* Parser::GetNamespace(clang::Decl* D,
         case Decl::LinkageSpec:
         {
             const LinkageSpecDecl* LD = cast<LinkageSpecDecl>(Ctx);
+            continue;
+        }
+        case Decl::Record:
+        {
+            auto RD = cast<RecordDecl>(Ctx);
+            DC = WalkRecord(RD);
             continue;
         }
         case Decl::CXXRecord:
@@ -2192,6 +2296,26 @@ Declaration* Parser::WalkDeclaration(clang::Decl* D,
     auto Kind = D->getKind();
     switch(D->getKind())
     {
+    case Decl::Record:
+    {
+        RecordDecl* RD = cast<RecordDecl>(D);
+
+        auto Class = WalkRecord(RD);
+
+        // We store a definition order index into the declarations.
+        // This is needed because declarations are added to their contexts as
+        // soon as they are referenced and we need to know the original order
+        // of the declarations.
+
+        if (CanBeDefinition && Class->DefinitionOrder == 0)
+        {
+            Class->DefinitionOrder = Index++;
+            //Debug("%d: %s\n", Index++, GetTagDeclName(RD).c_str());
+        }
+
+        Decl = Class;
+        break;
+    }
     case Decl::CXXRecord:
     {
         CXXRecordDecl* RD = cast<CXXRecordDecl>(D);

--- a/src/CppParser/Parser.h
+++ b/src/CppParser/Parser.h
@@ -70,6 +70,8 @@ protected:
         bool AddToNamespace = true);
     Class* WalkRecordCXX(clang::CXXRecordDecl* Record);
     void WalkRecordCXX(clang::CXXRecordDecl* Record, Class* RC);
+    Class* WalkRecord(clang::RecordDecl* Record);
+    void WalkRecord(clang::RecordDecl* Record, Class* RC);
     ClassTemplateSpecialization*
     WalkClassTemplateSpecialization(clang::ClassTemplateSpecializationDecl* CTS);
     ClassTemplatePartialSpecialization*

--- a/src/Parser/Parser.h
+++ b/src/Parser/Parser.h
@@ -67,6 +67,8 @@ protected:
         bool AddToNamespace = true);
     CppSharp::AST::Class^ WalkRecordCXX(clang::CXXRecordDecl* Record);
     void WalkRecordCXX(clang::CXXRecordDecl* Record, CppSharp::AST::Class^ RC);
+    CppSharp::AST::Class^ WalkRecord(clang::RecordDecl* Record);
+    void WalkRecord(clang::RecordDecl* Record, CppSharp::AST::Class^ RC);
     CppSharp::AST::ClassTemplateSpecialization^
     WalkClassTemplateSpecialization(clang::ClassTemplateSpecializationDecl* CTS);
     CppSharp::AST::ClassTemplatePartialSpecialization^


### PR DESCRIPTION
Adds the necessary methods to handle clang::RecordDecl parsing in the Parser.
There is already support for clang::CXXRecordDecl.

This is needed when passing std=gnu99 to clang and parsing in C mode instead of c++ mode.
