### PR TITLE
Added primitive type to ref type pass and improved support for multi overloads…

### DIFF
--- a/src/Generator/Driver.cs
+++ b/src/Generator/Driver.cs
@@ -242,6 +242,7 @@ namespace CppSharp
             TranslationUnitPasses.AddPass(new SortDeclarationsPass());
             TranslationUnitPasses.AddPass(new ResolveIncompleteDeclsPass());
             TranslationUnitPasses.AddPass(new CheckIgnoredDeclsPass());
+            TranslationUnitPasses.AddPass(new MarshalPrimitivePointersAsRefTypePass());
 
             if (Options.IsCSharpGenerator && Options.GenerateInlines)
                 TranslationUnitPasses.AddPass(new GenerateInlinesCodePass());

--- a/src/Generator/Generators/CSharp/CSharpTextTemplate.cs
+++ b/src/Generator/Generators/CSharp/CSharpTextTemplate.cs
@@ -2035,13 +2035,6 @@ namespace CppSharp.Generators.CSharp
             if (method.IsPure)
                 Write("abstract ");
 
-            if(method.SynthKind == FunctionSynthKind.DefaultValueOverload)
-            {
-                var needUnsafe = method.Parameters.Any(p => p.Kind == ParameterKind.Regular && p.Ignore
-                             && p.Type.IsPointerToPrimitiveType() && p.Usage == ParameterUsage.InOut && p.HasDefaultValue);
-                Write("unsafe ");
-            }
-
             var functionName = GetMethodIdentifier(method);
 
             if (method.IsConstructor || method.IsDestructor)

--- a/src/Generator/Generators/CSharp/CSharpTextTemplate.cs
+++ b/src/Generator/Generators/CSharp/CSharpTextTemplate.cs
@@ -2137,6 +2137,25 @@ namespace CppSharp.Generators.CSharp
 
         private void GenerateOverloadCall(Function function)
         {
+            var needUnsafe = function.Parameters.Any(p => p.Kind == ParameterKind.Regular && p.Ignore
+                             && p.Type.IsPointerToPrimitiveType() && p.Usage == ParameterUsage.InOut && p.HasDefaultValue);
+            if(needUnsafe)
+            {
+                WriteLine("unsafe");
+                WriteStartBraceIndent();
+                int i = 0;
+                foreach(Parameter param in function.Parameters.Where(
+                            p => p.Kind == ParameterKind.Regular &&
+                                 p.Ignore && p.Type.IsPointerToPrimitiveType() && p.Usage == ParameterUsage.InOut && p.HasDefaultValue))
+                {
+                    var strtype = param.Type.CSharpType(TypePrinter).ToString();
+                    WriteLine("{0} arg{1} = ({0}){2};", strtype, i, param.DefaultArgument.String);
+                    WriteLine("{0} param{1} = *arg{1};", strtype.Substring(0, strtype.Length - 1), i);
+                    ++i;
+                }
+            }
+
+            int j = 0;
             Type type = function.OriginalReturnType.Type;
             WriteLine("{0}{1}({2});",
                 type.IsPrimitiveType(PrimitiveType.Void) ? string.Empty : "return ",
@@ -2144,7 +2163,10 @@ namespace CppSharp.Generators.CSharp
                 string.Join(", ",
                     function.Parameters.Where(
                         p => p.Kind == ParameterKind.Regular).Select(
-                            p => p.Ignore ? p.DefaultArgument.String : p.Name)));
+                        p => p.Ignore ? ((p.Type.IsPointerToPrimitiveType() && p.Usage == ParameterUsage.InOut && p.HasDefaultValue) ? "ref param" + j++ : p.DefaultArgument.String)
+                                        : (p.Usage == ParameterUsage.InOut ? "ref " : string.Empty) + p.Name)));
+            if(needUnsafe)
+                WriteCloseBraceIndent();
         }
 
         private void GenerateEquals(Function method, Class @class)
@@ -2487,6 +2509,10 @@ namespace CppSharp.Generators.CSharp
 
             if (needsFixedThis && operatorParam == null)
                 WriteCloseBraceIndent();
+
+            var numFixedBlocks = @params.Count(param => param.HasFixedBlock);
+            for(var i=0; i<numFixedBlocks; ++i)
+                WriteCloseBraceIndent();
         }
 
         private int GetInstanceParamIndex(Method method)
