### PR TITLE
"Fixes GetterSetterToPropertyAdvancedPass by visiting the bases and conve...

### DIFF
--- a/src/Generator/Passes/GetterSetterToPropertyAdvancedPass.cs
+++ b/src/Generator/Passes/GetterSetterToPropertyAdvancedPass.cs
@@ -278,6 +278,11 @@ namespace CppSharp.Passes
         {
             if (VisitDeclarationContext(@class))
             {
+                if (Options.VisitClassBases)
+                    foreach (var baseClass in @class.Bases)
+                        if (baseClass.IsClass)
+                            VisitClassDecl(baseClass.Class);
+
                 new PropertyGenerator(@class, Log).GenerateProperties();
             }
             return false;


### PR DESCRIPTION
...rting their properties first. This is neccessary for overrided properties of derived classes to work."

Hi, thanks for the quick fix for my previous crash report. I've got one more.

In the GetterSetterToPropertyAdvancedPass, QtGui generation crashes, when trying to access the base property of overrided property of a derived type. This happens with QWindow.surfaceType, which overrides QSurface.surfaceType.

In AstVisitor, it always visits the base classes of visited class declarations, but the overrided VisitClassDecl of GetterSetterToPropertyAdvancedPass doesn't do that - that's why the properties of the base classes aren't set.

Strange that it has worked this far, though. I wonder what changed?