### PR TITLE
Fixed getter code for static Ref Type arrays.

### DIFF
--- a/src/Generator/Generators/CSharp/CSharpTextTemplate.cs
+++ b/src/Generator/Generators/CSharp/CSharpTextTemplate.cs
@@ -1018,15 +1018,19 @@ namespace CppSharp.Generators.CSharp
                 var location = string.Format("CppSharp.SymbolResolver.ResolveSymbol(\"{0}\", \"{1}\")",
                     libSymbol.Item1, libSymbol.Item2);
 
-                WriteLine("var {0} = ({1}*){2};", Generator.GeneratedIdentifier("ptr"),
-                    @var.Type, location);
+                var isRefTypeArray = decl.Type is ArrayType && @class != null && @class.IsRefType;
+                if (isRefTypeArray)
+                    WriteLine("var {0} = (byte*){1};", Generator.GeneratedIdentifier("ptr"), location);
+                else
+                    WriteLine("var {0} = ({1}*){2};", Generator.GeneratedIdentifier("ptr"),
+                        @var.Type, location);
 
                 TypePrinter.PopContext();
 
                 var ctx = new CSharpMarshalContext(Driver)
                 {
                     ArgName = decl.Name,
-                    ReturnVarName = "*" + Generator.GeneratedIdentifier("ptr"),
+                    ReturnVarName = (isRefTypeArray ? string.Empty : "*") + Generator.GeneratedIdentifier("ptr"),
                     ReturnType = new QualifiedType(var.Type)
                 };
 

--- a/tests/CSharpTemp/CSharpTemp.h
+++ b/tests/CSharpTemp/CSharpTemp.h
@@ -694,3 +694,9 @@ public:
     OverrideFromIndirectSecondaryBase();
     int property();
 };
+
+class DLL_API TestVariableWithFixedArrayType
+{
+public:
+	static Foo variableWithFixedArrayType[2];
+};


### PR DESCRIPTION
Just a query. Is it intended to not generate setter for a static variable? If so, why?
Also, how do I write test for it without a setter?