### PR TITLE
Fix CheckStaticClass pass and add test.

### DIFF
--- a/src/Generator/Passes/CheckStaticClass.cs
+++ b/src/Generator/Passes/CheckStaticClass.cs
@@ -90,8 +90,8 @@ namespace CppSharp.Passes
             // If one exists, we assume it's a factory function and the class is
             // not meant to be static. It's a simple heuristic but it should be
             // good enough for the time being.
-            if (@class.Functions.Any(ReturnsClassInstance) ||
-                @class.Methods.Any(ReturnsClassInstance))
+            if (@class.Functions.Any(m => !m.IsOperator && ReturnsClassInstance(m)) ||
+                @class.Methods.Any(m => !m.IsOperator && ReturnsClassInstance(m)))
                 return false;
 
             // If the class is to be used as an opaque type, then it cannot be

--- a/tests/Common/Common.Tests.cs
+++ b/tests/Common/Common.Tests.cs
@@ -339,6 +339,9 @@ public class CommonTests : GeneratorTestFixture
     [Test]
     public void TestStaticClasses()
     {
+        Type staticClassType = typeof(TestStaticClass);
+        // Only static class can be both abstract and sealed
+        Assert.IsTrue(staticClassType.IsAbstract && staticClassType.IsSealed);
         Assert.That(TestStaticClass.Add(1, 2), Is.EqualTo(3));
         Assert.That(TestStaticClass.OneTwoThree, Is.EqualTo(123));
         Assert.That(TestStaticClassDerived.Foo, Is.EqualTo(0));

--- a/tests/Common/Common.cpp
+++ b/tests/Common/Common.cpp
@@ -668,3 +668,8 @@ void hasPointerParam(const Foo& foo)
 void sMallFollowedByCapital()
 {
 }
+
+TestStaticClass& TestStaticClass::operator=(const TestStaticClass& oth)
+{
+    return *this;
+}

--- a/tests/Common/Common.h
+++ b/tests/Common/Common.h
@@ -385,13 +385,14 @@ struct DLL_API TestStaticClass
 
     static int GetOneTwoThree();
 
-protected:
+    TestStaticClass& operator=(const TestStaticClass& oth);
+
+private:
 
     static int _Mult(int a, int b);
 
     static int GetFourFiveSix();
 
-private:
     TestStaticClass();
 };
 


### PR DESCRIPTION
Fixes #743  
  
I had to change protected members to private as in C# static class cannot have protected members...  
Also, the way to check static is taken from [here](http://stackoverflow.com/questions/1175888/determine-if-a-type-is-static).  
  
Although my NUnit 2.0 could not find any tests, so I I haven't run the test after edit, but most probably it should pass. Do I need NUnit 3.0 to run the tests? 