### PR TITLE
Fixed compilation issues when nesting more than one anonymous types.

### DIFF
--- a/src/Generator/Generators/CSharp/CSharpTextTemplate.cs
+++ b/src/Generator/Generators/CSharp/CSharpTextTemplate.cs
@@ -713,6 +713,11 @@ namespace CppSharp.Generators.CSharp
 
             var safeIdentifier = Helpers.SafeIdentifier(field.OriginalName);
 
+            if(safeIdentifier.All(c => c.Equals('_')))
+            {
+                safeIdentifier = Helpers.SafeIdentifier(field.Name);
+            }
+
             PushBlock(CSharpBlockKind.Field);
 
             WriteLine("[FieldOffset({0})]", field.OffsetInBytes);

--- a/src/Generator/Passes/CleanInvalidDeclNamesPass.cs
+++ b/src/Generator/Passes/CleanInvalidDeclNamesPass.cs
@@ -3,6 +3,7 @@ using System.Linq;
 using CppSharp.AST;
 using CppSharp.Generators.CLI;
 using CppSharp.Generators.CSharp;
+using System.Text;
 
 namespace CppSharp.Passes
 {
@@ -152,6 +153,21 @@ namespace CppSharp.Passes
         {
             item.Name = CheckName(item.Name);
             return base.VisitEnumItem(item);
+        }
+
+        public override bool VisitFieldDecl(Field field)
+        {
+            if (field.Class.Fields.Count(c => c.Name.Equals(field.Name)) > 1)
+            {
+                StringBuilder str = new StringBuilder();
+                str.Append(field.Name);
+                do
+                {
+                    str.Append('_');
+                } while (field.Class.Fields.Any(c => c.Name.Equals(str.ToString())));
+                field.Name = str.ToString();
+            }
+            return base.VisitFieldDecl(field);
         }
     }
 }

--- a/tests/Basic/Basic.h
+++ b/tests/Basic/Basic.h
@@ -647,6 +647,24 @@ public:
         {
         };
     };
+	struct
+	{
+		struct
+		{
+		};
+	};
+	struct
+	{
+		struct
+		{
+		};
+	};
+	struct
+	{
+		struct
+		{
+		};
+	};
 
     union as_types
     {


### PR DESCRIPTION
The [double underscore] identifier was generated for anonymous types and hence resulted in conflict when nesting more than one anonymous types.
I checked if an identifier had just '_' in it then i repeated the underscore 'numSafeIden' times which kept track of how many times such identifier has been generated.
.
Alternate solution (probably more elegant) can be if [double underscore] was to be suffixed with integer 'numSafeIden' instead of repeating the underscore so many times.