### PR TITLE
Add new option for custom using statements/namespaces in generated units

### DIFF
--- a/src/Generator/Generators/CLI/CLISourcesTemplate.cs
+++ b/src/Generator/Generators/CLI/CLISourcesTemplate.cs
@@ -42,6 +42,10 @@ namespace CppSharp.Generators.CLI
             PushBlock(CLIBlockKind.Usings);
             WriteLine("using namespace System;");
             WriteLine("using namespace System::Runtime::InteropServices;");
+            foreach (var customUsingStatement in Options.DependentNameSpaces)
+            {
+                WriteLine(string.Format("using namespace {0};", customUsingStatement)); ;
+            }
             NewLine();
             PopBlock();
 

--- a/src/Generator/Generators/CSharp/CSharpTextTemplate.cs
+++ b/src/Generator/Generators/CSharp/CSharpTextTemplate.cs
@@ -156,6 +156,10 @@ namespace CppSharp.Generators.CSharp
             WriteLine("using System;");
             WriteLine("using System.Runtime.InteropServices;");
             WriteLine("using System.Security;");
+            foreach (var customUsingStatement in Options.DependentNameSpaces)
+            {
+                WriteLine(string.Format("using {0};", customUsingStatement));;
+            }
             PopBlock(NewLineKind.BeforeNextBlock);
 
             if (Options.GenerateLibraryNamespace)

--- a/src/Generator/Options.cs
+++ b/src/Generator/Options.cs
@@ -131,6 +131,7 @@ namespace CppSharp
         public bool Is32Bit { get { return true; } }
 
         public List<string> CodeFiles { get; private set; }
+        public readonly List<string> DependentNameSpaces = new List<string>();
     }
 
     public class InvalidOptionException : Exception


### PR DESCRIPTION
Add new option (DependentNameSpaces) that allows for specifying custom using statements/namespaces in generated units