@@ -2508,6 +2534,10 @@ namespace CppSharp.Generators.CSharp
             {
                 var param = paramInfo.Param;
                 if (!(param.IsOut || param.IsInOut)) continue;
+                if (param.IsInOut && param.Type.IsPointerToPrimitiveType()
+                    && ExtensionMethods.AllowedToHaveDefaultPtrVals.Any(
+                        primType => param.Type.IsPointerToPrimitiveType(primType)))
+                    continue;
 
                 var nativeVarName = paramInfo.Name;
 
@@ -2537,6 +2567,7 @@ namespace CppSharp.Generators.CSharp
             public string Name;
             public Parameter Param;
             public CSharpMarshalContext Context;
+            public bool HasFixedBlock;
         }
 
         public List<ParamMarshal> GenerateFunctionParamsMarshal(IEnumerable<Parameter> @params,
@@ -2566,7 +2597,7 @@ namespace CppSharp.Generators.CSharp
             }
 
             var argName = "arg" + paramIndex.ToString(CultureInfo.InvariantCulture);
-            var paramMarshal = new ParamMarshal { Name = argName, Param = param };
+            var paramMarshal = new ParamMarshal { Name = argName, Param = param, HasFixedBlock = false };
 
             if (param.IsOut || param.IsInOut)
             {
@@ -2590,16 +2621,26 @@ namespace CppSharp.Generators.CSharp
 
             paramMarshal.Context = ctx;
 
-            var marshal = new CSharpMarshalManagedToNativePrinter(ctx);
-            param.CSharpMarshalToNative(marshal);
+            if (param.IsInOut && param.Type.IsPointerToPrimitiveType()
+                && ExtensionMethods.AllowedToHaveDefaultPtrVals.Any(primType => param.Type.IsPointerToPrimitiveType(primType)))
+            {
+                WriteLine("fixed({0} {1} = &{2})", param.Type.CSharpType(TypePrinter), argName, param.Name);
+                paramMarshal.HasFixedBlock = true;
+                WriteStartBraceIndent();
+            }
+            else
+            {
+                var marshal = new CSharpMarshalManagedToNativePrinter(ctx);
+                param.CSharpMarshalToNative(marshal);
 
-            if (string.IsNullOrEmpty(marshal.Context.Return))
-                throw new Exception("Cannot marshal argument of function");
+                if (string.IsNullOrEmpty(marshal.Context.Return))
+                    throw new Exception("Cannot marshal argument of function");
 
-            if (!string.IsNullOrWhiteSpace(marshal.Context.SupportBefore))
-                Write(marshal.Context.SupportBefore);
+                if (!string.IsNullOrWhiteSpace(marshal.Context.SupportBefore))
+                    Write(marshal.Context.SupportBefore);
 
-            WriteLine("var {0} = {1};", argName, marshal.Context.Return);
+                WriteLine("var {0} = {1};", argName, marshal.Context.Return);
+            }
 
             return paramMarshal;
         }

--- a/src/Generator/Generators/ExtensionMethods.cs
+++ b/src/Generator/Generators/ExtensionMethods.cs
@@ -1,5 +1,7 @@
-﻿using System.Collections.Generic;
+﻿using System.Linq;
+using System.Collections.Generic;
 using CppSharp.AST;
+using CppSharp.AST.Extensions;
 using Interop = System.Runtime.InteropServices;
 
 namespace CppSharp.Generators
@@ -27,6 +29,12 @@ namespace CppSharp.Generators
             }
 
             return Interop.CallingConvention.Winapi;
+        }
+
+        public static bool IsParamPrimToRefTypeConvertible(Parameter param, bool checkParamUsage = true)
+        {
+            return (checkParamUsage ? param.IsInOut : true) && param.Type.IsPointerToPrimitiveType()
+                && AllowedToHaveDefaultPtrVals.Any(primType => param.Type.IsPointerToPrimitiveType(primType));
         }
     }
 }

