### PR TITLE
Fix for fn call when def argument is interface.

### DIFF
--- a/tests/CSharp/CSharp.cpp
+++ b/tests/CSharp/CSharp.cpp
@@ -143,6 +143,10 @@ Bar::Bar(Qux qux)
 {
 }
 
+Bar::Bar(Items item)
+{
+}
+
 int Bar::method()
 {
     return 2;
@@ -468,6 +472,10 @@ void MethodsWithDefaultValues::defaultImplicitCtorFoo(Quux arg)
 }
 
 void MethodsWithDefaultValues::defaultImplicitCtorEnum(Baz arg)
+{
+}
+
+void MethodsWithDefaultValues::defaultImplicitCtorEnumTwo(Bar arg)
 {
 }
 

--- a/tests/CSharp/CSharp.h
+++ b/tests/CSharp/CSharp.h
@@ -63,6 +63,7 @@ public:
     };
     Bar();
     Bar(Qux qux);
+    Bar(Items item);
     int method();
     const Foo& operator[](int i) const;
     Foo& operator[](int i);
@@ -364,6 +365,7 @@ public:
     // in this case the arg is a MaterializeTemporaryExpr, in the other not
     // I cannot see the difference but it's there so we need both tests
     void defaultImplicitCtorEnum(Baz arg = Bar::Item1);
+    void defaultImplicitCtorEnumTwo(Bar arg = Bar::Items::Item1);
     void defaultIntWithLongExpression(unsigned int i = DEFAULT_INT);
     void defaultRefTypeEnumImplicitCtor(const QColor &fillColor = Qt::white);
     void rotate4x4Matrix(float angle, float x, float y, float z = 0.0f);


### PR DESCRIPTION
This is my initial thought as I found that ```desugered``` is always the class required. I couldn't find a way to figure out if the parameter type is interface. So, probably it will change as currently it generates the cast for every argument whether required or not.