### PR TITLE
Add PrimitiveType.UIntPtr in AST and code generators

### DIFF
--- a/src/AST/Type.cs
+++ b/src/AST/Type.cs
@@ -818,6 +818,7 @@ namespace CppSharp.AST
         Float,
         Double,
         IntPtr,
+        UIntPtr,
         Char16
     }
 

--- a/src/Generator/Generators/CLI/CLITypePrinter.cs
+++ b/src/Generator/Generators/CLI/CLITypePrinter.cs
@@ -184,6 +184,7 @@ namespace CppSharp.Generators.CLI
                 case PrimitiveType.Float: return "float";
                 case PrimitiveType.Double: return "double";
                 case PrimitiveType.IntPtr: return "IntPtr";
+                case PrimitiveType.UIntPtr: return "UIntPtr";
             }
 
             throw new NotSupportedException();

--- a/src/Generator/Generators/CSharp/CSharpTypePrinter.cs
+++ b/src/Generator/Generators/CSharp/CSharpTypePrinter.cs
@@ -380,6 +380,7 @@ namespace CppSharp.Generators.CSharp
                 case PrimitiveType.Float: return "float";
                 case PrimitiveType.Double: return "double";
                 case PrimitiveType.IntPtr: return "global::System.IntPtr";
+                case PrimitiveType.UIntPtr: return "global::System.UIntPtr";
             }
 
             throw new NotSupportedException();

--- a/src/Generator/Types/CppTypePrinter.cs
+++ b/src/Generator/Types/CppTypePrinter.cs
@@ -111,6 +111,7 @@ namespace CppSharp.Types
                 case PrimitiveType.Float: return "float";
                 case PrimitiveType.Double: return "double";
                 case PrimitiveType.IntPtr: return "void*";
+                case PrimitiveType.UIntPtr: return "uintptr_t";
             }
 
             throw new NotSupportedException();


### PR DESCRIPTION
I'm not 100% sure what to map UIntPtr to in the Cpp type printer.
I chose size_t as that is the use-case for which I need this, is there anything better/more correct?
