### PR TITLE
A fix to the templates equality testing

### DIFF
--- a/src/AST/Template.cs
+++ b/src/AST/Template.cs
@@ -66,7 +66,7 @@ namespace CppSharp.AST
         {
             var temp = obj as Template;
             if (temp == null) return false;
-            return this.QualifiedName == temp.QualifiedName;
+            return this.QualifiedName == temp.QualifiedName && this.Namespace.QualifiedName == temp.Namespace.QualifiedName;
         }
     }
 


### PR DESCRIPTION
I was able to do the pull request finally. (The problem was that I originally created a local clone of the CppSharp repository, and then pushed that to GitHub... I'm collaborating on GitHub for the first time, so I don't know how it works, pardon me!)

In C++ you are able to declare things multiple times and define them once. In the AST clang creates, every declaration is a different node, but since they actually refer to the same thing, their equality testing should compare the name and namespace instead of the reference. This fixes (at least) the crash on FixDefaultParamValuesOfOverridesPass with Qt5Gui discussed on this issue: https://github.com/mono/CppSharp/issues/328.
