### PR TITLE
Don't visit invalid units

### DIFF
--- a/src/Generator/Passes/Pass.cs
+++ b/src/Generator/Passes/Pass.cs
@@ -30,6 +30,9 @@ namespace CppSharp.Passes
 
         public virtual bool VisitTranslationUnit(TranslationUnit unit)
         {
+            if (!unit.IsValid)
+                return false;
+
             if (unit.IsSystemHeader)
                 return false;
 


### PR DESCRIPTION
CppSharp master fails compiling QtSharp in https://github.com/mono/CppSharp/blob/master/src/Generator/Passes/RenameRootNamespaces.cs#L18 because one of the filenames is invalid and an ArgumentException is thrown when accessing the FileName.

Returning false on invalid units will stop the RenameNamespacePass before accessing the FileName property.