### PR TITLE
The simplest and least intrusive way to fix this.

### DIFF
--- a/src/AST/Type.cs
+++ b/src/AST/Type.cs
@@ -488,7 +488,7 @@ namespace CppSharp.AST
             if (type == null) return false;
 
             return Arguments.SequenceEqual(type.Arguments)
-                && Template.Equals(type.Template);
+                && Template.Name == type.Template.Name;
         }
 
         public override int GetHashCode()


### PR DESCRIPTION
This is the simplest way that works. It won't change the existing .Equals() or == semantics, so it should be safe. It also actually compares the names of the TemplatedDecl, but the Template.Name property is overloaded to return that.

And it fixes the crash with QtGui.
