### PR TITLE
Fix osx detection, we do not parse result of os.getversion() in premake ...

### DIFF
--- a/build/Helpers.lua
+++ b/build/Helpers.lua
@@ -24,13 +24,11 @@ gcc_buildflags = { "-std=c++11" }
 msvc_cpp_defines = { }
 
 function os.is_osx()
-  local version = os.getversion()
-  return string.find(version.description, "Mac OS X") ~= nil
+  return os.is("macosx")
 end
 
 function os.is_windows()
-  local version = os.getversion()
-  return string.find(version.description, "Windows") ~= nil
+  return os.is("windows")
 end
 
 function string.starts(str, start)


### PR DESCRIPTION
...(seems it return something strange). Instead use internal os detection in pre make.

I inserted this in premake script:

``` lua
print( os.getversion() )
```

And got something like: `table: 0x100206dc0` may be os.getversion() return object... but os.is("osx") work very well.
