### PR TITLE
Optimised the passes for time

### DIFF
--- a/src/AST/TranslationUnit.cs
+++ b/src/AST/TranslationUnit.cs
@@ -31,28 +31,39 @@ namespace CppSharp.AST
         /// Contains the path to the file.
         public string FilePath;
 
+        private string fileName;
+        private string fileNameWithoutExtension;
+
         /// Contains the name of the file.
         public string FileName
         {
-            get { return Path.GetFileName(FilePath); }
+            get { return fileName ?? (fileName = Path.GetFileName(FilePath)); }
         }
 
         /// Contains the name of the module.
         public string FileNameWithoutExtension
         {
-            get { return Path.GetFileNameWithoutExtension(FileName); }
+            get
+            {
+                return fileNameWithoutExtension ??
+                    (fileNameWithoutExtension = Path.GetFileNameWithoutExtension(FileName));
+            }
         }
 
         /// Contains the include path.
         public string IncludePath;
 
+        private string fileRelativeDirectory;
+        private string fileRelativePath;
+
         public string FileRelativeDirectory
         {
             get
             {
+                if (fileRelativeDirectory != null) return fileRelativeDirectory;
                 var path = IncludePath.Replace('\\', '/');
                 var index = path.LastIndexOf('/');
-                return path.Substring(0, index);
+                return fileRelativeDirectory = path.Substring(0, index);
             }
         }
 
@@ -60,7 +71,8 @@ namespace CppSharp.AST
         {
             get
             {
-                return Path.Combine(FileRelativeDirectory, FileName);
+                return fileRelativePath ??
+                    (fileRelativePath = Path.Combine(FileRelativeDirectory, FileName));
             }
         }
     }

--- a/src/Generator/Passes/CheckIgnoredDecls.cs
+++ b/src/Generator/Passes/CheckIgnoredDecls.cs
@@ -321,7 +321,7 @@ namespace CppSharp.Passes
         /// reasons: incomplete definitions, being explicitly ignored, or also
         /// by being a type we do not know how to handle.
         /// </remarks>
-        bool HasInvalidType(Type type, out string msg)
+        private bool HasInvalidType(Type type, out string msg)
         {
             if (type == null)
             {
@@ -355,7 +355,7 @@ namespace CppSharp.Passes
             return false;
         }
 
-        bool HasInvalidDecl(Declaration decl, out string msg)
+        private bool HasInvalidDecl(Declaration decl, out string msg)
         {
             if (decl == null)
             {
@@ -393,7 +393,7 @@ namespace CppSharp.Passes
             return !decl.IsIncomplete;
         }
 
-        bool IsTypeIgnored(Type type)
+        private bool IsTypeIgnored(Type type)
         {
             var checker = new TypeIgnoreChecker(Driver.TypeDatabase);
             type.Visit(checker);
@@ -401,12 +401,14 @@ namespace CppSharp.Passes
             return checker.IsIgnored;
         }
 
-        bool IsDeclIgnored(Declaration decl)
+        private bool IsDeclIgnored(Declaration decl)
         {
-            var checker = new TypeIgnoreChecker(Driver.TypeDatabase);
-            decl.Visit(checker);
+            var parameter = decl as Parameter;
+            if (parameter != null && parameter.Type.Desugar().IsPrimitiveType(PrimitiveType.Null))
+                return true;
 
-            return checker.IsIgnored;
+            TypeMap typeMap;
+            return Driver.TypeDatabase.FindTypeMap(decl, out typeMap) ? typeMap.IsIgnored : decl.Ignore;
         }
 
         #endregion

--- a/src/Generator/Types/Types.cs
+++ b/src/Generator/Types/Types.cs
@@ -5,29 +5,6 @@ using CppSharp.Types;
 namespace CppSharp
 {
     /// <summary>
-    /// This type checker is used to check if a type is complete.
-    /// </summary>
-    public class TypeCompletionChecker : AstVisitor
-    {
-        public TypeCompletionChecker()
-        {
-            Options.VisitClassBases = false;
-            Options.VisitTemplateArguments = false;
-        }
-
-        public override bool VisitDeclaration(Declaration decl)
-        {
-            if (AlreadyVisited(decl))
-                return false;
-
-            if (decl.CompleteDeclaration != null)
-                return true;
-
-            return !decl.IsIncomplete;
-        }
-    }
-
-    /// <summary>
     /// This type checker is used to check if a type is ignored.
     /// </summary>
     public class TypeIgnoreChecker : AstVisitor


### PR DESCRIPTION
A few properties actually had really slow bodies. On the other hand, as properties they were used without saving their values in local variables. So I changed those to methods in order to let users know they should cache the results instead of making multiple calls.