### PR TITLE
Add missing reference

### DIFF
--- a/src/Generator.Tests/GeneratorTest.cs
+++ b/src/Generator.Tests/GeneratorTest.cs
@@ -2,6 +2,7 @@
 using System.IO;
 using System.Reflection;
 using System.Text.RegularExpressions;
+using System.Runtime.InteropServices;
 using CppSharp.AST;
 using CppSharp.Generators;
 using NUnit.Framework;


### PR DESCRIPTION
For some reason premake didn't rebuild when I changed this and no compile error was thrown.