### PR TITLE
fix CSharpTemp.TestDestructors

### DIFF
--- a/tests/CSharpTemp/CSharpTemp.Tests.cs
+++ b/tests/CSharpTemp/CSharpTemp.Tests.cs
@@ -89,6 +89,7 @@ public class CSharpTempTests : GeneratorTestFixture
     [Test]
     public void TestDestructors()
     {
+        CSharpTemp.TestDestructors.InitMarker();
         Assert.AreEqual(0, CSharpTemp.TestDestructors.Marker);
 
         var dtors = new TestDestructors();

--- a/tests/CSharpTemp/CSharpTemp.h
+++ b/tests/CSharpTemp/CSharpTemp.h
@@ -138,6 +138,7 @@ private:
 // Tests destructors
 struct DLL_API TestDestructors
 {
+    static void InitMarker() { Marker = 0; }
     static int Marker;
 
     TestDestructors();


### PR DESCRIPTION
TestDestructors test cannot be run twice as a static variable holds data from
the first run.

Add an init function to set the static variable to a known state.

Signed-off-by: Tomi Valkeinen tomi.valkeinen@iki.fi
