### PR TITLE
Fixed 3 bugs related to custom comparison operators

### DIFF
--- a/src/AST/Declaration.cs
+++ b/src/AST/Declaration.cs
@@ -265,7 +265,6 @@ namespace CppSharp.AST
             set { if (value) ExplicitlyIgnore(); }
         }
 
-        [Obsolete("Replace set by ExplicitlyIgnore(). Replace get by GenerationKind == GenerationKind.None.")]
         public virtual bool Ignore
         {
             get { return GenerationKind == GenerationKind.None; }

--- a/src/Generator/Generators/CSharp/CSharpMarshal.cs
+++ b/src/Generator/Generators/CSharp/CSharpMarshal.cs
@@ -568,7 +568,11 @@ namespace CppSharp.Generators.CSharp
                 if (type.TryGetClass(out decl) && decl.IsValueType)
                     Context.Return.Write("{0}.{1}", param, Helpers.InstanceIdentifier);
                 else
-                    Context.Return.Write("{0} == ({2}) null ? global::System.IntPtr.Zero : {0}.{1}", param,
+                    Context.Return.Write("{0}{1}.{2}",
+                        method != null && method.OperatorKind == CXXOperatorKind.EqualEqual
+                            ? string.Empty
+                            : string.Format("ReferenceEquals({0}, null) ? global::System.IntPtr.Zero : ", param),
+                        param,
                         Helpers.InstanceIdentifier, type);
                 return;
             }

--- a/tests/Basic/Basic.Tests.cs
+++ b/tests/Basic/Basic.Tests.cs
@@ -458,5 +458,11 @@ public class BasicTests : GeneratorTestFixture
     {
         new InvokesInternalCtorAmbiguity().InvokeInternalCtor();
     }
+
+    [Test]
+    public void TestEqualityOperator()
+    {
+        Assert.AreEqual(new Foo { A = 5, B = 5.5f }, new Foo { A = 5, B = 5.5f });
+    }
 }
  

--- a/tests/Basic/Basic.cpp
+++ b/tests/Basic/Basic.cpp
@@ -23,6 +23,11 @@ void Foo::TakesTypedefedPtr(FooPtr date)
 {
 }
 
+bool Foo::operator ==(const Foo& other) const
+{
+    return A == other.A && B == other.B;
+}
+
 Foo2::Foo2() {}
 
 Foo2 Foo2::operator<<(signed int i)
@@ -60,6 +65,11 @@ Bar::Item Bar::RetItem1()
 Bar* Bar::returnPointerToValueType()
 {
     return this;
+}
+
+bool Bar::operator ==(const Bar& other) const
+{
+    return A == other.A && B == other.B;
 }
 
 Bar2::Nested::operator int() const

--- a/tests/Basic/Basic.h
+++ b/tests/Basic/Basic.h
@@ -45,6 +45,8 @@ public:
     typedef Foo* FooPtr;
 
     void TakesTypedefedPtr(FooPtr date);
+
+    bool operator ==(const Foo& other) const;
 };
 
 struct DLL_API Bar
@@ -61,6 +63,8 @@ struct DLL_API Bar
     float B;
 
     Bar* returnPointerToValueType();
+
+    bool operator ==(const Bar& other) const;
 };
 
 class DLL_API Foo2 : public Foo


### PR DESCRIPTION
1. Missing Equals to complement operator ==;
2. Endless recursion when having a == and comparing to null;
3. Crash when having a == and comparing a null pointer to sth else.
