### PR TITLE
Fixed namespace conflict in C++/CLI.

### DIFF
--- a/src/Generator/Generators/CLI/CLIHeadersTemplate.cs
+++ b/src/Generator/Generators/CLI/CLIHeadersTemplate.cs
@@ -221,7 +221,7 @@ namespace CppSharp.Generators.CLI
         {
             PushBlock(CLIBlockKind.FunctionsClass);
 
-            WriteLine("public ref class {0}", TranslationUnit.FileNameWithoutExtension);
+            WriteLine("public ref class {0}", TranslationUnit.FileNameWithoutExtension + "WrapperClass");
             WriteLine("{");
             WriteLine("public:");
             PushIndent();

--- a/src/Generator/Generators/CLI/CLISourcesTemplate.cs
+++ b/src/Generator/Generators/CLI/CLISourcesTemplate.cs
@@ -878,7 +878,7 @@ namespace CppSharp.Generators.CLI
             GenerateDeclarationCommon(function);
 
             var classSig = string.Format("{0}::{1}", QualifiedIdentifier(@namespace),
-                TranslationUnit.FileNameWithoutExtension);
+                TranslationUnit.FileNameWithoutExtension + "WrapperClass");
 
             Write("{0} {1}::{2}(", function.ReturnType, classSig,
                 function.Name);


### PR DESCRIPTION
Just was going through the codes and found the TODO in UTF16 Test....
Added CLI generation for the test and one of the problems that i encountered was same as #365 
.
This pull solves that. But, it is totally a naming convention thing. So please see if this would be carried out or not. @tritao 