### PR TITLE
Fixed wrong recording of declaration order

### DIFF
--- a/src/CppParser/Parser.cpp
+++ b/src/CppParser/Parser.cpp
@@ -3547,7 +3547,7 @@ Declaration* Parser::WalkDeclaration(const clang::Decl* D,
 
         if (WalkRedecls)
             for (auto redecl : RD->redecls())
-                Class->Redeclarations.push_back(WalkDeclaration(redecl, CanBeDefinition, false));
+                Class->Redeclarations.push_back(WalkDeclaration(redecl, false, false));
 
         // We store a definition order index into the declarations.
         // This is needed because declarations are added to their contexts as

--- a/src/Generator/Passes/RenamePass.cs
+++ b/src/Generator/Passes/RenamePass.cs
@@ -218,8 +218,7 @@ namespace CppSharp.Passes
 
         public override bool VisitClassDecl(Class @class)
         {
-            if (!base.VisitClassDecl(@class)) 
-                return false;
+            base.VisitClassDecl(@class);
 
             foreach (var property in @class.Properties.OrderByDescending(p => p.Access))
                 VisitProperty(property);


### PR DESCRIPTION
This is a bugfix for critical bug. With the fix the generation of the parser bindings should be nearly correct.