--- a/src/Generator/Generators/ExtensionMethods.cs
+++ b/src/Generator/Generators/ExtensionMethods.cs
@@ -8,10 +8,6 @@ namespace CppSharp.Generators
 {
     public static class ExtensionMethods
     {
-        public static List<PrimitiveType> AllowedToHaveDefaultPtrVals = new List<PrimitiveType> {PrimitiveType.Bool, PrimitiveType.Double, PrimitiveType.Float,
-                                                                         PrimitiveType.Int, PrimitiveType.Long, PrimitiveType.LongLong, PrimitiveType.Short,
-                                                                         PrimitiveType.UInt, PrimitiveType.ULong, PrimitiveType.ULongLong, PrimitiveType.UShort};
-
         public static Interop.CallingConvention ToInteropCallConv(this CallingConvention convention)
         {
             switch (convention)
@@ -33,6 +29,9 @@ namespace CppSharp.Generators
 
         public static bool IsParamPrimToRefTypeConvertible(Parameter param, bool checkParamUsage = true)
         {
+            List<PrimitiveType> AllowedToHaveDefaultPtrVals = new List<PrimitiveType> {PrimitiveType.Bool, PrimitiveType.Double, PrimitiveType.Float,
+                                                                         PrimitiveType.Int, PrimitiveType.Long, PrimitiveType.LongLong, PrimitiveType.Short,
+                                                                         PrimitiveType.UInt, PrimitiveType.ULong, PrimitiveType.ULongLong, PrimitiveType.UShort};
             return (checkParamUsage ? param.IsInOut : true) && param.Type.IsPointerToPrimitiveType()
                 && AllowedToHaveDefaultPtrVals.Any(primType => param.Type.IsPointerToPrimitiveType(primType));
         }

--- a/src/Generator/Generators/ExtensionMethods.cs
+++ b/src/Generator/Generators/ExtensionMethods.cs
@@ -1,10 +1,15 @@
-﻿using CppSharp.AST;
+﻿using System.Collections.Generic;
+using CppSharp.AST;
 using Interop = System.Runtime.InteropServices;
 
 namespace CppSharp.Generators
 {
     public static class ExtensionMethods
     {
+        public static List<PrimitiveType> AllowedToHaveDefaultPtrVals = new List<PrimitiveType> {PrimitiveType.Bool, PrimitiveType.Double, PrimitiveType.Float,
+                                                                         PrimitiveType.Int, PrimitiveType.Long, PrimitiveType.LongLong, PrimitiveType.Short,
+                                                                         PrimitiveType.UInt, PrimitiveType.ULong, PrimitiveType.ULongLong, PrimitiveType.UShort};
+
         public static Interop.CallingConvention ToInteropCallConv(this CallingConvention convention)
         {
             switch (convention)

--- a/src/Generator/Passes/HandleDefaultParamValuesPass.cs
+++ b/src/Generator/Passes/HandleDefaultParamValuesPass.cs
@@ -54,9 +54,8 @@ namespace CppSharp.Passes
                     parameter.QualifiedType.Qualifiers);
                 if (defaultConstruct == null ||
                     (!Driver.Options.MarshalCharAsManagedChar &&
-                     parameter.Type.Desugar().IsPrimitiveType(PrimitiveType.UChar)) ||
-                    (parameter.Type.IsPointerToPrimitiveType() && ExtensionMethods.AllowedToHaveDefaultPtrVals.Any(
-                    primType => parameter.Type.Desugar().IsPointerToPrimitiveType(primType)) && parameter.Usage == ParameterUsage.InOut))
+                    parameter.Type.Desugar().IsPrimitiveType(PrimitiveType.UChar)) ||
+                    ExtensionMethods.IsParamPrimToRefTypeConvertible(parameter))
                 {
                     overloadIndices.Add(function.Parameters.IndexOf(parameter));
                     continue;
@@ -108,9 +107,7 @@ namespace CppSharp.Passes
                     return true;
                 }
 
-                if (parameter.Usage == ParameterUsage.InOut && parameter.Type.IsPointerToPrimitiveType() &&
-                    ExtensionMethods.AllowedToHaveDefaultPtrVals.Any(
-                        primType => desugared.IsPointerToPrimitiveType(primType)))
+                if (ExtensionMethods.IsParamPrimToRefTypeConvertible(parameter))
                     return false;
                     
 

--- a/src/Generator/Passes/HandleDefaultParamValuesPass.cs
+++ b/src/Generator/Passes/HandleDefaultParamValuesPass.cs
@@ -106,10 +106,8 @@ namespace CppSharp.Passes
                     parameter.DefaultArgument.String = "new global::System.IntPtr()";
                     return true;
                 }
-
                 if (ExtensionMethods.IsParamPrimToRefTypeConvertible(parameter))
                     return false;
-                    
 
                 Class @class;
                 if (desugared.GetFinalPointee().TryGetClass(out @class) && @class.IsValueType)
@@ -118,11 +116,9 @@ namespace CppSharp.Passes
                         new CSharpTypePrinter(Driver).VisitClassDecl(@class));
                     return true;
                 }
