### PR TITLE
Determine bitness on osx

### DIFF
--- a/src/CppParser/Bindings/premake4.lua
+++ b/src/CppParser/Bindings/premake4.lua
@@ -29,7 +29,14 @@ project "CppSharp.Parser.CSharp"
   if os.is_windows() then
       files { "CSharp/i686-pc-win32-msvc/**.cs" }
   elseif os.is_osx() then
-      files { "CSharp/i686-apple-darwin12.4.0/**.cs" }
+      local file = io.popen("lipo -info `which mono`")
+      local output = file:read('*all')
+      if string.find(output, "x86_64") then  
+        files { "CSharp/x86_64-apple-darwin12.4.0/**.cs" }
+      else
+        files { "CSharp/i686-apple-darwin12.4.0/**.cs" }
+      end
+
   elseif os.is_linux() then
       files { "CSharp/x86_64-linux-gnu/**.cs" }
   else


### PR DESCRIPTION
This reads the bitness from mono which is in path.

lipo -info gives the following output on a 64 bit mono:
```
localhost:build Stephan$ lipo -info `which mono`
Non-fat file: /usr/local/bin/mono is architecture: x86_64
```

With the executable from the Mono MDK the following is returned:
```
localhost:build Stephan$ lipo -info /Library/Frameworks/Mono.framework/Mono
Non-fat file: /Library/Frameworks/Mono.framework/Mono is architecture: i386
```

This patch checks for x86_64 in the output if found a 64 bit build is configured, else 32 bit.