### PR TITLE
Fix crash with parsing stdarg.h (or around this on Mac).

### DIFF
--- a/src/CppParser/Parser.cpp
+++ b/src/CppParser/Parser.cpp
@@ -546,6 +546,10 @@ Class* Parser::WalkRecordCXX(clang::CXXRecordDecl* Record)
     if (Record->isInjectedClassName())
         return nullptr;
 
+    // skip va_list_tag as in clang: lib/Sema/SemaLookup.cpp
+    if (Record->getDeclName() == C->getSema().VAListTagName)
+        return nullptr;
+
     auto NS = GetNamespace(Record);
     assert(NS && "Expected a valid namespace");
 


### PR DESCRIPTION
 Simple skip fake `va_list_tag` declaration as in clang repo in lib/Sema/SemaLookup.cpp
