### PR TITLE
Fixed code generation when using arrays in Value Type types...

### DIFF
--- a/src/Generator/Generators/CLI/CLIMarshal.cs
+++ b/src/Generator/Generators/CLI/CLIMarshal.cs
@@ -47,8 +47,7 @@ namespace CppSharp.Generators.CLI
             {
                 case ArrayType.ArraySize.Constant:
                     var supportBefore = Context.SupportBefore;
-                    string value = Generator.GeneratedIdentifier("array") 
-                                            + _arrayNum;
+                    string value = Generator.GeneratedIdentifier("array") + _arrayNum;
                     ++_arrayNum;
                     supportBefore.WriteLine("cli::array<{0}>^ {1} = nullptr;", array.Type, value, array.Size);
                     supportBefore.WriteLine("if ({0} != 0)", Context.ReturnVarName);

--- a/src/Generator/Generators/CLI/CLIMarshal.cs
+++ b/src/Generator/Generators/CLI/CLIMarshal.cs
@@ -40,15 +40,15 @@ namespace CppSharp.Generators.CLI
             return decl.Visit(this);
         }
 
-        private static int _arrayNum = 0;
+        private static int arrayNum = 0;
         public override bool VisitArrayType(ArrayType array, TypeQualifiers quals)
         {
             switch (array.SizeType)
             {
                 case ArrayType.ArraySize.Constant:
                     var supportBefore = Context.SupportBefore;
-                    string value = Generator.GeneratedIdentifier("array") + _arrayNum;
-                    ++_arrayNum;
+                    string value = Generator.GeneratedIdentifier("array") + arrayNum;
+                    ++arrayNum;
                     supportBefore.WriteLine("cli::array<{0}>^ {1} = nullptr;", array.Type, value, array.Size);
                     supportBefore.WriteLine("if ({0} != 0)", Context.ReturnVarName);
                     supportBefore.WriteStartBraceIndent();

--- a/src/Generator/Generators/CLI/CLIMarshal.cs
+++ b/src/Generator/Generators/CLI/CLIMarshal.cs
@@ -40,13 +40,16 @@ namespace CppSharp.Generators.CLI
             return decl.Visit(this);
         }
 
+        private static int _arrayNum = 0;
         public override bool VisitArrayType(ArrayType array, TypeQualifiers quals)
         {
             switch (array.SizeType)
             {
                 case ArrayType.ArraySize.Constant:
                     var supportBefore = Context.SupportBefore;
-                    string value = Generator.GeneratedIdentifier("array");
+                    string value = Generator.GeneratedIdentifier("array") 
+                                            + _arrayNum;
+                    ++_arrayNum;
                     supportBefore.WriteLine("cli::array<{0}>^ {1} = nullptr;", array.Type, value, array.Size);
                     supportBefore.WriteLine("if ({0} != 0)", Context.ReturnVarName);
                     supportBefore.WriteStartBraceIndent();

--- a/src/Generator/Generators/CSharp/CSharpTextTemplate.cs
+++ b/src/Generator/Generators/CSharp/CSharpTextTemplate.cs
@@ -863,11 +863,12 @@ namespace CppSharp.Generators.CSharp
                 {
                     CSharpTypePrinter typePrinter = new CSharpTypePrinter(ctx.Driver);
                     string type = arrayType.CSharpType(typePrinter).Type;
-                    WriteLine(string.Format("fixed ({0} __arrPtr = {1}.{2})",
-                        type.Replace("[]","*"), Helpers.InstanceField,
+                    string arrPtrIden = Helpers.SafeIdentifier("__arrPtr");
+                    WriteLine(string.Format("fixed ({0} {1} = {2}.{3})",
+                        type.Replace("[]","*"), arrPtrIden, Helpers.InstanceField,
                         Helpers.SafeIdentifier(field.OriginalName)));
                     WriteStartBraceIndent();
-                    ctx.ReturnVarName = string.Format("__arrPtr");
+                    ctx.ReturnVarName = arrPtrIden;
                 }
                 else
                 {
@@ -890,9 +891,7 @@ namespace CppSharp.Generators.CSharp
                 }
 
                 if (arrayType != null && @class.IsValueType)
-                {
                     WriteCloseBraceIndent();
-                }
 
                 WriteCloseBraceIndent();
             }
@@ -990,11 +989,12 @@ namespace CppSharp.Generators.CSharp
                 {
                     CSharpTypePrinter typePrinter = new CSharpTypePrinter(ctx.Driver);
                     string type = arrayType.CSharpType(typePrinter).Type;
-                    WriteLine(string.Format("fixed ({0} __arrPtr = {1}.{2})",
-                        type.Replace("[]", "*"), Helpers.InstanceField,
+                    string arrPtrIden = Helpers.SafeIdentifier("__arrPtr");
+                    WriteLine(string.Format("fixed ({0} {1} = {2}.{3})",
+                        type.Replace("[]","*"), arrPtrIden, Helpers.InstanceField,
                         Helpers.SafeIdentifier(field.OriginalName)));
                     WriteStartBraceIndent();
-                    ctx.ReturnVarName = string.Format("__arrPtr");
+                    ctx.ReturnVarName = arrPtrIden;
                 }
 
                 var marshal = new CSharpMarshalNativeToManagedPrinter(ctx);
@@ -1005,13 +1005,8 @@ namespace CppSharp.Generators.CSharp
 
                 WriteLine("return {0};", marshal.Context.Return);
 
-
                 if (arrayType != null && @class.IsValueType)
-                {
                     WriteCloseBraceIndent();
-                }
-
-                
             }
             else if (decl is Variable)
             {

--- a/src/Generator/Generators/CSharp/CSharpTextTemplate.cs
+++ b/src/Generator/Generators/CSharp/CSharpTextTemplate.cs
@@ -859,10 +859,10 @@ namespace CppSharp.Generators.CSharp
 
                 var arrayType = field.Type as ArrayType;
                 
-                if(arrayType!=null && @class.IsValueType==true)
+                if(arrayType != null && @class.IsValueType)
                 {
-                    CSharpTypePrinter _ctp = new CSharpTypePrinter(ctx.Driver);
-                    string type = arrayType.CSharpType(_ctp).Type;
+                    CSharpTypePrinter typePrinter = new CSharpTypePrinter(ctx.Driver);
+                    string type = arrayType.CSharpType(typePrinter).Type;
                     WriteLine(string.Format("fixed ({0} __arrPtr = {1}.{2})",
                         type.Replace("[]","*"), Helpers.InstanceField,
                         Helpers.SafeIdentifier(field.OriginalName)));
@@ -889,7 +889,7 @@ namespace CppSharp.Generators.CSharp
                     WriteLine("{0} = {1};", ctx.ReturnVarName, marshal.Context.Return);                    
                 }
 
-                if (arrayType != null && @class.IsValueType == true)
+                if (arrayType != null && @class.IsValueType)
                 {
                     WriteCloseBraceIndent();
                 }
@@ -986,10 +986,10 @@ namespace CppSharp.Generators.CSharp
 
                 var arrayType = field.Type as ArrayType;
 
-                if (arrayType != null && @class.IsValueType == true)
+                if (arrayType != null && @class.IsValueType)
                 {
-                    CSharpTypePrinter _ctp = new CSharpTypePrinter(ctx.Driver);
-                    string type = arrayType.CSharpType(_ctp).Type;
+                    CSharpTypePrinter typePrinter = new CSharpTypePrinter(ctx.Driver);
+                    string type = arrayType.CSharpType(typePrinter).Type;
                     WriteLine(string.Format("fixed ({0} __arrPtr = {1}.{2})",
                         type.Replace("[]", "*"), Helpers.InstanceField,
                         Helpers.SafeIdentifier(field.OriginalName)));
@@ -1006,7 +1006,7 @@ namespace CppSharp.Generators.CSharp
                 WriteLine("return {0};", marshal.Context.Return);
 
 
-                if (arrayType != null && @class.IsValueType == true)
+                if (arrayType != null && @class.IsValueType)
                 {
                     WriteCloseBraceIndent();
                 }

--- a/tests/Basic/Basic.h
+++ b/tests/Basic/Basic.h
@@ -710,3 +710,13 @@ public:
     bool operator ==(const DifferentConstOverloads& other);
     bool operator ==(int number) const;
 };
+
+#define ARRAY_LENGTH 5
+#define CS_VALUE_TYPE
+struct CS_VALUE_TYPE ValueTypeArrays
+{
+	float firstValueTypeArrray[ARRAY_LENGTH];
+	int secondValueTypeArray[ARRAY_LENGTH];
+	char thirdValueTypeArray[ARRAY_LENGTH];
+	size_t size;
+};


### PR DESCRIPTION
Just added array number to end of '__array' identifier for CLI generator.
And added fixed scoping for C# generator in getters and setters since the arrays are fixed size buffers.