### PR TITLE
Fix bugs with default argument and implement the relevant test cases.

### DIFF
--- a/src/AST/Expression.cs
+++ b/src/AST/Expression.cs
@@ -36,12 +36,31 @@ namespace CppSharp.AST
 
         public override T Visit<T>(IExpressionVisitor<T> visitor)
         {
-            return visitor.VisitBuiltinExpression(this);
+            return visitor.VisitExpression(this);
+        }
+    }
+
+    public class CastExpr : Expression
+    {
+        public Expression SubExpression;
+
+        public override T Visit<T>(IExpressionVisitor<T> visitor)
+        {
+            return visitor.VisitExpression(this);
+        }
+    }
+    public class CtorExpr : Expression
+    {
+        public Expression SubExpression;
+
+        public override T Visit<T>(IExpressionVisitor<T> visitor)
+        {
+            return visitor.VisitExpression(this);
         }
     }
 
     public interface IExpressionVisitor<out T>
     {
-        T VisitBuiltinExpression(BuiltinTypeExpression builtinType);
+        T VisitExpression(Expression exp);
     }
 }

--- a/src/AST/Statement.cs
+++ b/src/AST/Statement.cs
@@ -6,7 +6,9 @@
         BinaryOperator,
         DeclarationReference,
         ConstructorReference,
-        CXXOperatorCall
+        CXXOperatorCall,
+        ImplicitCast,
+        ExplicitCast,
     }
 
     public abstract class Statement

--- a/src/Core/Parser/ASTConverter.cs
+++ b/src/Core/Parser/ASTConverter.cs
@@ -847,24 +847,51 @@ namespace CppSharp
             if (statement == null)
                 return null;
 
-            var expression = new AST.BuiltinTypeExpression();
-            expression.Declaration = this.typeConverter.declConverter.Visit(statement.Decl);
-            expression.String = statement.String;
+            AST.Expression expression;
             switch (statement.Class)
             {
                 case StatementClass.BinaryOperator:
+                    expression = new AST.BuiltinTypeExpression();
                     expression.Class = AST.StatementClass.BinaryOperator;
                     break;
                 case StatementClass.DeclRefExprClass:
+                    expression = new AST.BuiltinTypeExpression();
                     expression.Class = AST.StatementClass.DeclarationReference;
                     break;
-                case StatementClass.CXXConstructExprClass:
-                    expression.Class = AST.StatementClass.ConstructorReference;
-                    break;
                 case StatementClass.CXXOperatorCallExpr:
+                    expression = new AST.BuiltinTypeExpression();
                     expression.Class = AST.StatementClass.CXXOperatorCall;
                     break;
+                case StatementClass.CXXConstructExprClass:
+                    {
+                        var ctorExp = new AST.CtorExpr();
+                        ctorExp.SubExpression = VisitStatement(((Expression)statement).Subexpression);
+                        expression = ctorExp;
+                        expression.Class = AST.StatementClass.ConstructorReference;
+                        break;
+                    }
+                case StatementClass.ImplicitCastExpr:
+                    {
+                        var castExp = new AST.CastExpr();
+                        castExp.SubExpression = VisitStatement(((Expression)statement).Subexpression);
+                        expression = castExp;
+                        expression.Class = AST.StatementClass.ImplicitCast;
+                        break;
+                    }
+                case StatementClass.ExplicitCastExpr:
+                    {
+                        var castExp = new AST.CastExpr();
+                        castExp.SubExpression = VisitStatement(((Expression)statement).Subexpression);
+                        expression = castExp;
+                        expression.Class = AST.StatementClass.ExplicitCast;
+                        break;
+                    }
+                default:
+                    expression = new AST.BuiltinTypeExpression();
+                    break;
             }
+            expression.Declaration = this.typeConverter.declConverter.Visit(statement.Decl);
+            expression.String = statement.String;
             return expression;
         }
 

--- a/src/CppParser/AST.cpp
+++ b/src/CppParser/AST.cpp
@@ -433,7 +433,8 @@ DEF_STRING(Statement, String)
 
 Statement::Statement(const std::string& str, StatementClass stmtClass, Declaration* decl) : String(str), Class(stmtClass), Decl(decl) {}
 
-Expression::Expression(const std::string& str, StatementClass stmtClass, Declaration* decl) : Statement(str, stmtClass, decl) {}
+Expression::Expression(const std::string& str, StatementClass stmtClass, Declaration* decl, Expression* subexpr)
+:Statement(str, stmtClass, decl), Subexpression(subexpr) {}
 
 Parameter::Parameter() : Declaration(DeclarationKind::Parameter),
     IsIndirect(false), HasDefaultValue(false), DefaultArgument(0) {}

