### PR TITLE
Allow indexer to set non-primitive types (that aren't by reference and aren't const)

### DIFF
--- a/src/Generator/Passes/CheckOperatorsOverloads.cs
+++ b/src/Generator/Passes/CheckOperatorsOverloads.cs
@@ -108,6 +108,13 @@ namespace CppSharp.Passes
                 if (!qualifiedPointee.Qualifiers.IsConst)
                     property.SetMethod = @operator;
             }
+            // We can set non-primitive types (even if they are not addresses)
+            // as long as they are not const.
+            else if (!returnType.IsPrimitiveType())
+            {
+                if (!@operator.ReturnType.Qualifiers.IsConst)
+                    property.SetMethod = @operator;
+            }
             
             // If we've a setter use the pointee as the type of the property.
             var pointerType = property.Type as PointerType;


### PR DESCRIPTION
Imagine this code:
~~~
struct MyIndexerStruct { /*...*/ };
struct Test { MyIndexerStruct operator[](int index); };
~~~

Even though the struct is not returned by reference, it is still valid to assign to the indexer, e.g.:
~~~
Test t;
t[0] = MyIndexerStruct(); // valid code
~~~

The current implementation does not generate a set method, thus preventing this valid case.  Of course, if the indexer has a const return or primitive type, it is not valid, e.g.:
~~~
struct Test
{
   const MyIndexerStruct operator[](int index); // can get but not set
   int operator[](int index); // can get but not set
}
~~~