### PR TITLE
Fix build error on osx

### DIFF
--- a/src/CppParser/Parser.cpp
+++ b/src/CppParser/Parser.cpp
@@ -2412,7 +2412,7 @@ Friend* Parser::WalkFriend(clang::FriendDecl *FD)
 
     // Work around clangIndex's lack of USR handling for friends and pass the
     // pointed to friend declaration instead.
-    auto USR = GetDeclUSR(FriendDecl ? (Decl*)FriendDecl : FD);
+    auto USR = GetDeclUSR(FriendDecl ? ((Decl*)FriendDecl) : FD);
     if (auto F = NS->FindFriend(USR))
         return F;
 


### PR DESCRIPTION
The build fails on osx 10.10 building CppSharp for 64 bits using the recommended llvm version with the following error:

```
==== Building CppSharp.CppParser (release_x64) ====
AST.cpp
Comments.cpp
CppParser.cpp
Parser.cpp
../../../src/CppParser/Parser.cpp:2415:58: error: unexpected ':' in nested name specifier; did you mean '::'?
    auto USR = GetDeclUSR(FriendDecl ? (Decl*)FriendDecl : FD);
                                                         ^
                                                         ::
../../../src/CppParser/Parser.cpp:2415:47: error: no member named 'FD' in 'clang::FriendDecl'; did you mean simply 'FD'?
    auto USR = GetDeclUSR(FriendDecl ? (Decl*)FriendDecl : FD);
                                              ^~~~~~~~~~~~~~~
                                              FD
../../../src/CppParser/Parser.cpp:2404:47: note: 'FD' declared here
Friend* Parser::WalkFriend(clang::FriendDecl *FD)
                                              ^
../../../src/CppParser/Parser.cpp:2415:62: error: expected ':'
    auto USR = GetDeclUSR(FriendDecl ? (Decl*)FriendDecl : FD);
                                                             ^
                                                             : 
../../../src/CppParser/Parser.cpp:2415:38: note: to match this '?'
    auto USR = GetDeclUSR(FriendDecl ? (Decl*)FriendDecl : FD);
                                     ^
../../../src/CppParser/Parser.cpp:2415:62: error: expected expression
    auto USR = GetDeclUSR(FriendDecl ? (Decl*)FriendDecl : FD);
                                                             ^
4 errors generated.
make[1]: *** [../obj/x64/Release/CppSharp.CppParser/Parser.o] Error 1
```

This PR fixes the build issue.