### PR TITLE
build: remove explicit platforms

### DIFF
--- a/build/Helpers.lua
+++ b/build/Helpers.lua
@@ -14,7 +14,7 @@ if _ARGS[1] then
     builddir = path.getabsolute("./" .. _ARGS[1]);
 end
 
-libdir = path.join(builddir, "lib", "%{cfg.buildcfg}_%{cfg.platform}");
+libdir = path.join(builddir, "lib", "%{cfg.buildcfg}");
 gendir = path.join(builddir, "gen");
 
 common_flags = { "Unicode", "Symbols" }

--- a/build/premake4.lua
+++ b/build/premake4.lua
@@ -11,8 +11,7 @@ dofile "Parser.lua"
 
 solution "CppSharp"
 
-  configurations { "Debug", "Release" }
-  platforms { "x32", "x64" }
+  configurations { "Release", "Debug" }
   flags { common_flags }
   
   location (builddir)
@@ -29,6 +28,7 @@ solution "CppSharp"
 
   configuration "windows"
     defines { "WINDOWS" }
+    architecture "x32"
 	
   configuration {}
     


### PR DESCRIPTION
Selecting the platform when building feels a bit useless.

On Windows, the LLVM build is (afaik) always 32-bit. That means that all
the C++ libs need to be 32-bit, and in turn all the C# libs/exes using
those native libraries need to be 32-bit.

On Linux, the LLVM is in the system's native bitness. So if your system
is 64-bit, there's no reason for you to try to compile 32-bit CppSharp.

All in all, things seem cleaner with this patch: remove the platforms,
use 32-bit architecture on windows, and the native architecture on
others.

This patch also changes the configurations order so that Release is
first. That makes Release the default target, making it easier for the
user to compile CppSharp.

Signed-off-by: Tomi Valkeinen <tomi.valkeinen@iki.fi>