### PR TITLE
Revert "Fixed parsing of function signatures with const-qualified return types"

### DIFF
--- a/src/CppParser/Parser.cpp
+++ b/src/CppParser/Parser.cpp
@@ -2219,6 +2219,8 @@ void Parser::WalkFunction(clang::FunctionDecl* FD, Function* F,
     }
 
     clang::SourceLocation BeginLoc = FD->getLocStart();
+    if (ResultLoc.isValid())
+        BeginLoc = ResultLoc;
 
     // For some weird reason 'kw_const' doesn't work; Clang considers the 'const' a 'raw_identifier'
     clang::SourceLocation EndLoc = Lexer::findLocationAfterToken(

--- a/src/Generator.Tests/AST/TestAST.cs
+++ b/src/Generator.Tests/AST/TestAST.cs
@@ -243,7 +243,7 @@ namespace CppSharp.Generator.Tests.AST
         [Test]
         public void TestLineNumberOfFriend()
         {
-            Assert.AreEqual(82, AstContext.FindFunction("operator+").First().LineNumber);
+            Assert.AreEqual(83, AstContext.FindFunction("operator+").First().LineNumber);
         }
 
         [Test]
@@ -252,7 +252,9 @@ namespace CppSharp.Generator.Tests.AST
             Assert.AreEqual("void testSignature()", AstContext.FindFunction("testSignature").Single().Signature);
             Assert.AreEqual("void testImpl()", AstContext.FindFunction("testImpl").Single().Signature);
             Assert.AreEqual("void testConstSignature() const", AstContext.FindClass("HasConstFunction").Single().FindMethod("testConstSignature").Signature);
-            Assert.AreEqual("const int& testConstRefSignature()", AstContext.FindClass("HasConstFunction").Single().FindMethod("testConstRefSignature").Signature);
+            // TODO: restore when the const of a return type is fixed properly
+            //Assert.AreEqual("const int& testConstRefSignature()", AstContext.FindClass("HasConstFunction").Single().FindMethod("testConstRefSignature").Signature);
+            //Assert.AreEqual("const int& testStaticConstRefSignature()", AstContext.FindClass("HasConstFunction").Single().FindMethod("testStaticConstRefSignature").Signature);
         }
     }
 }

--- a/tests/Native/AST.h
+++ b/tests/Native/AST.h
@@ -72,6 +72,7 @@ class HasConstFunction
 public:
     void testConstSignature() const;
     const int& testConstRefSignature();
+    static const int& testStaticConstRefSignature();
     friend inline const TestTemplateClass2 operator+(const TestTemplateClass2& f1, const TestTemplateClass2& f2);
 };
 


### PR DESCRIPTION
This reverts commit 7d5e53e1df611e8dad5f3106c5d7775d6c841260.

Conflicts:
	tests/Native/AST.h

Signed-off-by: Dimitar Dobrev <dpldobrev@yahoo.com>