-                
                 parameter.DefaultArgument.String = "null";
                 return true;
             }
-            
             return false;
         }
 

--- a/src/Generator/Passes/MarshalPrimitivePointersAsRefTypePass.cs
+++ b/src/Generator/Passes/MarshalPrimitivePointersAsRefTypePass.cs
@@ -1,0 +1,25 @@
+﻿using System.Linq;
+using CppSharp.AST;
+using CppSharp.AST.Extensions;
+using CppSharp.Generators;
+
+namespace CppSharp.Passes
+{
+    public class MarshalPrimitivePointersAsRefTypePass : TranslationUnitPass
+    {
+        public MarshalPrimitivePointersAsRefTypePass()
+        {
+        }
+
+        public override bool VisitFunctionDecl(Function function)
+        {
+            foreach(var param in function.Parameters.Where(p => !p.IsOut && p.Type.IsPointerToPrimitiveType()
+                                          && ExtensionMethods.AllowedToHaveDefaultPtrVals.Any(defPtrType => p.Type.IsPointerToPrimitiveType(defPtrType))))
+            {
+                param.Usage = ParameterUsage.InOut;
+            }
+            return base.VisitFunctionDecl(function);
+        }
+
+    }
+}

--- a/src/Generator/Passes/MarshalPrimitivePointersAsRefTypePass.cs
+++ b/src/Generator/Passes/MarshalPrimitivePointersAsRefTypePass.cs
@@ -13,8 +13,7 @@ namespace CppSharp.Passes
 
         public override bool VisitFunctionDecl(Function function)
         {
-            foreach(var param in function.Parameters.Where(p => !p.IsOut && p.Type.IsPointerToPrimitiveType()
-                                          && ExtensionMethods.AllowedToHaveDefaultPtrVals.Any(defPtrType => p.Type.IsPointerToPrimitiveType(defPtrType))))
+            foreach(var param in function.Parameters.Where(p => !p.IsOut && ExtensionMethods.IsParamPrimToRefTypeConvertible(p, false)))
             {
                 param.Usage = ParameterUsage.InOut;
             }

--- a/tests/CSharpTemp/CSharpTemp.Tests.cs
+++ b/tests/CSharpTemp/CSharpTemp.Tests.cs
@@ -341,34 +341,31 @@ public class CSharpTempTests : GeneratorTestFixture
     }
 
     [Test]
-    public void TestMultiOverLoadNPtrToRefTypeGen()
+    public unsafe void TestMultiOverLoadNPtrToRefTypeGen()
     {
-        unsafe
-        {
-            var obj = new MultiOverLoadNPtrToRefTypeGenTest();
-            var p = obj.ReturnPrimTypePtr();
-            Assert.AreEqual(0, p[0]);
-            Assert.AreEqual(0, p[1]);
-            Assert.AreEqual(0, p[2]);
+        var obj = new MultiOverLoadNPtrToRefTypeGenTest();
+        var p = obj.ReturnPrimTypePtr();
+        Assert.AreEqual(0, p[0]);
+        Assert.AreEqual(0, p[1]);
+        Assert.AreEqual(0, p[2]);
 
-            obj.TakePrimTypePtr(ref *p);
-            Assert.AreEqual(100, p[0]);
-            Assert.AreEqual(200, p[1]);
-            Assert.AreEqual(300, p[2]);
+        obj.TakePrimTypePtr(ref *p);
+        Assert.AreEqual(100, p[0]);
+        Assert.AreEqual(200, p[1]);
+        Assert.AreEqual(300, p[2]);
             
-            int[] array = { 1, 2, 3 };
-            fixed (int* p1 = array)
-            {
-                obj.TakePrimTypePtr(ref *p1);
-                Assert.AreEqual(100, p1[0]);
-                Assert.AreEqual(200, p1[1]);
-                Assert.AreEqual(300, p1[2]);
-            }
-
-            Assert.AreEqual(100, array[0]);
-            Assert.AreEqual(200, array[1]);
-            Assert.AreEqual(300, array[2]);
+        int[] array = { 1, 2, 3 };
+        fixed (int* p1 = array)
+        {
+            obj.TakePrimTypePtr(ref *p1);
+            Assert.AreEqual(100, p1[0]);
+            Assert.AreEqual(200, p1[1]);
+            Assert.AreEqual(300, p1[2]);
         }
+
+        Assert.AreEqual(100, array[0]);
+        Assert.AreEqual(200, array[1]);
+        Assert.AreEqual(300, array[2]);
     }
 
 }

