### PR TITLE
Improved FindFunction To Search Namespaces

### DIFF
--- a/src/AST/Namespace.cs
+++ b/src/AST/Namespace.cs
@@ -166,6 +166,9 @@ namespace CppSharp.AST
 
         public Function FindFunction(string name, bool createDecl = false)
         {
+            if (string.IsNullOrEmpty(name)) 
+                return null;
+
             var entries = name.Split(new string[] { "::" },
                 StringSplitOptions.RemoveEmptyEntries).ToList();
 


### PR DESCRIPTION
Added an improvement similar to that of `FindEnum` and `FindClass` to the `DeclarationContext.FindFunction` helper method.

Sorry about the old merging junk in the history here.
