### PR TITLE
Added the ability to search the machine Path for ResolveSymbol

### DIFF
--- a/src/Runtime/SymbolResolver.cs
+++ b/src/Runtime/SymbolResolver.cs
@@ -57,9 +57,33 @@ namespace CppSharp
 
         public static IntPtr LoadImage (ref string name)
         {
+            var pathvalues = Environment.GetEnvironmentVariable("PATH");
+
             foreach (var format in formats)
             {
-                var attempted = System.IO.Path.Combine(Environment.CurrentDirectory, string.Format (format, name));
+                // Search the Current or specified directory for the library
+                string filename = string.Format(format, name);
+                string attempted = System.IO.Path.Combine(Environment.CurrentDirectory, filename);
+                if (!System.IO.File.Exists(attempted))
+                {
+                    // Search the Path directories for the library
+                    if (pathvalues == null)
+                        continue;
+
+                    foreach (var path in pathvalues.Split(System.IO.Path.PathSeparator))
+                    {
+                        var fullPath = System.IO.Path.Combine(path, filename);
+                        if (System.IO.File.Exists(fullPath))
+                        {
+                            attempted = fullPath;
+                            break;
+                        }
+
+                    }
+                }
+                if (!System.IO.File.Exists(attempted))
+                    continue;
+
                 var ptr = loadImage (attempted);
 
                 if (ptr == IntPtr.Zero)


### PR DESCRIPTION
This change allows ResolveSymbol to find a library by
1. the current directory or a specified directory
2. the directories within the system path

QtSharp uses ResolveSymbol when getting the QMetaObject of a class, however without this change it's unable to find the Qt dll's unless they're in the current directory. With this change as long as the Qt libs are in the system path ResolveSymbol is able to find them.