### PR TITLE
Fixing class specifiers in namespaces

### DIFF
--- a/src/Generator/Generators/CSharp/CSharpSources.cs
+++ b/src/Generator/Generators/CSharp/CSharpSources.cs
@@ -570,7 +570,7 @@ namespace CppSharp.Generators.CSharp
             // the proper fix is InternalsVisibleTo
             var keywords = new List<string>();
             
-            keywords.Add(@class.Access == AccessSpecifier.Protected ? "protected internal" : "public");
+            keywords.Add(@class.Access == AccessSpecifier.Internal ? "internal" : "public");
             keywords.Add("unsafe");
 
             if (@class.IsAbstract)


### PR DESCRIPTION
The specifiers for classes which own any attribute which isn't public have to be handled different in namespaces.
The old code generated not compileable code.