### PR TITLE
 Prevented duplication when a class and its base each have a field with the same name

### DIFF
--- a/src/AST/Field.cs
+++ b/src/AST/Field.cs
@@ -22,6 +22,12 @@ namespace CppSharp.AST
 
         public uint BitWidth { get; set; }
 
+        public string InternalName
+        {
+            get { return internalName ?? (internalName = OriginalName); }
+            set { internalName = value; }
+        }
+
         public Field()
         {
             Offset = 0;
@@ -49,5 +55,7 @@ namespace CppSharp.AST
         {
             return visitor.VisitFieldDecl(this);
         }
+
+        private string internalName;
     }
 }

--- a/src/Generator/Generators/CSharp/CSharpTextTemplate.cs
+++ b/src/Generator/Generators/CSharp/CSharpTextTemplate.cs
@@ -715,7 +715,7 @@ namespace CppSharp.Generators.CSharp
                 !(@class != null && @class.IsUnion)) || (@class != null && @class.TranslationUnit.IsSystemHeader))
                 return;
 
-            var safeIdentifier = Helpers.SafeIdentifier(field.OriginalName);
+            var safeIdentifier = Helpers.SafeIdentifier(field.InternalName);
 
             if(safeIdentifier.All(c => c.Equals('_')))
             {
@@ -863,7 +863,7 @@ namespace CppSharp.Generators.CSharp
                     string arrPtrIden = Helpers.SafeIdentifier("arrPtr");
                     WriteLine(string.Format("fixed ({0} {1} = {2}.{3})",
                         type.Replace("[]", "*"), arrPtrIden, Helpers.InstanceField,
-                        Helpers.SafeIdentifier(field.OriginalName)));
+                        Helpers.SafeIdentifier(field.InternalName)));
                     WriteStartBraceIndent();
                     ctx.ReturnVarName = arrPtrIden;
                 }
@@ -874,7 +874,7 @@ namespace CppSharp.Generators.CSharp
                         ? Helpers.InstanceField
                         : string.Format("((Internal*) {0})", Helpers.InstanceIdentifier),
                     @class.IsValueType ? "." : "->",
-                    Helpers.SafeIdentifier(field.OriginalName));
+                    Helpers.SafeIdentifier(field.InternalName));
                 }
                 param.Visit(marshal);
 
@@ -976,7 +976,7 @@ namespace CppSharp.Generators.CSharp
                             ? Helpers.InstanceField
                             : string.Format("((Internal*) {0})", Helpers.InstanceIdentifier),
                         @class.IsValueType ? "." : "->",
-                        Helpers.SafeIdentifier(field.OriginalName)),
+                        Helpers.SafeIdentifier(field.InternalName)),
                     ReturnType = decl.QualifiedType
                 };
 
@@ -989,7 +989,7 @@ namespace CppSharp.Generators.CSharp
                     string arrPtrIden = Helpers.SafeIdentifier("arrPtr");
                     WriteLine(string.Format("fixed ({0} {1} = {2}.{3})",
                         type.Replace("[]","*"), arrPtrIden, Helpers.InstanceField,
-                        Helpers.SafeIdentifier(field.OriginalName)));
+                        Helpers.SafeIdentifier(field.InternalName)));
                     WriteStartBraceIndent();
                     ctx.ReturnVarName = arrPtrIden;
                 }
@@ -1142,7 +1142,7 @@ namespace CppSharp.Generators.CSharp
                 {
                     GenerateClassField(prop.Field);
                     WriteLine("private bool {0};",
-                        GeneratedIdentifier(string.Format("{0}Initialised", prop.Field.OriginalName)));
+                        GeneratedIdentifier(string.Format("{0}Initialised", prop.Field.InternalName)));
                 }
 
                 GenerateDeclarationCommon(prop);

--- a/tests/CSharpTemp/CSharpTemp.Tests.cs
+++ b/tests/CSharpTemp/CSharpTemp.Tests.cs
@@ -102,6 +102,7 @@ public class CSharpTempTests : GeneratorTestFixture
             Assert.That(baz.TakesQux(baz), Is.EqualTo(20));
             Assert.That(baz.ReturnQux().FarAwayFunc, Is.EqualTo(20));
             baz.SetMethod(1);
+            Assert.AreEqual(5, baz.P);
         }
     }
 

--- a/tests/CSharpTemp/CSharpTemp.h
+++ b/tests/CSharpTemp/CSharpTemp.h
@@ -93,6 +93,8 @@ public:
 
     Baz();
 
+    int P;
+
     int takesQux(const Qux& qux);
     Qux returnQux();
     void setMethod(int value);
@@ -101,7 +103,7 @@ public:
     FunctionTypedef functionTypedef;
 };
 
-Baz::Baz() {}
+Baz::Baz() : P(5) {}
 
 struct QArrayData
 {


### PR DESCRIPTION
I had to implement more extensive support for expressions in order to better support constructor calls in default arguments. Constructor expressions have other expressions as parameters so I had to change the pass for default arguments to support recursively printing argument expressions when printing constructor expressions.