### PR TITLE
Fixed DownloadDeps.bat with Visual Studio

### DIFF
--- a/build/scripts/LLVM.lua
+++ b/build/scripts/LLVM.lua
@@ -62,7 +62,7 @@ function get_toolset_configuration_name()
 
     if not string.starts(vsver, "vs") then
       local out = outputof("cl")
-      local ver, arch = string.match(out, 'Version (%d+)%.%d+%.%d+%.?%d* for (%w+)')
+      local ver, arch = string.match(out, '(%d+).%d+.%d+.?%d*%s+%w*%s+(%w+)')
       vsver = get_vs_version(ver)
     end
 


### PR DESCRIPTION
See issue #718.

DownloadDeps.bat looked for a string in the form like "Version
<number>.<number>.<number>.<number> for <arch>" but this doesn't work
for installations of Visual Studio that are not English.

Changed the regex to make it user language agnostic.