### PR TITLE
Fixed ArgumentException 

### DIFF
--- a/src/Generator/Generators/CLI/CLIMarshal.cs
+++ b/src/Generator/Generators/CLI/CLIMarshal.cs
@@ -249,7 +249,7 @@ namespace CppSharp.Generators.CLI
             FunctionType function;
             if (decl.Type.IsPointerTo(out function))
             {
-                Context.Return.Write("safe_cast<{0}>(", typedef);
+                Context.Return.Write($"{Context.ReturnVarName} == nullptr ? nullptr : safe_cast<{typedef}>(");
                 Context.Return.Write("System::Runtime::InteropServices::Marshal::");
                 Context.Return.Write("GetDelegateForFunctionPointer(");
                 Context.Return.Write("IntPtr({0}), {1}::typeid))",Context.ReturnVarName,

--- a/src/Generator/Generators/CSharp/CSharpMarshal.cs
+++ b/src/Generator/Generators/CSharp/CSharpMarshal.cs
@@ -249,9 +249,9 @@ namespace CppSharp.Generators.CSharp
 
                 Context.SupportBefore.WriteLine("var {0} = {1};", ptrName,
                     Context.ReturnVarName);
-
-                Context.Return.Write("({1})Marshal.GetDelegateForFunctionPointer({0}, typeof({1}))",
-                    ptrName, typedef.ToString());
+                
+                var res = $"{ptrName} == IntPtr.Zero? null : ({typedef})Marshal.GetDelegateForFunctionPointer({ptrName}, typeof({typedef}))";
+                Context.Return.Write(res);
                 return true;
             }
 

--- a/tests/Common/Common.Tests.cs
+++ b/tests/Common/Common.Tests.cs
@@ -317,6 +317,9 @@ public class CommonTests : GeneratorTestFixture
 
         var cdecl = delegates.CDecl(i => i);
         Assert.AreEqual(1, cdecl);
+
+        var emptydelegeate = delegates.MarshalNullDelegate;
+        Assert.AreEqual(emptydelegeate, null);
     }
 
     [Test]

--- a/tests/Common/Common.cpp
+++ b/tests/Common/Common.cpp
@@ -421,6 +421,11 @@ void TestDelegates::MarshalDelegateInAnotherUnit(DelegateInAnotherUnit del)
 {
 }
 
+DelegateNullCheck TestDelegates::MarshalNullDelegate()
+{
+    return nullptr;
+}
+
 void DelegateNamespace::f2(void (*)())
 {
 }

--- a/tests/Common/Common.h
+++ b/tests/Common/Common.h
@@ -324,6 +324,7 @@ DLL_API int operator==(const Foo2& a, const Foo2& b)
 typedef int (*DelegateInGlobalNamespace)(int);
 typedef int (STDCALL *DelegateStdCall)(int);
 typedef int (CDECL *DelegateCDecl)(int n);
+typedef void(*DelegateNullCheck)(void);
 
 struct DLL_API TestDelegates
 {
@@ -344,6 +345,8 @@ struct DLL_API TestDelegates
     int (*MarshalAnonymousDelegate4())(int n);
 
     void MarshalDelegateInAnotherUnit(DelegateInAnotherUnit del);
+
+    DelegateNullCheck MarshalNullDelegate();
 
     DelegateInClass A;
     DelegateInGlobalNamespace B;


### PR DESCRIPTION
Which were due to nullptr arguments in Marshaling native.