### PR TITLE
CppParser: remove unnecessary #includes

### DIFF
--- a/src/CppParser/CXXABI.h
+++ b/src/CppParser/CXXABI.h
@@ -15,8 +15,6 @@
 #ifndef LLVM_CLANG_AST_CXXABI_H
 #define LLVM_CLANG_AST_CXXABI_H
 
-#include "clang/AST/Type.h"
-
 namespace clang {
 
 class ASTContext;

--- a/src/CppParser/Comments.cpp
+++ b/src/CppParser/Comments.cpp
@@ -7,6 +7,7 @@
 
 #include "Parser.h"
 
+#include <clang/AST/Comment.h>
 #include <clang/AST/ASTContext.h>
 
 using namespace CppSharp::CppParser;

--- a/src/CppParser/Parser.cpp
+++ b/src/CppParser/Parser.cpp
@@ -7,6 +7,7 @@
 
 #include "Parser.h"
 
+#include <llvm/Support/Host.h>
 #include <llvm/Support/Path.h>
 #include <llvm/Support/raw_ostream.h>
 #include <llvm/Object/Archive.h>
@@ -21,7 +22,9 @@
 #include <clang/AST/DeclTemplate.h>
 #include <clang/Lex/DirectoryLookup.h>
 #include <clang/Lex/HeaderSearch.h>
+#include <clang/Lex/Preprocessor.h>
 #include <clang/Lex/PreprocessingRecord.h>
+#include <clang/Parse/ParseAST.h>
 #include <clang/Sema/Sema.h>
 #include <clang/Sema/SemaConsumer.h>
 #include <clang/Frontend/Utils.h>

--- a/src/CppParser/Parser.h
+++ b/src/CppParser/Parser.h
@@ -7,26 +7,12 @@
 
 #pragma once
 
-#include <llvm/Support/Host.h>
-#include <clang/Frontend/CompilerInstance.h>
-#include <clang/Frontend/CompilerInvocation.h>
-#include <clang/Frontend/ASTConsumers.h>
-#include <clang/Basic/FileManager.h>
-#include <clang/Basic/TargetOptions.h>
+#include <clang/AST/ASTFwd.h>
+#include <clang/AST/Type.h>
 #include <clang/Basic/TargetInfo.h>
-#include <clang/Basic/IdentifierTable.h>
-#include <clang/AST/ASTConsumer.h>
-#include <clang/AST/Mangle.h>
-#include <clang/AST/RawCommentList.h>
-#include <clang/AST/Comment.h>
-#include <clang/AST/RecordLayout.h>
-#include <clang/AST/VTableBuilder.h>
-#include <clang/Lex/Preprocessor.h>
-#include <clang/Lex/PreprocessingRecord.h>
-#include <clang/Parse/ParseAST.h>
-#include <clang/Sema/Sema.h>
-#include "CXXABI.h"
+#include <clang/Frontend/CompilerInstance.h>
 
+#include "CXXABI.h"
 #include "CppParser.h"
 
 #include <string>
@@ -37,6 +23,16 @@ namespace clang {
   namespace CodeGen {
     class CodeGenTypes;
   }
+  struct ASTTemplateArgumentListInfo;
+  class FunctionTemplateSpecialization;
+  class FunctionTemplateSpecializationInfo;
+  class PreprocessingRecord;
+  class PreprocessedEntity;
+  class RawComment;
+  class TemplateSpecializationTypeLoc;
+  class TemplateArgumentList;
+  class VTableLayout;
+  class VTableComponent;
 }
 
 #define Debug printf

--- a/src/CppParser/Target.h
+++ b/src/CppParser/Target.h
@@ -7,12 +7,9 @@
 
 #pragma once
 
-#include "AST.h"
 #include "Helpers.h"
 
 namespace CppSharp { namespace CppParser {
-
-using namespace CppSharp::CppParser::AST;
 
 enum struct ParserIntType
 {


### PR DESCRIPTION
Use forward declarations to avoid the need to include lots of clang headers.

This drops the compilation time for CppParser from 17.8 seconds to 14.1 seconds
for me.

Signed-off-by: Tomi Valkeinen tomi.valkeinen@iki.fi
