### PR TITLE
[Fix issue #834] Stack mismatch when bool param passed from C++ to C#…

### DIFF
--- a/src/Generator/Generators/CSharp/CSharpSources.cs
+++ b/src/Generator/Generators/CSharp/CSharpSources.cs
@@ -2647,7 +2647,7 @@ namespace CppSharp.Generators.CSharp
                     && !string.IsNullOrWhiteSpace(param.Context.ArgumentPrefix))
                     name.Append(param.Context.ArgumentPrefix);
 
-                var paramString = param.Param.Type.IsPrimitiveType() && ((BuiltinType)param.Param.Type).Type == PrimitiveType.Bool? $"{param.Name} ? (sbyte)1: (sbyte)0" : param.Name;
+                var paramString = param.Param.Type.IsPrimitiveType() && (param.Param.Type as BuiltinType)?.Type == PrimitiveType.Bool? $"{param.Name} ? (sbyte)1: (sbyte)0" : param.Name;
                 name.Append(paramString);
                 names.Add(name.ToString());
             }

--- a/src/Generator/Generators/CSharp/CSharpSources.cs
+++ b/src/Generator/Generators/CSharp/CSharpSources.cs
@@ -537,7 +537,16 @@ namespace CppSharp.Generators.CSharp
 
             retType = function.ReturnType.CSharpType(TypePrinter);
 
-            var @params = function.GatherInternalParams(Context.ParserOptions.IsItaniumLikeAbi).Select(p =>
+            var paramsCopy = function
+              .GatherInternalParams(Context.ParserOptions.IsItaniumLikeAbi, false)
+              .Select(p => new Parameter(p)).ToArray();
+
+            foreach (var p in paramsCopy.Where(paramCopy => paramCopy.Type.IsPrimitiveType() && (paramCopy.Type as BuiltinType)?.Type == PrimitiveType.Bool))
+            {
+                p.QualifiedType = new QualifiedType(new BuiltinType(PrimitiveType.Char));
+            }
+
+            var @params = paramsCopy.Select(p =>
                 string.Format("{0} {1}", p.CSharpType(TypePrinter), p.Name)).ToList();
 
             TypePrinter.PopContext();
@@ -1548,9 +1557,10 @@ namespace CppSharp.Generators.CSharp
                     ReturnVarName = param.Name,
                     ParameterIndex = i
                 };
-
+                ctx.PushMarshalKind(param.Type.IsPrimitiveType() ? MarshalKind.NativeField : MarshalKind.Unknown);
                 var marshal = new CSharpMarshalNativeToManagedPrinter(ctx) { MarshalsParameter = true };
                 param.Visit(marshal);
+                ctx.PopMarshalKind();
 
                 if (!string.IsNullOrWhiteSpace(marshal.Context.Before))
                     Write(marshal.Context.Before);
@@ -2637,7 +2647,8 @@ namespace CppSharp.Generators.CSharp
                     && !string.IsNullOrWhiteSpace(param.Context.ArgumentPrefix))
                     name.Append(param.Context.ArgumentPrefix);
 
-                name.Append(param.Name);
+                var paramString = param.Param.Type.IsPrimitiveType() && ((BuiltinType)param.Param.Type).Type == PrimitiveType.Bool? $"{param.Name} ? (sbyte)1: (sbyte)0" : param.Name;
+                name.Append(paramString);
                 names.Add(name.ToString());
             }
 

--- a/src/Generator/Generators/CSharp/CSharpTypePrinter.cs
+++ b/src/Generator/Generators/CSharp/CSharpTypePrinter.cs
@@ -613,7 +613,6 @@ namespace CppSharp.Generators.CSharp
             @params = @params.Where(
                 p => ContextKind == TypePrinterContextKind.Native ||
                     (p.Kind != ParameterKind.IndirectReturnType && !p.Ignore));
-
             return base.VisitParameters(@params, hasNames);
         }
 
@@ -630,9 +629,14 @@ namespace CppSharp.Generators.CSharp
 
         public override TypePrinterResult VisitDelegate(FunctionType function)
         {
+            var paramsCopy = function.Parameters.Select(p => new Parameter(p)).ToArray();
+            foreach (var p in paramsCopy.Where(paramCopy => paramCopy.Type.IsPrimitiveType() && ((BuiltinType)paramCopy.Type).Type == PrimitiveType.Bool))
+            {
+              p.QualifiedType = new QualifiedType(new BuiltinType(PrimitiveType.Char));
+            }
             return string.Format("delegate {0} {{0}}({1})",
                 function.ReturnType.Visit(this),
-                VisitParameters(function.Parameters, hasNames: true));
+                VisitParameters(paramsCopy, hasNames: true));
         }
 
         public override string ToString(Type type)


### PR DESCRIPTION
…, cast to sbyte instead. keeping the interface