### PR TITLE
[Fix issue #831] Ignore from not implemented constructors, but still …

### DIFF
--- a/src/Generator/Generators/CSharp/CSharpSources.cs
+++ b/src/Generator/Generators/CSharp/CSharpSources.cs
@@ -440,10 +440,22 @@ namespace CppSharp.Generators.CSharp
                 var functions = GatherClassInternalFunctions(@class);
 
                 foreach (var function in functions)
-                    GenerateInternalFunction(function);
+                {
+                    // Ignore auto generated DllImports of not Implemened Ctors (and functions at all)
+                    if (Options.IgnoreNotImplementedCtors)
+                    {
+                        if (Context.Symbols.Symbols.ContainsKey(function.Mangled))
+                            GenerateInternalFunction(function);
+                    }
+                    else
+                    {
+                        GenerateInternalFunction(function);
+                    }
+                }
+
             }
 
-            TypePrinter.PopContext();
+      TypePrinter.PopContext();
 
             WriteCloseBraceIndent();
             PopBlock(NewLineKind.BeforeNextBlock);
@@ -1806,7 +1818,17 @@ namespace CppSharp.Generators.CSharp
                 if (ASTUtils.CheckIgnoreMethod(ctor, Options))
                     continue;
 
-                GenerateMethod(ctor, @class);
+                // Ignore auto generate body methods of not implemented c'tors. excpet default c'tors
+                if (Options.IgnoreNotImplementedCtors)
+                {
+                    if (ctor.Access == AccessSpecifier.Public || Context.Symbols.Symbols.ContainsKey(ctor.Mangled))
+                        GenerateMethod(ctor, @class);
+                }
+                else
+                {
+                    GenerateMethod(ctor, @class);
+                }
+
             }
 
             if (@class.IsRefType)
@@ -1965,7 +1987,18 @@ namespace CppSharp.Generators.CSharp
                 PopBlock(NewLineKind.BeforeNextBlock);
             }
 
-            GenerateNativeConstructorByValue(@class, ctorCall);
+            // Ignore auto generate of not implemented native copy c'tors.
+            if (Options.IgnoreNotImplementedCtors)
+            {
+                var ctorMethod = @class.FindMethod(ctorCall);
+                if (ctorMethod != null && Context.Symbols.Symbols.ContainsKey(ctorMethod.Mangled))
+                    GenerateNativeConstructorByValue(@class, ctorCall);
+            }
+            else
+            {
+                GenerateNativeConstructorByValue(@class, ctorCall);
+            }
+
 
             PushBlock(BlockKind.Method);
             WriteLine("{0} {1}(void* native, bool skipVTables = false){2}",
@@ -2260,7 +2293,16 @@ namespace CppSharp.Generators.CSharp
             {
                 if (method.IsConstructor)
                 {
-                    GenerateInternalFunctionCall(method);
+                    // Ignore struct c'tors that not exist in the libs.
+                    if (Options.IgnoreNotImplementedCtors)
+                    {
+                        if (Context.Symbols.Symbols.ContainsKey(method.Mangled))
+                            GenerateInternalFunctionCall(method);
+                    }
+                    else
+                    {
+                        GenerateInternalFunctionCall(method);
+                    }
                 }
                 else if (method.IsOperator)
                 {
@@ -2514,7 +2556,18 @@ namespace CppSharp.Generators.CSharp
             if (method.IsCopyConstructor)
             {
                 if (@class.HasNonTrivialCopyConstructor)
-                    GenerateInternalFunctionCall(method);
+                {
+                    if (Options.IgnoreNotImplementedCtors)
+                    {
+                        // at wanted public c'tors we don't want to call to doesn't exist native entry point.
+                        if (Context.Symbols.Symbols.ContainsKey(method.Mangled))
+                            GenerateInternalFunctionCall(method);
+                    }
+                    else
+                    {
+                        GenerateInternalFunctionCall(method);
+                    }
+                }
                 else
                 {
                     TypePrinter.PushContext(TypePrinterContextKind.Native);
@@ -2527,8 +2580,19 @@ namespace CppSharp.Generators.CSharp
             else
             {
                 if (!method.IsDefaultConstructor || @class.HasNonTrivialDefaultConstructor)
-                    GenerateInternalFunctionCall(method);
-            }
+                {
+                    if (Options.IgnoreNotImplementedCtors)
+                    {
+                        // at wanted public c'tors we don't want to call to doesn't exist native entry point.
+                        if (Context.Symbols.Symbols.ContainsKey(method.Mangled))
+                           GenerateInternalFunctionCall(method);
+                    }
+                    else
+                    {
+                        GenerateInternalFunctionCall(method);
+                    }
+                }
+      }
 
             GenerateVTableClassSetupCall(@class);
         }

--- a/src/Generator/Options.cs
+++ b/src/Generator/Options.cs
@@ -83,6 +83,7 @@ namespace CppSharp
         public CompilationOptions Compilation = new CompilationOptions();
 
         #region Generator options
+        public bool IgnoreNotImplementedCtors = false;
 
         public GeneratorKind GeneratorKind;
 


### PR DESCRIPTION
…keep on defaults. Using new flag in Driver Options called IgnoreNotImplementedCtors