--- a/src/CppParser/AST.h
+++ b/src/CppParser/AST.h
@@ -465,7 +465,9 @@ enum class StatementClass
     BinaryOperator,
     DeclRefExprClass,
     CXXConstructExprClass,
-    CXXOperatorCallExpr
+    CXXOperatorCallExpr,
+    ImplicitCastExpr,
+    ExplicitCastExpr,
 };
 
 class CS_API Statement
@@ -480,7 +482,8 @@ public:
 class CS_API Expression : public Statement
 {
 public:
-    Expression(const std::string& str, StatementClass Class = StatementClass::Any, Declaration* decl = 0);
+    Expression(const std::string& str, StatementClass Class = StatementClass::Any, Declaration* decl = 0, Expression* subexpr = 0);
+    Expression* Subexpression;
 };
 
 class CS_API Parameter : public Declaration

--- a/src/CppParser/Bindings/CLI/AST.cpp
+++ b/src/CppParser/Bindings/CLI/AST.cpp
@@ -1562,6 +1562,16 @@ CppSharp::Parser::AST::Expression^ CppSharp::Parser::AST::Expression::__CreateIn
     return gcnew CppSharp::Parser::AST::Expression((::CppSharp::CppParser::AST::Expression*) native.ToPointer());
 }
 
+CppSharp::Parser::AST::Expression^ CppSharp::Parser::AST::Expression::Subexpression::get()
+{
+    return (((::CppSharp::CppParser::AST::Expression*)NativePtr)->Subexpression == nullptr) ? nullptr : gcnew CppSharp::Parser::AST::Expression((::CppSharp::CppParser::AST::Expression*)((::CppSharp::CppParser::AST::Expression*)NativePtr)->Subexpression);
+}
+
+void CppSharp::Parser::AST::Expression::Subexpression::set(CppSharp::Parser::AST::Expression^ value)
+{
+    ((::CppSharp::CppParser::AST::Expression*)NativePtr)->Subexpression = (::CppSharp::CppParser::AST::Expression*)value->NativePtr;
+}
+
 CppSharp::Parser::AST::Parameter::Parameter(::CppSharp::CppParser::AST::Parameter* native)
     : CppSharp::Parser::AST::Declaration((::CppSharp::CppParser::AST::Declaration*)native)
 {

--- a/src/CppParser/Bindings/CLI/AST.h
+++ b/src/CppParser/Bindings/CLI/AST.h
@@ -214,7 +214,9 @@ namespace CppSharp
                 BinaryOperator = 1,
                 DeclRefExprClass = 2,
                 CXXConstructExprClass = 3,
-                CXXOperatorCallExpr = 4
+                CXXOperatorCallExpr = 4,
+                ImplicitCastExpr = 5,
+                ExplicitCastExpr = 6
             };
 
             public enum struct TemplateSpecializationKind
@@ -1211,6 +1213,11 @@ namespace CppSharp
 
                 Expression(::CppSharp::CppParser::AST::Expression* native);
                 static Expression^ __CreateInstance(::System::IntPtr native);
+                property CppSharp::Parser::AST::Expression^ Subexpression
+                {
+                    CppSharp::Parser::AST::Expression^ get();
+                    void set(CppSharp::Parser::AST::Expression^);
+                }
             };
 
             public ref class Parameter : CppSharp::Parser::AST::Declaration

--- a/src/CppParser/Bindings/CSharp/i686-pc-win32-msvc/AST.cs
+++ b/src/CppParser/Bindings/CSharp/i686-pc-win32-msvc/AST.cs
@@ -137,7 +137,9 @@ namespace CppSharp
                 BinaryOperator = 1,
                 DeclRefExprClass = 2,
                 CXXConstructExprClass = 3,
-                CXXOperatorCallExpr = 4
+                CXXOperatorCallExpr = 4,
+                ImplicitCastExpr = 5,
+                ExplicitCastExpr = 6
             }
 
             public enum TemplateSpecializationKind
