### PR TITLE
Use the qualified pointee type when printing/visiting pointer types.

### DIFF
--- a/src/Generator/Generators/CLI/CLIMarshal.cs
+++ b/src/Generator/Generators/CLI/CLIMarshal.cs
@@ -167,7 +167,7 @@ namespace CppSharp.Generators.CLI
                 return true;
             }
 
-            return pointer.Pointee.Visit(this, quals);
+            return pointer.QualifiedPointee.Visit(this);
         }
 
         private string MarshalStringToManaged(string varName, BuiltinType type)
@@ -553,22 +553,21 @@ namespace CppSharp.Generators.CLI
             {
                 if (Context.Function == null)
                     Context.Return.Write("&");
-                return pointee.Visit(this, quals);
+                return pointer.QualifiedPointee.Visit(this);
             }
 
             var finalPointee = pointer.GetFinalPointee();
             if (finalPointee.IsPrimitiveType())
             {
                 var cppTypePrinter = new CppTypePrinter();
-                var cppTypeName = pointer.Visit(cppTypePrinter,
-                    pointer.GetFinalQualifiedPointee().Qualifiers);
+                var cppTypeName = pointer.Visit(cppTypePrinter, quals);
 
                 Context.Return.Write("({0})", cppTypeName);
                 Context.Return.Write(Context.Parameter.Name);
                 return true;
             }
 
-            return pointer.Pointee.Visit(this, quals);
+            return pointer.QualifiedPointee.Visit(this);
         }
 
         public override bool VisitMemberPointerType(MemberPointerType member,

--- a/src/Generator/Generators/CLI/CLITypePrinter.cs
+++ b/src/Generator/Generators/CLI/CLITypePrinter.cs
@@ -161,12 +161,12 @@ namespace CppSharp.Generators.CLI
                 var param = TypePrinterContext.Parameter;
                 bool isRefParam = param != null && (param.IsOut || param.IsInOut);
                 if (isRefParam)
-                    return pointee.Visit(this, quals);
+                    return pointer.QualifiedPointee.Visit(this);
 
                 if (pointee.IsPrimitiveType(PrimitiveType.Void))
                     return "::System::IntPtr";
 
-                var result = pointee.Visit(this, quals);
+                var result = pointer.QualifiedPointee.Visit(this);
                 return !isRefParam && result == "::System::IntPtr" ? "void**" : result + "*";
             }
 
@@ -184,13 +184,13 @@ namespace CppSharp.Generators.CLI
                 return string.Format("{0}*", typeName);
             }
 
-            return pointer.Pointee.Visit(this, quals);
+            return pointer.QualifiedPointee.Visit(this);
         }
 
         public string VisitMemberPointerType(MemberPointerType member,
                                              TypeQualifiers quals)
         {
-            return member.Pointee.Visit(this);
+            return member.QualifiedPointee.Visit(this);
         }
 
         public string VisitBuiltinType(BuiltinType builtin, TypeQualifiers quals)

--- a/src/Generator/Generators/CSharp/CSharpMarshal.cs
+++ b/src/Generator/Generators/CSharp/CSharpMarshal.cs
@@ -186,7 +186,7 @@ namespace CppSharp.Generators.CSharp
                 return true;
             }
 
-            return pointer.Pointee.Visit(this, quals);
+            return pointer.QualifiedPointee.Visit(this);
         }
 
         private string MarshalStringToManaged(string varName, BuiltinType type)
@@ -600,7 +600,7 @@ namespace CppSharp.Generators.CSharp
                 return true;
             }
 
-            return pointer.Pointee.Visit(this, quals);
+            return pointer.QualifiedPointee.Visit(this);
         }
 
         private string MarshalStringToUnmanaged(string varName)

--- a/src/Generator/Generators/CSharp/CSharpTypePrinter.cs
+++ b/src/Generator/Generators/CSharp/CSharpTypePrinter.cs
@@ -311,7 +311,7 @@ namespace CppSharp.Generators.CSharp
                 var param = TypePrinterContext.Parameter;
                 bool isRefParam = param != null && (param.IsOut || param.IsInOut);
                 if (isManagedContext && isRefParam)
-                    return pointee.Visit(this, quals);
+                    return pointer.QualifiedPointee.Visit(this);
 
                 if (pointee.IsPrimitiveType(PrimitiveType.Void))
                     return IntPtrType;
@@ -322,7 +322,7 @@ namespace CppSharp.Generators.CSharp
                 // Do not allow strings inside primitive arrays case, else we'll get invalid types
                 // like string* for const char **.
                 allowStrings = isRefParam;
-                var result = pointee.Visit(this, quals);
+                var result = pointer.QualifiedPointee.Visit(this);
                 allowStrings = true;
 
                 return !isRefParam && result.Type == IntPtrType ? "void**" : result + "*";
@@ -335,9 +335,9 @@ namespace CppSharp.Generators.CSharp
                 var param = TypePrinterContext.Parameter;
                 if (isManagedContext && param != null && (param.IsOut || param.IsInOut)
                     && pointee == finalPointee)
-                    return pointee.Visit(this, quals);
+                    return pointer.QualifiedPointee.Visit(this);
 
-                return pointee.Visit(this, quals) + "*";
+                return pointer.QualifiedPointee.Visit(this) + "*";
             }
 
             Class @class;
@@ -348,7 +348,7 @@ namespace CppSharp.Generators.CSharp
                 return IntPtrType;
             }
 
-            return pointee.Visit(this, quals);
+            return pointer.QualifiedPointee.Visit(this);
         }
 
         public CSharpTypePrinterResult VisitMemberPointerType(MemberPointerType member,


### PR DESCRIPTION
@ddobrev please review and see if it makes sense to change all these instances to qualified visitation.

The tests seem to pass but I am not sure about making these changes.
