### PR TITLE
Made sure CLI comment block text is commented out.

### DIFF
--- a/src/Generator/Generators/CLI/CLITemplate.cs
+++ b/src/Generator/Generators/CLI/CLITemplate.cs
@@ -124,7 +124,7 @@ namespace CppSharp.Generators.CLI
 
             PushBlock(BlockKind.BlockComment);
             WriteLine("/// <summary>");
-            WriteLine(comment);
+            WriteLine("/// {0}", comment);
             WriteLine("/// </summary>");
             PopBlock();
         }


### PR DESCRIPTION
Before, when generating CLI code, the comment text is not commented out. e.g.

Original.h
~~~
/**
 * This adds foo.
 *
 * @param foo  the first argument
 * @return  the result
 */
int FooAdd(int foo);
~~~

Generated.h
~~~
/// <summary>
This adds foo.
/// </summary>
static int FooAdd(int foo);
~~~

Now, the generated code will comment out the comment text. e.g.

Generated.h
~~~
/// <summary>
/// This adds foo.
/// </summary>
static int FooAdd(int foo);
~~~