@@ -4170,7 +4172,7 @@ namespace CppSharp
 
             public unsafe partial class Expression : CppSharp.Parser.AST.Statement, IDisposable
             {
-                [StructLayout(LayoutKind.Explicit, Size = 32)]
+                [StructLayout(LayoutKind.Explicit, Size = 36)]
                 public new partial struct Internal
                 {
                     [FieldOffset(0)]
@@ -4178,6 +4180,9 @@ namespace CppSharp
 
                     [FieldOffset(4)]
                     public global::System.IntPtr Decl;
+
+                    [FieldOffset(32)]
+                    public global::System.IntPtr Subexpression;
 
                     [SuppressUnmanagedCodeSecurity]
                     [DllImport("CppSharp.CppParser.dll", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.ThisCall,
@@ -4204,7 +4209,7 @@ namespace CppSharp
 
                 private static Expression.Internal* __CopyValue(Expression.Internal native)
                 {
-                    var ret = Marshal.AllocHGlobal(32);
+                    var ret = Marshal.AllocHGlobal(36);
                     CppSharp.Parser.AST.Expression.Internal.cctor_1(ret, new global::System.IntPtr(&native));
                     return (Expression.Internal*) ret;
                 }
@@ -4227,6 +4232,21 @@ namespace CppSharp
                         Marshal.FreeHGlobal(__Instance);
                     }
                     base.Dispose(disposing);
+                }
+
+                public CppSharp.Parser.AST.Expression Subexpression
+                {
+                    get
+                    {
+                        var __ptr = (Internal*)__Instance.ToPointer();
+                        return (__ptr->Subexpression == IntPtr.Zero) ? null : CppSharp.Parser.AST.Expression.__CreateInstance(__ptr->Subexpression);
+                    }
+
+                    set
+                    {
+                        var __ptr = (Internal*)__Instance.ToPointer();
+                        __ptr->Subexpression = value == (CppSharp.Parser.AST.Expression) null ? global::System.IntPtr.Zero : value.__Instance;
+                    }
                 }
             }
 

--- a/src/CppParser/Parser.cpp
+++ b/src/CppParser/Parser.cpp
@@ -2510,8 +2510,13 @@ AST::Expression* Parser::WalkExpression(clang::Expr* Expr)
     case Stmt::CXXFunctionalCastExprClass:
     case Stmt::CXXReinterpretCastExprClass:
     case Stmt::CXXStaticCastExprClass:
+        return  new AST::Expression(GetStringFromStatement(Expr), StatementClass::ExplicitCastExpr,
+            0,
+            WalkExpression(cast<CastExpr>(Expr)->getSubExpr()));
     case Stmt::ImplicitCastExprClass:
-        return WalkExpression(cast<CastExpr>(Expr)->getSubExprAsWritten());
+        return  new AST::Expression(GetStringFromStatement(Expr), StatementClass::ImplicitCastExpr,
+            0,
+            WalkExpression(cast<CastExpr>(Expr)->getSubExpr()));
     case Stmt::CXXOperatorCallExprClass:
         return new AST::Expression(GetStringFromStatement(Expr), StatementClass::CXXOperatorCallExpr,
             WalkDeclaration(cast<CXXOperatorCallExpr>(Expr)->getCalleeDecl()));
@@ -2521,17 +2526,22 @@ AST::Expression* Parser::WalkExpression(clang::Expr* Expr)
         auto ConstructorExpr = cast<CXXConstructExpr>(Expr);
         if (ConstructorExpr->getNumArgs() == 1)
         {
-            auto Arg = ConstructorExpr->getArg(0);
-            auto TemporaryExpr = dyn_cast<MaterializeTemporaryExpr>(Arg);
-            if (TemporaryExpr)
+            if (ConstructorExpr->isElidable())
             {
-                auto Cast = dyn_cast<CastExpr>(TemporaryExpr->GetTemporaryExpr());
-                if (Cast && Cast->getSubExprAsWritten()->getStmtClass() != Stmt::IntegerLiteralClass)
-                    return WalkExpression(Cast->getSubExprAsWritten());
+                return WalkExpression(ConstructorExpr->getArg(0));
+            }
+            else
+            {
+                return new AST::Expression(GetStringFromStatement(Expr), StatementClass::CXXConstructExprClass,
+                    WalkDeclaration(ConstructorExpr->getConstructor()),
+                    WalkExpression(ConstructorExpr->getArg(0)));
             }
         }
-        return new AST::Expression(GetStringFromStatement(Expr), StatementClass::CXXConstructExprClass,
-            WalkDeclaration(ConstructorExpr->getConstructor()));
+        else
+        {
+            return new AST::Expression(GetStringFromStatement(Expr), StatementClass::CXXConstructExprClass,
+                WalkDeclaration(ConstructorExpr->getConstructor()));
+        }
     }
     case Stmt::MaterializeTemporaryExprClass:
         return WalkExpression(cast<MaterializeTemporaryExpr>(Expr)->GetTemporaryExpr());

