### PR TITLE
Added an additional property to type maps indicating if they actually provide marshalling (useful if only copy constructors are replaced)

### DIFF
--- a/src/Generator/Generators/CLI/CLIMarshal.cs
+++ b/src/Generator/Generators/CLI/CLIMarshal.cs
@@ -18,7 +18,7 @@ namespace CppSharp.Generators.CLI
         public override bool VisitType(Type type, TypeQualifiers quals)
         {
             TypeMap typeMap;
-            if (Context.Driver.TypeDatabase.FindTypeMap(type, out typeMap))
+            if (Context.Driver.TypeDatabase.FindTypeMap(type, out typeMap) && typeMap.DoesMarshalling)
             {
                 typeMap.Type = type;
                 typeMap.CLIMarshalToManaged(Context);
@@ -149,8 +149,8 @@ namespace CppSharp.Generators.CLI
         {
             var decl = typedef.Declaration;
 
-            TypeMap typeMap = null;
-            if (Context.Driver.TypeDatabase.FindTypeMap(decl, out typeMap))
+            TypeMap typeMap;
+            if (Context.Driver.TypeDatabase.FindTypeMap(decl, out typeMap) && typeMap.DoesMarshalling)
             {
                 typeMap.Type = typedef;
                 typeMap.CLIMarshalToManaged(Context);
@@ -175,7 +175,7 @@ namespace CppSharp.Generators.CLI
                                                     TypeQualifiers quals)
         {
             TypeMap typeMap;
-            if (Context.Driver.TypeDatabase.FindTypeMap(template, out typeMap))
+            if (Context.Driver.TypeDatabase.FindTypeMap(template, out typeMap) && typeMap.DoesMarshalling)
             {
                 typeMap.Type = template;
                 typeMap.CLIMarshalToManaged(Context);
@@ -338,7 +338,7 @@ namespace CppSharp.Generators.CLI
         public override bool VisitType(Type type, TypeQualifiers quals)
         {
             TypeMap typeMap;
-            if (Context.Driver.TypeDatabase.FindTypeMap(type, out typeMap))
+            if (Context.Driver.TypeDatabase.FindTypeMap(type, out typeMap) && typeMap.DoesMarshalling)
             {
                 typeMap.Type = type;
                 typeMap.CLIMarshalToNative(Context);
@@ -479,8 +479,8 @@ namespace CppSharp.Generators.CLI
         {
             var decl = typedef.Declaration;
 
-            TypeMap typeMap = null;
-            if (Context.Driver.TypeDatabase.FindTypeMap(decl, out typeMap))
+            TypeMap typeMap;
+            if (Context.Driver.TypeDatabase.FindTypeMap(decl, out typeMap) && typeMap.DoesMarshalling)
             {
                 typeMap.CLIMarshalToNative(Context);
                 return typeMap.IsValueType;
@@ -505,8 +505,8 @@ namespace CppSharp.Generators.CLI
         public override bool VisitTemplateSpecializationType(TemplateSpecializationType template,
                                                     TypeQualifiers quals)
         {
-            TypeMap typeMap = null;
-            if (Context.Driver.TypeDatabase.FindTypeMap(template, out typeMap))
+            TypeMap typeMap;
+            if (Context.Driver.TypeDatabase.FindTypeMap(template, out typeMap) && typeMap.DoesMarshalling)
             {
                 typeMap.Type = template;
                 typeMap.CLIMarshalToNative(Context);
@@ -552,7 +552,7 @@ namespace CppSharp.Generators.CLI
         private void MarshalRefClass(Class @class)
         {
             TypeMap typeMap = null;
-            if (Context.Driver.TypeDatabase.FindTypeMap(@class, out typeMap))
+            if (Context.Driver.TypeDatabase.FindTypeMap(@class, out typeMap) && typeMap.DoesMarshalling)
             {
                 typeMap.CLIMarshalToNative(Context);
                 return;

--- a/src/Generator/Generators/CSharp/CSharpMarshal.cs
+++ b/src/Generator/Generators/CSharp/CSharpMarshal.cs
@@ -84,7 +84,7 @@ namespace CppSharp.Generators.CSharp
         public override bool VisitType(Type type, TypeQualifiers quals)
         {
             TypeMap typeMap;
-            if (Context.Driver.TypeDatabase.FindTypeMap(type, out typeMap))
+            if (Context.Driver.TypeDatabase.FindTypeMap(type, out typeMap) && typeMap.DoesMarshalling)
             {
                 typeMap.Type = type;
                 typeMap.CSharpMarshalToManaged(Context);
@@ -97,7 +97,7 @@ namespace CppSharp.Generators.CSharp
         public override bool VisitDeclaration(Declaration decl)
         {
             TypeMap typeMap;
-            if (Context.Driver.TypeDatabase.FindTypeMap(decl, out typeMap))
+            if (Context.Driver.TypeDatabase.FindTypeMap(decl, out typeMap) && typeMap.DoesMarshalling)
             {
                 typeMap.Declaration = decl;
                 typeMap.CSharpMarshalToManaged(Context);
@@ -353,7 +353,7 @@ namespace CppSharp.Generators.CSharp
         public override bool VisitType(Type type, TypeQualifiers quals)
         {
             TypeMap typeMap;
-            if (Context.Driver.TypeDatabase.FindTypeMap(type, out typeMap))
+            if (Context.Driver.TypeDatabase.FindTypeMap(type, out typeMap) && typeMap.DoesMarshalling)
             {
                 typeMap.Type = type;
                 typeMap.CSharpMarshalToNative(Context);
@@ -366,7 +366,7 @@ namespace CppSharp.Generators.CSharp
         public override bool VisitDeclaration(Declaration decl)
         {
             TypeMap typeMap;
-            if (Context.Driver.TypeDatabase.FindTypeMap(decl, out typeMap))
+            if (Context.Driver.TypeDatabase.FindTypeMap(decl, out typeMap) && typeMap.DoesMarshalling)
             {
                 typeMap.Declaration = decl;
                 typeMap.CSharpMarshalToNative(Context);

--- a/src/Generator/Generators/CSharp/CSharpTypePrinter.cs
+++ b/src/Generator/Generators/CSharp/CSharpTypePrinter.cs
@@ -97,11 +97,15 @@ namespace CppSharp.Generators.CSharp
                 Context.CSharpKind = ContextKind;
                 Context.Type = tag;
 
-                return new CSharpTypePrinterResult()
+                string type = typeMap.CSharpSignature(Context);
+                if (!string.IsNullOrEmpty(type))
                 {
-                    Type = typeMap.CSharpSignature(Context),
-                    TypeMap = typeMap
-                };
+                    return new CSharpTypePrinterResult
+                    {
+                        Type = type,
+                        TypeMap = typeMap
+                    };
+                }
             }
 
             return tag.Declaration.Visit(this);
@@ -252,11 +256,15 @@ namespace CppSharp.Generators.CSharp
                 Context.CSharpKind = ContextKind;
                 Context.Type = typedef;
 
-                return new CSharpTypePrinterResult()
+                string type = typeMap.CSharpSignature(Context);
+                if (!string.IsNullOrEmpty(type))
+                {
+                    return new CSharpTypePrinterResult
                     {
-                        Type = typeMap.CSharpSignature(Context),
+                        Type = type,
                         TypeMap = typeMap
                     };
+                }
             }
 
             FunctionType func;
@@ -294,11 +302,15 @@ namespace CppSharp.Generators.CSharp
                 Context.Type = template;
                 Context.CSharpKind = ContextKind;
 
-                return new CSharpTypePrinterResult()
+                string type = GetCSharpSignature(typeMap);
+                if (!string.IsNullOrEmpty(type))
+                {
+                    return new CSharpTypePrinterResult
                     {
-                        Type = GetCSharpSignature(typeMap),
+                        Type = type,
                         TypeMap = typeMap
                     };
+                }
             }
 
             return decl.Name;

--- a/src/Generator/Types/TypeMap.cs
+++ b/src/Generator/Types/TypeMap.cs
@@ -42,6 +42,11 @@ namespace CppSharp.Types
             get { return false; }
         }
 
+        /// <summary>
+        /// Determines if the type map performs marshalling or only replaces copy ctors.
+        /// </summary>
+        public virtual bool DoesMarshalling { get { return true; } }
+
         #region C# backend
 
         public virtual string CSharpSignature(CSharpTypePrinterContext ctx)


### PR DESCRIPTION
...ovide marshalling (useful if only copy constructors are replaced).

Signed-off-by: Dimitar Dobrev dpldobrev@yahoo.com