--- a/tests/CSharpTemp/CSharpTemp.Tests.cs
+++ b/tests/CSharpTemp/CSharpTemp.Tests.cs
@@ -340,4 +340,35 @@ public class CSharpTempTests : GeneratorTestFixture
         }
     }
 
+    [Test]
+    public void TestMultiOverLoadNPtrToRefTypeGen()
+    {
+        unsafe
+        {
+            var obj = new MultiOverLoadNPtrToRefTypeGenTest();
+            var p = obj.ReturnPrimTypePtr();
+            Assert.AreEqual(0, p[0]);
+            Assert.AreEqual(0, p[1]);
+            Assert.AreEqual(0, p[2]);
+
+            obj.TakePrimTypePtr(ref *p);
+            Assert.AreEqual(100, p[0]);
+            Assert.AreEqual(200, p[1]);
+            Assert.AreEqual(300, p[2]);
+            
+            int[] array = { 1, 2, 3 };
+            fixed (int* p1 = array)
+            {
+                obj.TakePrimTypePtr(ref *p1);
+                Assert.AreEqual(100, p1[0]);
+                Assert.AreEqual(200, p1[1]);
+                Assert.AreEqual(300, p1[2]);
+            }
+
+            Assert.AreEqual(100, array[0]);
+            Assert.AreEqual(200, array[1]);
+            Assert.AreEqual(300, array[2]);
+        }
+    }
+
 }

--- a/tests/CSharpTemp/CSharpTemp.cpp
+++ b/tests/CSharpTemp/CSharpTemp.cpp
@@ -663,3 +663,32 @@ void InheritsProtectedVirtualFromSecondaryBase::protectedVirtual()
 void freeFunctionWithUnsupportedDefaultArg(Foo foo)
 {
 }
+
+void MultiOverLoadNPtrToRefTypeGenTest::funcPrimPtrToRefType(int* pOne, char* pTwo, float* pThree)
+{
+}
+
+void MultiOverLoadNPtrToRefTypeGenTest::funcPrimPtrToRefTypeWithDefVal(int* pOne, char* pTwo, Foo* pThree, int* pFour)
+{
+}
+
+void MultiOverLoadNPtrToRefTypeGenTest::funcPrimPtrToRefTypeWithMultiOverload(int* pOne, char* pTwo, Foo* pThree, int* pFour, long* pFive)
+{
+}
+
+MultiOverLoadNPtrToRefTypeGenTest::MultiOverLoadNPtrToRefTypeGenTest()
+{
+	arr = new int[3]{0};
+}
+
+int* MultiOverLoadNPtrToRefTypeGenTest::ReturnPrimTypePtr()
+{
+	return arr;
+}
+
+void MultiOverLoadNPtrToRefTypeGenTest::TakePrimTypePtr(int* ptr)
+{
+	ptr[0] = 100;
+	ptr[1] = 200;
+	ptr[2] = 300;
+}

--- a/tests/CSharpTemp/CSharpTemp.h
+++ b/tests/CSharpTemp/CSharpTemp.h
@@ -593,3 +593,16 @@ protected:
 };
 
 void DLL_API freeFunctionWithUnsupportedDefaultArg(Foo foo = Foo());
+
+class DLL_API MultiOverLoadNPtrToRefTypeGenTest
+{
+	int * arr;
+public:
+	void funcPrimPtrToRefType(int *pOne, char* pTwo, float* pThree);
+	void funcPrimPtrToRefTypeWithDefVal(int* pOne, char* pTwo, Foo* pThree, int* pFour = 0);
+	void funcPrimPtrToRefTypeWithMultiOverload(int* pOne, char* pTwo, Foo* pThree, int* pFour = 0, long* pFive = 0);
+
+	MultiOverLoadNPtrToRefTypeGenTest();
+	int* ReturnPrimTypePtr();
+	void TakePrimTypePtr(int* ptr);
+};


### PR DESCRIPTION
The test is failing. One of the reasons may be that when we pass ref int to C# code it might not allow some thing like:
```C#
public void TakePrimTypePtr(ref int ptr)
{
int _ptr = ptr;
var arg0 = &_ptr;
Internal.TakePrimTypePtr_0(__Instance, arg0);
ptr = _ptr;
}
```
The arg0 might not be pointing to the same memory as ptr and hence the mismatch.
But again, I am just begineer in C# so I might be wrong.
@ddobrev @tritao Insights?