--- a/src/Generator/Generators/CSharp/CSharpExpressionPrinter.cs
+++ b/src/Generator/Generators/CSharp/CSharpExpressionPrinter.cs
@@ -15,8 +15,7 @@ namespace CppSharp.Generators.CSharp
 
     public static class CSharpExpressionPrinterExtensions
     {
-        public static CSharpExpressionPrinterResult CSharpValue(this Expression value,
-            CSharpExpressionPrinter printer)
+        public static CSharpExpressionPrinterResult CSharpValue(this Expression value, CSharpExpressionPrinter printer)
         {
             return value.Visit(printer);
         }
@@ -25,11 +24,11 @@ namespace CppSharp.Generators.CSharp
     public class CSharpExpressionPrinter : IExpressionPrinter<CSharpExpressionPrinterResult>,
         IExpressionVisitor<CSharpExpressionPrinterResult>
     {
-        public CSharpExpressionPrinterResult VisitBuiltinExpression(BuiltinTypeExpression builtinType)
+        public CSharpExpressionPrinterResult VisitExpression(Expression expr)
         {
             return new CSharpExpressionPrinterResult()
             {
-                Value = builtinType.ToString(),
+                Value = expr.ToString(),
             };
         }
 

--- a/tests/CSharpTemp/CSharpTemp.cpp
+++ b/tests/CSharpTemp/CSharpTemp.cpp
@@ -31,6 +31,39 @@ const Foo& Bar::operator[](int i) const
     return m_foo;
 }
 
+
+Quux::Quux()
+{
+
+}
+
+Quux::Quux(int i)
+{
+
+}
+
+Quux::Quux(char c)
+{
+
+}
+
+Quux::Quux(Foo f)
+{
+
+}
+
+
+
+QColor::QColor()
+{
+
+}
+
+QColor::QColor(Qt::GlobalColor color)
+{
+
+}
+
 Qux::Qux()
 {
 
@@ -294,7 +327,19 @@ void MethodsWithDefaultValues::defaultMappedToZeroEnum(QFlags<Flags> qFlags)
 {
 }
 
+void MethodsWithDefaultValues::defaultImplicitCtorInt(Quux arg)
+{
+}
+
+void MethodsWithDefaultValues::defaultImplicitCtorChar(Quux arg)
+{
+}
+
 void MethodsWithDefaultValues::defaultIntWithLongExpression(unsigned int i)
+{
+}
+
+void MethodsWithDefaultValues::defaultRefTypeEnumImplicitCtor(const QColor &fillColor)
 {
 }
 

--- a/tests/CSharpTemp/CSharpTemp.h
+++ b/tests/CSharpTemp/CSharpTemp.h
@@ -16,6 +16,18 @@ protected:
     int P;
 };
 
+class DLL_API Quux
+{
+public:
+    Quux();
+    Quux(int i);
+    Quux(char c);
+    Quux(Foo f);
+private:
+    int priv;
+};
+
+
 class DLL_API Qux
 {
 public:
@@ -216,6 +228,21 @@ private:
 
 #define DEFAULT_INT (2 * 1000UL + 500UL)
 
+namespace Qt
+{
+    enum GlobalColor {
+        black,
+        white,
+    };
+}
+
+class QColor
+{
+public:
+    QColor();
+    QColor(Qt::GlobalColor color);
+};
+
 class DLL_API MethodsWithDefaultValues
 {
 public:
@@ -236,7 +263,11 @@ public:
     void defaultNonEmptyCtor(QGenericArgument arg = QGenericArgument(0));
     void defaultMappedToEnum(QFlags<Flags> qFlags = Flags::Flag1);
     void defaultMappedToZeroEnum(QFlags<Flags> qFlags = 0);
+    void defaultImplicitCtorInt(Quux arg = 0);
+    void defaultImplicitCtorChar(Quux arg = 'a');
+    void defaultImplicitCtorFoo(Quux arg = Foo());
     void defaultIntWithLongExpression(unsigned int i = DEFAULT_INT);
+    void defaultRefTypeEnumImplicitCtor(const QColor &fillColor = Qt::white);
 };
 
 class DLL_API HasPrivateOverrideBase


### PR DESCRIPTION
Test that demonstrate the "new 0" and show some other erroneus behaviour too.

Implemented CastExpression. ImplicitCast and ExplicitCast statement classes.

Fixed implicit constructor string generation.

Implemented CtorExpr.

All test cases pass.

Fixed indentations, streamlined the code.

Fixed regressions.

Fixed regressions.

Adding a test case not covered before.

Fixed, refactored and simplified things.

Still more fixes (0 to null ptr conversion, enum check). The additional test passes now too.
