### PR TITLE
Removed the macro in C++ AST for std::string because we can marshal it

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ Generates the glue binding code from a syntax tree of the native code.
  * Multiple runtimes: .NET and Mono
  * C++ virtual methods overriding from managed code
  * C++ multiple inheritance by translating to C# interfaces
- * C++ standard library types (work-in-progress)
+ * C++ std::string
  * C++ default parameter values
  * C/C++ semantic comments (Doxygen) to C# comments
  * Extensible bindings semantics via user passes and type mapping 

--- a/src/CppParser/AST.cpp
+++ b/src/CppParser/AST.cpp
@@ -187,7 +187,6 @@ DependentNameType::DependentNameType() : Type(TypeKind::DependentName) {}
 
 DependentNameType::~DependentNameType() {}
 
-DEF_STRING(DependentNameType, Identifier)
 
 PackExpansionType::PackExpansionType() : Type(TypeKind::PackExpansion) {}
 
@@ -215,15 +214,13 @@ LayoutField::LayoutField() : offset(0), fieldPtr(0) {}
 
 LayoutField::LayoutField(const LayoutField & other)
     : offset(other.offset)
-    , Name(other.Name)
+    , name(other.name)
     , qualifiedType(other.qualifiedType)
     , fieldPtr(other.fieldPtr)
 {
 }
 
 LayoutField::~LayoutField() {}
-
-DEF_STRING(LayoutField, Name)
 
 LayoutBase::LayoutBase() : offset(0), _class(0) {}
 
@@ -264,9 +261,9 @@ Declaration::Declaration(const Declaration& rhs)
     , location(rhs.location.ID)
     , lineNumberStart(rhs.lineNumberStart)
     , lineNumberEnd(rhs.lineNumberEnd)
-    , Name(rhs.Name)
+    , name(rhs.name)
     , comment(rhs.comment)
-    , DebugText(rhs.DebugText)
+    , debugText(rhs.debugText)
     , isIncomplete(rhs.isIncomplete)
     , isDependent(rhs.isDependent)
     , isImplicit(rhs.isImplicit)
@@ -281,9 +278,6 @@ Declaration::~Declaration()
 {
 }
 
-DEF_STRING(Declaration, Name)
-DEF_STRING(Declaration, USR)
-DEF_STRING(Declaration, DebugText)
 DEF_VECTOR(Declaration, PreprocessedEntity*, PreprocessedEntities)
 DEF_VECTOR(Declaration, Declaration*, Redeclarations)
 
@@ -325,7 +319,7 @@ DeclarationContext::FindNamespace(const std::vector<std::string>& Namespaces)
         auto childNamespace = std::find_if(currentNamespace->Namespaces.begin(),
             currentNamespace->Namespaces.end(),
             [&](CppSharp::CppParser::AST::Namespace* ns) {
-                return ns->Name == _namespace;
+                return ns->name == _namespace;
         });
 
         if (childNamespace == currentNamespace->Namespaces.end())
@@ -344,7 +338,7 @@ Namespace* DeclarationContext::FindCreateNamespace(const std::string& Name)
     if (!_namespace)
     {
         _namespace = new Namespace();
-        _namespace->Name = Name;
+        _namespace->name = Name;
         _namespace->_namespace = this;
 
         Namespaces.push_back(_namespace);
@@ -362,7 +356,7 @@ Class* DeclarationContext::FindClass(const std::string& Name, bool IsComplete)
     if (entries.size() == 1)
     {
         auto _class = std::find_if(Classes.begin(), Classes.end(),
-            [&](Class* klass) { return klass->Name == Name &&
+            [&](Class* klass) { return klass->name == Name &&
                 (!klass->isIncomplete || !IsComplete); });
 
         return _class != Classes.end() ? *_class : nullptr;
@@ -383,7 +377,7 @@ Class* DeclarationContext::FindClass(const std::string& Name, bool IsComplete)
 Class* DeclarationContext::CreateClass(std::string Name, bool IsComplete)
 {
     auto _class = new Class();
-    _class->Name = Name;
+    _class->name = Name;
     _class->_namespace = this;
     _class->isIncomplete = !IsComplete;
 
@@ -427,7 +421,7 @@ Enumeration* DeclarationContext::FindEnum(const std::string& Name, bool Create)
     if (entries.size() == 1)
     {
         auto foundEnum = std::find_if(Enums.begin(), Enums.end(),
-            [&](Enumeration* _enum) { return _enum->Name == Name; });
+            [&](Enumeration* _enum) { return _enum->name == Name; });
 
         if (foundEnum != Enums.end())
             return *foundEnum;
@@ -436,7 +430,7 @@ Enumeration* DeclarationContext::FindEnum(const std::string& Name, bool Create)
             return nullptr;
 
         auto _enum = new Enumeration();
-        _enum->Name = Name;
+        _enum->name = Name;
         _enum->_namespace = this;
         Enums.push_back(_enum);
         return _enum;
@@ -495,7 +489,7 @@ Function* DeclarationContext::FindFunction(const std::string& USR)
 TypedefDecl* DeclarationContext::FindTypedef(const std::string& Name, bool Create)
 {
     auto foundTypedef = std::find_if(Typedefs.begin(), Typedefs.end(),
-            [&](TypedefDecl* tdef) { return tdef->Name == Name; });
+            [&](TypedefDecl* tdef) { return tdef->name == Name; });
 
     if (foundTypedef != Typedefs.end())
         return *foundTypedef;
@@ -504,7 +498,7 @@ TypedefDecl* DeclarationContext::FindTypedef(const std::string& Name, bool Creat
         return nullptr;
      
     auto tdef = new TypedefDecl();
-    tdef->Name = Name;
+    tdef->name = Name;
     tdef->_namespace = this;
 
     return tdef;
@@ -513,7 +507,7 @@ TypedefDecl* DeclarationContext::FindTypedef(const std::string& Name, bool Creat
 TypeAlias* DeclarationContext::FindTypeAlias(const std::string& Name, bool Create)
 {
     auto foundTypeAlias = std::find_if(TypeAliases.begin(), TypeAliases.end(),
-        [&](TypeAlias* talias) { return talias->Name == Name; });
+        [&](TypeAlias* talias) { return talias->name == Name; });
 
     if (foundTypeAlias != TypeAliases.end())
         return *foundTypeAlias;
@@ -522,7 +516,7 @@ TypeAlias* DeclarationContext::FindTypeAlias(const std::string& Name, bool Creat
         return nullptr;
 
     auto talias = new TypeAlias();
-    talias->Name = Name;
+    talias->name = Name;
     talias->_namespace = this;
 
     return talias;
@@ -566,15 +560,14 @@ Friend::Friend() : CppSharp::CppParser::AST::Declaration(DeclarationKind::Friend
 
 Friend::~Friend() {}
 
-DEF_STRING(Statement, String)
 
-Statement::Statement(const std::string& str, StatementClass stmtClass, Declaration* decl) : String(str), _class(stmtClass), decl(decl) {}
+Statement::Statement(const std::string& str, StatementClass stmtClass, Declaration* decl) : string(str), _class(stmtClass), decl(decl) {}
 
 Expression::Expression(const std::string& str, StatementClass stmtClass, Declaration* decl)
     : Statement(str, stmtClass, decl) {}
 
 BinaryOperator::BinaryOperator(const std::string& str, Expression* lhs, Expression* rhs, const std::string& opcodeStr)
-    : Expression(str, StatementClass::BinaryOperator), LHS(lhs), RHS(rhs), OpcodeStr(opcodeStr) {}
+    : Expression(str, StatementClass::BinaryOperator), LHS(lhs), RHS(rhs), opcodeStr(opcodeStr) {}
 
 BinaryOperator::~BinaryOperator()
 {
@@ -582,7 +575,6 @@ BinaryOperator::~BinaryOperator()
     delete RHS;
 }
 
-DEF_STRING(BinaryOperator, OpcodeStr)
 
 CallExpr::CallExpr(const std::string& str, Declaration* decl)
     : Expression(str, StatementClass::CallExprClass, decl) {}
@@ -649,10 +641,6 @@ Function::Function()
 }
 
 Function::~Function() {}
-
-DEF_STRING(Function, Mangled)
-DEF_STRING(Function, Signature)
-DEF_STRING(Function, Body)
 DEF_VECTOR(Function, Parameter*, Parameters)
 
 Method::Method() 
@@ -684,16 +672,14 @@ DEF_VECTOR(Enumeration, Enumeration::Item*, Items)
 Enumeration::Item::Item() : Declaration(DeclarationKind::EnumerationItem) {}
 
 Enumeration::Item::Item(const Item& rhs) : Declaration(rhs),
-    Expression(rhs.Expression), value(rhs.value) {}
+    expression(rhs.expression), value(rhs.value) {}
 
 Enumeration::Item::~Item() {}
-
-DEF_STRING(Enumeration::Item, Expression)
 
 Enumeration::Item* Enumeration::FindItemByName(const std::string& Name)
 {
     auto foundEnumItem = std::find_if(Items.begin(), Items.end(),
-        [&](Item* _item) { return _item->Name == Name; });
+        [&](Item* _item) { return _item->name == Name; });
     if (foundEnumItem != Items.end())
         return *foundEnumItem;
     return nullptr;
@@ -702,8 +688,6 @@ Enumeration::Item* Enumeration::FindItemByName(const std::string& Name)
 Variable::Variable() : Declaration(DeclarationKind::Variable) {}
 
 Variable::~Variable() {}
-
-DEF_STRING(Variable, Mangled)
 
 BaseClassSpecifier::BaseClassSpecifier() : type(0), offset(0) {}
 
@@ -872,21 +856,13 @@ MacroDefinition::MacroDefinition()
 
 MacroDefinition::~MacroDefinition() {}
 
-DEF_STRING(MacroDefinition, Name)
-DEF_STRING(MacroDefinition, Expression)
-
 MacroExpansion::MacroExpansion() : definition(0) { kind = DeclarationKind::MacroExpansion; }
 
 MacroExpansion::~MacroExpansion() {}
 
-DEF_STRING(MacroExpansion, Name)
-DEF_STRING(MacroExpansion, Text)
-
 TranslationUnit::TranslationUnit() { kind = DeclarationKind::TranslationUnit; }
 
 TranslationUnit::~TranslationUnit() {}
-
-DEF_STRING(TranslationUnit, FileName)
 DEF_VECTOR(TranslationUnit, MacroDefinition*, Macros)
 
 NativeLibrary::NativeLibrary()
@@ -899,7 +875,6 @@ NativeLibrary::~NativeLibrary()
 }
 
 // NativeLibrary
-DEF_STRING(NativeLibrary, FileName)
 DEF_VECTOR_STRING(NativeLibrary, Symbols)
 DEF_VECTOR_STRING(NativeLibrary, Dependencies)
 
@@ -935,14 +910,14 @@ TranslationUnit* ASTContext::FindOrCreateModule(std::string File)
 
     auto existingUnit = std::find_if(TranslationUnits.begin(),
         TranslationUnits.end(), [&](TranslationUnit* unit) {
-            return unit && unit->FileName == normalizedFile;
+            return unit && unit->fileName == normalizedFile;
     });
 
     if (existingUnit != TranslationUnits.end())
         return *existingUnit;
 
     auto unit = new TranslationUnit();
-    unit->FileName = normalizedFile;
+    unit->fileName = normalizedFile;
     TranslationUnits.push_back(unit);
 
     return unit;
@@ -950,9 +925,6 @@ TranslationUnit* ASTContext::FindOrCreateModule(std::string File)
 
 // Comments
 Comment::Comment(CommentKind kind) : kind(kind) {}
-
-DEF_STRING(RawComment, Text)
-DEF_STRING(RawComment, BriefText)
 
 RawComment::RawComment() : fullCommentBlock(0) {}
 
@@ -1004,9 +976,8 @@ BlockContentComment::BlockContentComment(CommentKind Kind) : Comment(Kind) {}
 
 BlockCommandComment::Argument::Argument() {}
 
-BlockCommandComment::Argument::Argument(const Argument& rhs) : Text(rhs.Text) {}
+BlockCommandComment::Argument::Argument(const Argument& rhs) : text(rhs.text) {}
 
-DEF_STRING(BlockCommandComment::Argument, Text)
 
 BlockCommandComment::BlockCommandComment() : BlockContentComment(CommentKind::BlockCommandComment), commandId(0), paragraphComment(0) {}
 
@@ -1036,8 +1007,6 @@ VerbatimBlockComment::~VerbatimBlockComment()
 DEF_VECTOR(VerbatimBlockComment, VerbatimBlockLineComment*, Lines)
 
 VerbatimLineComment::VerbatimLineComment() : BlockCommandComment(CommentKind::VerbatimLineComment) {}
-
-DEF_STRING(VerbatimLineComment, Text)
 
 ParagraphComment::ParagraphComment() : BlockContentComment(CommentKind::ParagraphComment), isWhitespace(false) {}
 
@@ -1078,21 +1047,13 @@ HTMLTagComment::HTMLTagComment(CommentKind Kind) : InlineContentComment(Kind) {}
 
 HTMLStartTagComment::Attribute::Attribute() {}
 
-HTMLStartTagComment::Attribute::Attribute(const Attribute& rhs) : Name(rhs.Name), Value(rhs.Value) {}
-
-DEF_STRING(HTMLStartTagComment::Attribute, Name)
-
-DEF_STRING(HTMLStartTagComment::Attribute, Value)
+HTMLStartTagComment::Attribute::Attribute(const Attribute& rhs) : name(rhs.name), value(rhs.value) {}
 
 HTMLStartTagComment::HTMLStartTagComment() : HTMLTagComment(CommentKind::HTMLStartTagComment) {}
 
 DEF_VECTOR(HTMLStartTagComment, HTMLStartTagComment::Attribute, Attributes)
 
-DEF_STRING(HTMLStartTagComment, TagName)
-
 HTMLEndTagComment::HTMLEndTagComment() : HTMLTagComment(CommentKind::HTMLEndTagComment) {}
-
-DEF_STRING(HTMLEndTagComment, TagName)
 
 InlineContentComment::InlineContentComment() : Comment(CommentKind::InlineContentComment), hasTrailingNewline(false) {}
 
@@ -1100,13 +1061,9 @@ InlineContentComment::InlineContentComment(CommentKind Kind) : Comment(Kind), ha
 
 TextComment::TextComment() : InlineContentComment(CommentKind::TextComment) {}
 
-DEF_STRING(TextComment, Text)
-
 InlineCommandComment::Argument::Argument() {}
 
-InlineCommandComment::Argument::Argument(const Argument& rhs) : Text(rhs.Text) {}
-
-DEF_STRING(InlineCommandComment::Argument, Text)
+InlineCommandComment::Argument::Argument(const Argument& rhs) : text(rhs.text) {}
 
 InlineCommandComment::InlineCommandComment()
     : InlineContentComment(CommentKind::InlineCommandComment), commandId(0), commentRenderKind(RenderNormal) {}
@@ -1114,7 +1071,5 @@ InlineCommandComment::InlineCommandComment()
 DEF_VECTOR(InlineCommandComment, InlineCommandComment::Argument, Arguments)
 
 VerbatimBlockLineComment::VerbatimBlockLineComment() : Comment(CommentKind::VerbatimBlockLineComment) {}
-
-DEF_STRING(VerbatimBlockLineComment, Text)
 
 } } }

--- a/src/CppParser/AST.h
+++ b/src/CppParser/AST.h
@@ -260,7 +260,7 @@ public:
     DECLARE_TYPE_KIND(DependentName)
     ~DependentNameType();
     QualifiedType qualifier;
-    STRING(Identifier)
+    std::string identifier;
 };
 
 class CS_API PackExpansionType : public Type
@@ -379,7 +379,7 @@ public:
     LayoutField(const LayoutField& other);
     ~LayoutField();
     unsigned offset;
-    STRING(Name)
+    std::string name;
     QualifiedType qualifiedType;
     void* fieldPtr;
 };
@@ -476,9 +476,9 @@ public:
     SourceLocation location;
     int lineNumberStart;
     int lineNumberEnd;
-    STRING(Name)
-    STRING(USR)
-    STRING(DebugText)
+    std::string name;
+    std::string USR;
+    std::string debugText;
     bool isIncomplete;
     bool isDependent;
     bool isImplicit;
@@ -599,7 +599,7 @@ public:
     Statement(const std::string& str, StatementClass Class = StatementClass::Any, Declaration* decl = 0);
     StatementClass _class;
     Declaration* decl;
-    STRING(String)
+    std::string string;
 };
 
 class CS_API Expression : public Statement
@@ -615,7 +615,7 @@ public:
     ~BinaryOperator();
     Expression* LHS;
     Expression* RHS;
-    STRING(OpcodeStr)
+    std::string opcodeStr;
 };
 
 class CS_API CallExpr : public Expression
@@ -732,9 +732,9 @@ public:
     bool isDeleted;
     FriendKind friendKind;
     CXXOperatorKind operatorKind;
-    STRING(Mangled)
-    STRING(Signature)
-    STRING(Body)
+    std::string mangled;
+    std::string signature;
+    std::string body;
     CallingConvention callingConvention;
     VECTOR(Parameter*, Parameters)
     FunctionTemplateSpecialization* specializationInfo;
@@ -785,8 +785,7 @@ public:
         DECLARE_DECL_KIND(Item, EnumerationItem)
         Item(const Item&);
         ~Item();
-
-        STRING(Expression)
+        std::string expression;
         uint64_t value;
     };
 
@@ -810,7 +809,7 @@ class CS_API Variable : public Declaration
 public:
     DECLARE_DECL_KIND(Variable, Variable)
     ~Variable();
-    STRING(Mangled)
+    std::string mangled;
     QualifiedType qualifiedType;
 };
 
@@ -1063,8 +1062,8 @@ class CS_API MacroDefinition : public PreprocessedEntity
 public:
     MacroDefinition();
     ~MacroDefinition();
-    STRING(Name)
-    STRING(Expression)
+    std::string name;
+    std::string expression;
     int lineNumberStart;
     int lineNumberEnd;
 };
@@ -1074,8 +1073,8 @@ class CS_API MacroExpansion : public PreprocessedEntity
 public:
     MacroExpansion();
     ~MacroExpansion();
-    STRING(Name)
-    STRING(Text)
+    std::string name;
+    std::string text;
     MacroDefinition* definition;
 };
 
@@ -1084,7 +1083,7 @@ class CS_API TranslationUnit : public Namespace
 public:
     TranslationUnit();
     ~TranslationUnit();
-    STRING(FileName)
+    std::string fileName;
     bool isSystemHeader;
     VECTOR(MacroDefinition*, Macros)
 };
@@ -1101,7 +1100,7 @@ class CS_API NativeLibrary
 public:
     NativeLibrary();
     ~NativeLibrary();
-    STRING(FileName)
+    std::string fileName;
     ArchType archType;
     VECTOR_STRING(Symbols)
     VECTOR_STRING(Dependencies)
@@ -1186,7 +1185,7 @@ public:
     public:
         Argument();
         Argument(const Argument&);
-        STRING(Text)
+        std::string text;
     };
     BlockCommandComment();
     BlockCommandComment(CommentKind Kind);
@@ -1221,7 +1220,7 @@ class CS_API VerbatimBlockLineComment : public Comment
 {
 public:
     VerbatimBlockLineComment();
-    STRING(Text)
+    std::string text;
 };
 
 class CS_API VerbatimBlockComment : public BlockCommandComment
@@ -1236,7 +1235,7 @@ class CS_API VerbatimLineComment : public BlockCommandComment
 {
 public:
     VerbatimLineComment();
-    STRING(Text)
+    std::string text;
 };
 
 class CS_API InlineCommandComment : public InlineContentComment
@@ -1254,7 +1253,7 @@ public:
     public:
         Argument();
         Argument(const Argument&);
-        STRING(Text)
+        std::string text;
     };
     InlineCommandComment();
     unsigned commandId;
@@ -1277,11 +1276,11 @@ public:
     public:
         Attribute();
         Attribute(const Attribute&);
-        STRING(Name)
-        STRING(Value)
+        std::string name;
+        std::string value;
     };
     HTMLStartTagComment();
-    STRING(TagName)
+    std::string tagName;
     VECTOR(Attribute, Attributes)
 };
 
@@ -1289,14 +1288,14 @@ class CS_API HTMLEndTagComment : public HTMLTagComment
 {
 public:
     HTMLEndTagComment();
-    STRING(TagName)
+    std::string tagName;
 };
 
 class CS_API TextComment : public InlineContentComment
 {
 public:
     TextComment();
-    STRING(Text)
+    std::string text;
 };
 
 enum class RawCommentKind
@@ -1317,8 +1316,8 @@ public:
     RawComment();
     ~RawComment();
     RawCommentKind kind;
-    STRING(Text)
-    STRING(BriefText)
+    std::string text;
+    std::string briefText;
     FullComment* fullCommentBlock;
 };
 

--- a/src/CppParser/Bindings/CLI/AST.cpp
+++ b/src/CppParser/Bindings/CLI/AST.cpp
@@ -410,6 +410,28 @@ void CppSharp::Parser::AST::FunctionType::ExceptionSpecType::set(CppSharp::Parse
     ((::CppSharp::CppParser::AST::FunctionType*)NativePtr)->exceptionSpecType = (::CppSharp::CppParser::AST::ExceptionSpecType)value;
 }
 
+System::Collections::Generic::List<CppSharp::Parser::AST::Parameter^>^ CppSharp::Parser::AST::FunctionType::Parameters::get()
+{
+    auto _tmp__Parameters = gcnew System::Collections::Generic::List<CppSharp::Parser::AST::Parameter^>();
+    for(auto _element : ((::CppSharp::CppParser::AST::FunctionType*)NativePtr)->Parameters)
+    {
+        auto _marshalElement = (_element == nullptr) ? nullptr : gcnew CppSharp::Parser::AST::Parameter((::CppSharp::CppParser::AST::Parameter*)_element);
+        _tmp__Parameters->Add(_marshalElement);
+    }
+    return _tmp__Parameters;
+}
+
+void CppSharp::Parser::AST::FunctionType::Parameters::set(System::Collections::Generic::List<CppSharp::Parser::AST::Parameter^>^ value)
+{
+    auto _tmpvalue = std::vector<::CppSharp::CppParser::AST::Parameter*>();
+    for each(CppSharp::Parser::AST::Parameter^ _element in value)
+    {
+        auto _marshalElement = (::CppSharp::CppParser::AST::Parameter*)_element->NativePtr;
+        _tmpvalue.push_back(_marshalElement);
+    }
+    ((::CppSharp::CppParser::AST::FunctionType*)NativePtr)->Parameters = _tmpvalue;
+}
+
 unsigned int CppSharp::Parser::AST::FunctionType::ParametersCount::get()
 {
     auto __ret = ((::CppSharp::CppParser::AST::FunctionType*)NativePtr)->getParametersCount();
@@ -799,6 +821,29 @@ void CppSharp::Parser::AST::TemplateSpecializationType::ClearArguments()
     ((::CppSharp::CppParser::AST::TemplateSpecializationType*)NativePtr)->clearArguments();
 }
 
+System::Collections::Generic::List<CppSharp::Parser::AST::TemplateArgument^>^ CppSharp::Parser::AST::TemplateSpecializationType::Arguments::get()
+{
+    auto _tmp__Arguments = gcnew System::Collections::Generic::List<CppSharp::Parser::AST::TemplateArgument^>();
+    for(auto _element : ((::CppSharp::CppParser::AST::TemplateSpecializationType*)NativePtr)->Arguments)
+    {
+        auto ___element = new ::CppSharp::CppParser::AST::TemplateArgument(_element);
+        auto _marshalElement = (___element == nullptr) ? nullptr : gcnew CppSharp::Parser::AST::TemplateArgument((::CppSharp::CppParser::AST::TemplateArgument*)___element);
+        _tmp__Arguments->Add(_marshalElement);
+    }
+    return _tmp__Arguments;
+}
+
+void CppSharp::Parser::AST::TemplateSpecializationType::Arguments::set(System::Collections::Generic::List<CppSharp::Parser::AST::TemplateArgument^>^ value)
+{
+    auto _tmpvalue = std::vector<::CppSharp::CppParser::AST::TemplateArgument>();
+    for each(CppSharp::Parser::AST::TemplateArgument^ _element in value)
+    {
+        auto _marshalElement = *(::CppSharp::CppParser::AST::TemplateArgument*)_element->NativePtr;
+        _tmpvalue.push_back(_marshalElement);
+    }
+    ((::CppSharp::CppParser::AST::TemplateSpecializationType*)NativePtr)->Arguments = _tmpvalue;
+}
+
 CppSharp::Parser::AST::Template^ CppSharp::Parser::AST::TemplateSpecializationType::Template::get()
 {
     return (((::CppSharp::CppParser::AST::TemplateSpecializationType*)NativePtr)->_template == nullptr) ? nullptr : gcnew CppSharp::Parser::AST::Template((::CppSharp::CppParser::AST::Template*)((::CppSharp::CppParser::AST::TemplateSpecializationType*)NativePtr)->_template);
@@ -880,6 +925,29 @@ void CppSharp::Parser::AST::DependentTemplateSpecializationType::AddArguments(Cp
 void CppSharp::Parser::AST::DependentTemplateSpecializationType::ClearArguments()
 {
     ((::CppSharp::CppParser::AST::DependentTemplateSpecializationType*)NativePtr)->clearArguments();
+}
+
+System::Collections::Generic::List<CppSharp::Parser::AST::TemplateArgument^>^ CppSharp::Parser::AST::DependentTemplateSpecializationType::Arguments::get()
+{
+    auto _tmp__Arguments = gcnew System::Collections::Generic::List<CppSharp::Parser::AST::TemplateArgument^>();
+    for(auto _element : ((::CppSharp::CppParser::AST::DependentTemplateSpecializationType*)NativePtr)->Arguments)
+    {
+        auto ___element = new ::CppSharp::CppParser::AST::TemplateArgument(_element);
+        auto _marshalElement = (___element == nullptr) ? nullptr : gcnew CppSharp::Parser::AST::TemplateArgument((::CppSharp::CppParser::AST::TemplateArgument*)___element);
+        _tmp__Arguments->Add(_marshalElement);
+    }
+    return _tmp__Arguments;
+}
+
+void CppSharp::Parser::AST::DependentTemplateSpecializationType::Arguments::set(System::Collections::Generic::List<CppSharp::Parser::AST::TemplateArgument^>^ value)
+{
+    auto _tmpvalue = std::vector<::CppSharp::CppParser::AST::TemplateArgument>();
+    for each(CppSharp::Parser::AST::TemplateArgument^ _element in value)
+    {
+        auto _marshalElement = *(::CppSharp::CppParser::AST::TemplateArgument*)_element->NativePtr;
+        _tmpvalue.push_back(_marshalElement);
+    }
+    ((::CppSharp::CppParser::AST::DependentTemplateSpecializationType*)NativePtr)->Arguments = _tmpvalue;
 }
 
 CppSharp::Parser::AST::QualifiedType^ CppSharp::Parser::AST::DependentTemplateSpecializationType::Desugared::get()
@@ -1126,16 +1194,12 @@ void CppSharp::Parser::AST::DependentNameType::Qualifier::set(CppSharp::Parser::
 
 System::String^ CppSharp::Parser::AST::DependentNameType::Identifier::get()
 {
-    auto __ret = ((::CppSharp::CppParser::AST::DependentNameType*)NativePtr)->getIdentifier();
-    if (__ret == nullptr) return nullptr;
-    return (__ret == 0 ? nullptr : clix::marshalString<clix::E_UTF8>(__ret));
+    return clix::marshalString<clix::E_UTF8>(((::CppSharp::CppParser::AST::DependentNameType*)NativePtr)->identifier);
 }
 
-void CppSharp::Parser::AST::DependentNameType::Identifier::set(System::String^ s)
+void CppSharp::Parser::AST::DependentNameType::Identifier::set(System::String^ value)
 {
-    auto ___arg0 = clix::marshalString<clix::E_UTF8>(s);
-    auto __arg0 = ___arg0.c_str();
-    ((::CppSharp::CppParser::AST::DependentNameType*)NativePtr)->setIdentifier(__arg0);
+    ((::CppSharp::CppParser::AST::DependentNameType*)NativePtr)->identifier = clix::marshalString<clix::E_UTF8>(value);
 }
 
 CppSharp::Parser::AST::PackExpansionType::PackExpansionType(::CppSharp::CppParser::AST::PackExpansionType* native)
@@ -1444,6 +1508,29 @@ void CppSharp::Parser::AST::VTableLayout::__Instance::set(System::IntPtr object)
     NativePtr = (::CppSharp::CppParser::AST::VTableLayout*)object.ToPointer();
 }
 
+System::Collections::Generic::List<CppSharp::Parser::AST::VTableComponent^>^ CppSharp::Parser::AST::VTableLayout::Components::get()
+{
+    auto _tmp__Components = gcnew System::Collections::Generic::List<CppSharp::Parser::AST::VTableComponent^>();
+    for(auto _element : ((::CppSharp::CppParser::AST::VTableLayout*)NativePtr)->Components)
+    {
+        auto ___element = new ::CppSharp::CppParser::AST::VTableComponent(_element);
+        auto _marshalElement = (___element == nullptr) ? nullptr : gcnew CppSharp::Parser::AST::VTableComponent((::CppSharp::CppParser::AST::VTableComponent*)___element);
+        _tmp__Components->Add(_marshalElement);
+    }
+    return _tmp__Components;
+}
+
+void CppSharp::Parser::AST::VTableLayout::Components::set(System::Collections::Generic::List<CppSharp::Parser::AST::VTableComponent^>^ value)
+{
+    auto _tmpvalue = std::vector<::CppSharp::CppParser::AST::VTableComponent>();
+    for each(CppSharp::Parser::AST::VTableComponent^ _element in value)
+    {
+        auto _marshalElement = *(::CppSharp::CppParser::AST::VTableComponent*)_element->NativePtr;
+        _tmpvalue.push_back(_marshalElement);
+    }
+    ((::CppSharp::CppParser::AST::VTableLayout*)NativePtr)->Components = _tmpvalue;
+}
+
 unsigned int CppSharp::Parser::AST::VTableLayout::ComponentsCount::get()
 {
     auto __ret = ((::CppSharp::CppParser::AST::VTableLayout*)NativePtr)->getComponentsCount();
@@ -1582,6 +1669,16 @@ void CppSharp::Parser::AST::LayoutField::Offset::set(unsigned int value)
     ((::CppSharp::CppParser::AST::LayoutField*)NativePtr)->offset = value;
 }
 
+System::String^ CppSharp::Parser::AST::LayoutField::Name::get()
+{
+    return clix::marshalString<clix::E_UTF8>(((::CppSharp::CppParser::AST::LayoutField*)NativePtr)->name);
+}
+
+void CppSharp::Parser::AST::LayoutField::Name::set(System::String^ value)
+{
+    ((::CppSharp::CppParser::AST::LayoutField*)NativePtr)->name = clix::marshalString<clix::E_UTF8>(value);
+}
+
 CppSharp::Parser::AST::QualifiedType^ CppSharp::Parser::AST::LayoutField::QualifiedType::get()
 {
     return (&((::CppSharp::CppParser::AST::LayoutField*)NativePtr)->qualifiedType == nullptr) ? nullptr : gcnew CppSharp::Parser::AST::QualifiedType((::CppSharp::CppParser::AST::QualifiedType*)&((::CppSharp::CppParser::AST::LayoutField*)NativePtr)->qualifiedType);
@@ -1600,20 +1697,6 @@ void CppSharp::Parser::AST::LayoutField::QualifiedType::set(CppSharp::Parser::AS
 void CppSharp::Parser::AST::LayoutField::FieldPtr::set(::System::IntPtr value)
 {
     ((::CppSharp::CppParser::AST::LayoutField*)NativePtr)->fieldPtr = (void*)value;
-}
-
-System::String^ CppSharp::Parser::AST::LayoutField::Name::get()
-{
-    auto __ret = ((::CppSharp::CppParser::AST::LayoutField*)NativePtr)->getName();
-    if (__ret == nullptr) return nullptr;
-    return (__ret == 0 ? nullptr : clix::marshalString<clix::E_UTF8>(__ret));
-}
-
-void CppSharp::Parser::AST::LayoutField::Name::set(System::String^ s)
-{
-    auto ___arg0 = clix::marshalString<clix::E_UTF8>(s);
-    auto __arg0 = ___arg0.c_str();
-    ((::CppSharp::CppParser::AST::LayoutField*)NativePtr)->setName(__arg0);
 }
 
 CppSharp::Parser::AST::LayoutBase::LayoutBase(::CppSharp::CppParser::AST::LayoutBase* native)
@@ -1788,6 +1871,29 @@ void CppSharp::Parser::AST::ClassLayout::ABI::set(CppSharp::Parser::AST::CppAbi 
     ((::CppSharp::CppParser::AST::ClassLayout*)NativePtr)->ABI = (::CppSharp::CppParser::AST::CppAbi)value;
 }
 
+System::Collections::Generic::List<CppSharp::Parser::AST::VFTableInfo^>^ CppSharp::Parser::AST::ClassLayout::VFTables::get()
+{
+    auto _tmp__VFTables = gcnew System::Collections::Generic::List<CppSharp::Parser::AST::VFTableInfo^>();
+    for(auto _element : ((::CppSharp::CppParser::AST::ClassLayout*)NativePtr)->VFTables)
+    {
+        auto ___element = new ::CppSharp::CppParser::AST::VFTableInfo(_element);
+        auto _marshalElement = (___element == nullptr) ? nullptr : gcnew CppSharp::Parser::AST::VFTableInfo((::CppSharp::CppParser::AST::VFTableInfo*)___element);
+        _tmp__VFTables->Add(_marshalElement);
+    }
+    return _tmp__VFTables;
+}
+
+void CppSharp::Parser::AST::ClassLayout::VFTables::set(System::Collections::Generic::List<CppSharp::Parser::AST::VFTableInfo^>^ value)
+{
+    auto _tmpvalue = std::vector<::CppSharp::CppParser::AST::VFTableInfo>();
+    for each(CppSharp::Parser::AST::VFTableInfo^ _element in value)
+    {
+        auto _marshalElement = *(::CppSharp::CppParser::AST::VFTableInfo*)_element->NativePtr;
+        _tmpvalue.push_back(_marshalElement);
+    }
+    ((::CppSharp::CppParser::AST::ClassLayout*)NativePtr)->VFTables = _tmpvalue;
+}
+
 CppSharp::Parser::AST::VTableLayout^ CppSharp::Parser::AST::ClassLayout::Layout::get()
 {
     return (&((::CppSharp::CppParser::AST::ClassLayout*)NativePtr)->layout == nullptr) ? nullptr : gcnew CppSharp::Parser::AST::VTableLayout((::CppSharp::CppParser::AST::VTableLayout*)&((::CppSharp::CppParser::AST::ClassLayout*)NativePtr)->layout);
@@ -1846,6 +1952,52 @@ int CppSharp::Parser::AST::ClassLayout::DataSize::get()
 void CppSharp::Parser::AST::ClassLayout::DataSize::set(int value)
 {
     ((::CppSharp::CppParser::AST::ClassLayout*)NativePtr)->dataSize = value;
+}
+
+System::Collections::Generic::List<CppSharp::Parser::AST::LayoutField^>^ CppSharp::Parser::AST::ClassLayout::Fields::get()
+{
+    auto _tmp__Fields = gcnew System::Collections::Generic::List<CppSharp::Parser::AST::LayoutField^>();
+    for(auto _element : ((::CppSharp::CppParser::AST::ClassLayout*)NativePtr)->Fields)
+    {
+        auto ___element = new ::CppSharp::CppParser::AST::LayoutField(_element);
+        auto _marshalElement = (___element == nullptr) ? nullptr : gcnew CppSharp::Parser::AST::LayoutField((::CppSharp::CppParser::AST::LayoutField*)___element);
+        _tmp__Fields->Add(_marshalElement);
+    }
+    return _tmp__Fields;
+}
+
+void CppSharp::Parser::AST::ClassLayout::Fields::set(System::Collections::Generic::List<CppSharp::Parser::AST::LayoutField^>^ value)
+{
+    auto _tmpvalue = std::vector<::CppSharp::CppParser::AST::LayoutField>();
+    for each(CppSharp::Parser::AST::LayoutField^ _element in value)
+    {
+        auto _marshalElement = *(::CppSharp::CppParser::AST::LayoutField*)_element->NativePtr;
+        _tmpvalue.push_back(_marshalElement);
+    }
+    ((::CppSharp::CppParser::AST::ClassLayout*)NativePtr)->Fields = _tmpvalue;
+}
+
+System::Collections::Generic::List<CppSharp::Parser::AST::LayoutBase^>^ CppSharp::Parser::AST::ClassLayout::Bases::get()
+{
+    auto _tmp__Bases = gcnew System::Collections::Generic::List<CppSharp::Parser::AST::LayoutBase^>();
+    for(auto _element : ((::CppSharp::CppParser::AST::ClassLayout*)NativePtr)->Bases)
+    {
+        auto ___element = new ::CppSharp::CppParser::AST::LayoutBase(_element);
+        auto _marshalElement = (___element == nullptr) ? nullptr : gcnew CppSharp::Parser::AST::LayoutBase((::CppSharp::CppParser::AST::LayoutBase*)___element);
+        _tmp__Bases->Add(_marshalElement);
+    }
+    return _tmp__Bases;
+}
+
+void CppSharp::Parser::AST::ClassLayout::Bases::set(System::Collections::Generic::List<CppSharp::Parser::AST::LayoutBase^>^ value)
+{
+    auto _tmpvalue = std::vector<::CppSharp::CppParser::AST::LayoutBase>();
+    for each(CppSharp::Parser::AST::LayoutBase^ _element in value)
+    {
+        auto _marshalElement = *(::CppSharp::CppParser::AST::LayoutBase*)_element->NativePtr;
+        _tmpvalue.push_back(_marshalElement);
+    }
+    ((::CppSharp::CppParser::AST::ClassLayout*)NativePtr)->Bases = _tmpvalue;
 }
 
 unsigned int CppSharp::Parser::AST::ClassLayout::VFTablesCount::get()
@@ -2018,6 +2170,36 @@ void CppSharp::Parser::AST::Declaration::LineNumberEnd::set(int value)
     ((::CppSharp::CppParser::AST::Declaration*)NativePtr)->lineNumberEnd = value;
 }
 
+System::String^ CppSharp::Parser::AST::Declaration::Name::get()
+{
+    return clix::marshalString<clix::E_UTF8>(((::CppSharp::CppParser::AST::Declaration*)NativePtr)->name);
+}
+
+void CppSharp::Parser::AST::Declaration::Name::set(System::String^ value)
+{
+    ((::CppSharp::CppParser::AST::Declaration*)NativePtr)->name = clix::marshalString<clix::E_UTF8>(value);
+}
+
+System::String^ CppSharp::Parser::AST::Declaration::USR::get()
+{
+    return clix::marshalString<clix::E_UTF8>(((::CppSharp::CppParser::AST::Declaration*)NativePtr)->USR);
+}
+
+void CppSharp::Parser::AST::Declaration::USR::set(System::String^ value)
+{
+    ((::CppSharp::CppParser::AST::Declaration*)NativePtr)->USR = clix::marshalString<clix::E_UTF8>(value);
+}
+
+System::String^ CppSharp::Parser::AST::Declaration::DebugText::get()
+{
+    return clix::marshalString<clix::E_UTF8>(((::CppSharp::CppParser::AST::Declaration*)NativePtr)->debugText);
+}
+
+void CppSharp::Parser::AST::Declaration::DebugText::set(System::String^ value)
+{
+    ((::CppSharp::CppParser::AST::Declaration*)NativePtr)->debugText = clix::marshalString<clix::E_UTF8>(value);
+}
+
 bool CppSharp::Parser::AST::Declaration::IsIncomplete::get()
 {
     return ((::CppSharp::CppParser::AST::Declaration*)NativePtr)->isIncomplete;
@@ -2068,6 +2250,50 @@ void CppSharp::Parser::AST::Declaration::DefinitionOrder::set(unsigned int value
     ((::CppSharp::CppParser::AST::Declaration*)NativePtr)->definitionOrder = value;
 }
 
+System::Collections::Generic::List<CppSharp::Parser::AST::PreprocessedEntity^>^ CppSharp::Parser::AST::Declaration::PreprocessedEntities::get()
+{
+    auto _tmp__PreprocessedEntities = gcnew System::Collections::Generic::List<CppSharp::Parser::AST::PreprocessedEntity^>();
+    for(auto _element : ((::CppSharp::CppParser::AST::Declaration*)NativePtr)->PreprocessedEntities)
+    {
+        auto _marshalElement = (_element == nullptr) ? nullptr : gcnew CppSharp::Parser::AST::PreprocessedEntity((::CppSharp::CppParser::AST::PreprocessedEntity*)_element);
+        _tmp__PreprocessedEntities->Add(_marshalElement);
+    }
+    return _tmp__PreprocessedEntities;
+}
+
+void CppSharp::Parser::AST::Declaration::PreprocessedEntities::set(System::Collections::Generic::List<CppSharp::Parser::AST::PreprocessedEntity^>^ value)
+{
+    auto _tmpvalue = std::vector<::CppSharp::CppParser::AST::PreprocessedEntity*>();
+    for each(CppSharp::Parser::AST::PreprocessedEntity^ _element in value)
+    {
+        auto _marshalElement = (::CppSharp::CppParser::AST::PreprocessedEntity*)_element->NativePtr;
+        _tmpvalue.push_back(_marshalElement);
+    }
+    ((::CppSharp::CppParser::AST::Declaration*)NativePtr)->PreprocessedEntities = _tmpvalue;
+}
+
+System::Collections::Generic::List<CppSharp::Parser::AST::Declaration^>^ CppSharp::Parser::AST::Declaration::Redeclarations::get()
+{
+    auto _tmp__Redeclarations = gcnew System::Collections::Generic::List<CppSharp::Parser::AST::Declaration^>();
+    for(auto _element : ((::CppSharp::CppParser::AST::Declaration*)NativePtr)->Redeclarations)
+    {
+        auto _marshalElement = (_element == nullptr) ? nullptr : gcnew CppSharp::Parser::AST::Declaration((::CppSharp::CppParser::AST::Declaration*)_element);
+        _tmp__Redeclarations->Add(_marshalElement);
+    }
+    return _tmp__Redeclarations;
+}
+
+void CppSharp::Parser::AST::Declaration::Redeclarations::set(System::Collections::Generic::List<CppSharp::Parser::AST::Declaration^>^ value)
+{
+    auto _tmpvalue = std::vector<::CppSharp::CppParser::AST::Declaration*>();
+    for each(CppSharp::Parser::AST::Declaration^ _element in value)
+    {
+        auto _marshalElement = (::CppSharp::CppParser::AST::Declaration*)_element->NativePtr;
+        _tmpvalue.push_back(_marshalElement);
+    }
+    ((::CppSharp::CppParser::AST::Declaration*)NativePtr)->Redeclarations = _tmpvalue;
+}
+
 ::System::IntPtr CppSharp::Parser::AST::Declaration::OriginalPtr::get()
 {
     return ::System::IntPtr(((::CppSharp::CppParser::AST::Declaration*)NativePtr)->originalPtr);
@@ -2086,48 +2312,6 @@ CppSharp::Parser::AST::RawComment^ CppSharp::Parser::AST::Declaration::Comment::
 void CppSharp::Parser::AST::Declaration::Comment::set(CppSharp::Parser::AST::RawComment^ value)
 {
     ((::CppSharp::CppParser::AST::Declaration*)NativePtr)->comment = (::CppSharp::CppParser::AST::RawComment*)value->NativePtr;
-}
-
-System::String^ CppSharp::Parser::AST::Declaration::Name::get()
-{
-    auto __ret = ((::CppSharp::CppParser::AST::Declaration*)NativePtr)->getName();
-    if (__ret == nullptr) return nullptr;
-    return (__ret == 0 ? nullptr : clix::marshalString<clix::E_UTF8>(__ret));
-}
-
-void CppSharp::Parser::AST::Declaration::Name::set(System::String^ s)
-{
-    auto ___arg0 = clix::marshalString<clix::E_UTF8>(s);
-    auto __arg0 = ___arg0.c_str();
-    ((::CppSharp::CppParser::AST::Declaration*)NativePtr)->setName(__arg0);
-}
-
-System::String^ CppSharp::Parser::AST::Declaration::USR::get()
-{
-    auto __ret = ((::CppSharp::CppParser::AST::Declaration*)NativePtr)->getUSR();
-    if (__ret == nullptr) return nullptr;
-    return (__ret == 0 ? nullptr : clix::marshalString<clix::E_UTF8>(__ret));
-}
-
-void CppSharp::Parser::AST::Declaration::USR::set(System::String^ s)
-{
-    auto ___arg0 = clix::marshalString<clix::E_UTF8>(s);
-    auto __arg0 = ___arg0.c_str();
-    ((::CppSharp::CppParser::AST::Declaration*)NativePtr)->setUSR(__arg0);
-}
-
-System::String^ CppSharp::Parser::AST::Declaration::DebugText::get()
-{
-    auto __ret = ((::CppSharp::CppParser::AST::Declaration*)NativePtr)->getDebugText();
-    if (__ret == nullptr) return nullptr;
-    return (__ret == 0 ? nullptr : clix::marshalString<clix::E_UTF8>(__ret));
-}
-
-void CppSharp::Parser::AST::Declaration::DebugText::set(System::String^ s)
-{
-    auto ___arg0 = clix::marshalString<clix::E_UTF8>(s);
-    auto __arg0 = ___arg0.c_str();
-    ((::CppSharp::CppParser::AST::Declaration*)NativePtr)->setDebugText(__arg0);
 }
 
 unsigned int CppSharp::Parser::AST::Declaration::PreprocessedEntitiesCount::get()
@@ -2366,6 +2550,204 @@ CppSharp::Parser::AST::DeclarationContext::operator CppSharp::Parser::AST::Decla
     auto __ret = (::CppSharp::CppParser::AST::DeclarationContext) __arg0;
     auto ____ret = new ::CppSharp::CppParser::AST::DeclarationContext(__ret);
     return (____ret == nullptr) ? nullptr : gcnew CppSharp::Parser::AST::DeclarationContext((::CppSharp::CppParser::AST::DeclarationContext*)____ret);
+}
+
+System::Collections::Generic::List<CppSharp::Parser::AST::Namespace^>^ CppSharp::Parser::AST::DeclarationContext::Namespaces::get()
+{
+    auto _tmp__Namespaces_ = gcnew System::Collections::Generic::List<CppSharp::Parser::AST::Namespace^>();
+    for(auto _element : ((::CppSharp::CppParser::AST::DeclarationContext*)NativePtr)->Namespaces)
+    {
+        auto _marshalElement = (_element == nullptr) ? nullptr : gcnew CppSharp::Parser::AST::Namespace((::CppSharp::CppParser::AST::Namespace*)_element);
+        _tmp__Namespaces_->Add(_marshalElement);
+    }
+    return _tmp__Namespaces_;
+}
+
+void CppSharp::Parser::AST::DeclarationContext::Namespaces::set(System::Collections::Generic::List<CppSharp::Parser::AST::Namespace^>^ value)
+{
+    auto _tmpvalue = std::vector<::CppSharp::CppParser::AST::Namespace*>();
+    for each(CppSharp::Parser::AST::Namespace^ _element in value)
+    {
+        auto _marshalElement = (::CppSharp::CppParser::AST::Namespace*)_element->NativePtr;
+        _tmpvalue.push_back(_marshalElement);
+    }
+    ((::CppSharp::CppParser::AST::DeclarationContext*)NativePtr)->Namespaces = _tmpvalue;
+}
+
+System::Collections::Generic::List<CppSharp::Parser::AST::Enumeration^>^ CppSharp::Parser::AST::DeclarationContext::Enums::get()
+{
+    auto _tmp__Enums_ = gcnew System::Collections::Generic::List<CppSharp::Parser::AST::Enumeration^>();
+    for(auto _element : ((::CppSharp::CppParser::AST::DeclarationContext*)NativePtr)->Enums)
+    {
+        auto _marshalElement = (_element == nullptr) ? nullptr : gcnew CppSharp::Parser::AST::Enumeration((::CppSharp::CppParser::AST::Enumeration*)_element);
+        _tmp__Enums_->Add(_marshalElement);
+    }
+    return _tmp__Enums_;
+}
+
+void CppSharp::Parser::AST::DeclarationContext::Enums::set(System::Collections::Generic::List<CppSharp::Parser::AST::Enumeration^>^ value)
+{
+    auto _tmpvalue = std::vector<::CppSharp::CppParser::AST::Enumeration*>();
+    for each(CppSharp::Parser::AST::Enumeration^ _element in value)
+    {
+        auto _marshalElement = (::CppSharp::CppParser::AST::Enumeration*)_element->NativePtr;
+        _tmpvalue.push_back(_marshalElement);
+    }
+    ((::CppSharp::CppParser::AST::DeclarationContext*)NativePtr)->Enums = _tmpvalue;
+}
+
+System::Collections::Generic::List<CppSharp::Parser::AST::Function^>^ CppSharp::Parser::AST::DeclarationContext::Functions::get()
+{
+    auto _tmp__Functions = gcnew System::Collections::Generic::List<CppSharp::Parser::AST::Function^>();
+    for(auto _element : ((::CppSharp::CppParser::AST::DeclarationContext*)NativePtr)->Functions)
+    {
+        auto _marshalElement = (_element == nullptr) ? nullptr : gcnew CppSharp::Parser::AST::Function((::CppSharp::CppParser::AST::Function*)_element);
+        _tmp__Functions->Add(_marshalElement);
+    }
+    return _tmp__Functions;
+}
+
+void CppSharp::Parser::AST::DeclarationContext::Functions::set(System::Collections::Generic::List<CppSharp::Parser::AST::Function^>^ value)
+{
+    auto _tmpvalue = std::vector<::CppSharp::CppParser::AST::Function*>();
+    for each(CppSharp::Parser::AST::Function^ _element in value)
+    {
+        auto _marshalElement = (::CppSharp::CppParser::AST::Function*)_element->NativePtr;
+        _tmpvalue.push_back(_marshalElement);
+    }
+    ((::CppSharp::CppParser::AST::DeclarationContext*)NativePtr)->Functions = _tmpvalue;
+}
+
+System::Collections::Generic::List<CppSharp::Parser::AST::Class^>^ CppSharp::Parser::AST::DeclarationContext::Classes::get()
+{
+    auto _tmp__Classes_ = gcnew System::Collections::Generic::List<CppSharp::Parser::AST::Class^>();
+    for(auto _element : ((::CppSharp::CppParser::AST::DeclarationContext*)NativePtr)->Classes)
+    {
+        auto _marshalElement = (_element == nullptr) ? nullptr : gcnew CppSharp::Parser::AST::Class((::CppSharp::CppParser::AST::Class*)_element);
+        _tmp__Classes_->Add(_marshalElement);
+    }
+    return _tmp__Classes_;
+}
+
+void CppSharp::Parser::AST::DeclarationContext::Classes::set(System::Collections::Generic::List<CppSharp::Parser::AST::Class^>^ value)
+{
+    auto _tmpvalue = std::vector<::CppSharp::CppParser::AST::Class*>();
+    for each(CppSharp::Parser::AST::Class^ _element in value)
+    {
+        auto _marshalElement = (::CppSharp::CppParser::AST::Class*)_element->NativePtr;
+        _tmpvalue.push_back(_marshalElement);
+    }
+    ((::CppSharp::CppParser::AST::DeclarationContext*)NativePtr)->Classes = _tmpvalue;
+}
+
+System::Collections::Generic::List<CppSharp::Parser::AST::Template^>^ CppSharp::Parser::AST::DeclarationContext::Templates::get()
+{
+    auto _tmp__Templates = gcnew System::Collections::Generic::List<CppSharp::Parser::AST::Template^>();
+    for(auto _element : ((::CppSharp::CppParser::AST::DeclarationContext*)NativePtr)->Templates)
+    {
+        auto _marshalElement = (_element == nullptr) ? nullptr : gcnew CppSharp::Parser::AST::Template((::CppSharp::CppParser::AST::Template*)_element);
+        _tmp__Templates->Add(_marshalElement);
+    }
+    return _tmp__Templates;
+}
+
+void CppSharp::Parser::AST::DeclarationContext::Templates::set(System::Collections::Generic::List<CppSharp::Parser::AST::Template^>^ value)
+{
+    auto _tmpvalue = std::vector<::CppSharp::CppParser::AST::Template*>();
+    for each(CppSharp::Parser::AST::Template^ _element in value)
+    {
+        auto _marshalElement = (::CppSharp::CppParser::AST::Template*)_element->NativePtr;
+        _tmpvalue.push_back(_marshalElement);
+    }
+    ((::CppSharp::CppParser::AST::DeclarationContext*)NativePtr)->Templates = _tmpvalue;
+}
+
+System::Collections::Generic::List<CppSharp::Parser::AST::TypedefDecl^>^ CppSharp::Parser::AST::DeclarationContext::Typedefs::get()
+{
+    auto _tmp__Typedefs = gcnew System::Collections::Generic::List<CppSharp::Parser::AST::TypedefDecl^>();
+    for(auto _element : ((::CppSharp::CppParser::AST::DeclarationContext*)NativePtr)->Typedefs)
+    {
+        auto _marshalElement = (_element == nullptr) ? nullptr : gcnew CppSharp::Parser::AST::TypedefDecl((::CppSharp::CppParser::AST::TypedefDecl*)_element);
+        _tmp__Typedefs->Add(_marshalElement);
+    }
+    return _tmp__Typedefs;
+}
+
+void CppSharp::Parser::AST::DeclarationContext::Typedefs::set(System::Collections::Generic::List<CppSharp::Parser::AST::TypedefDecl^>^ value)
+{
+    auto _tmpvalue = std::vector<::CppSharp::CppParser::AST::TypedefDecl*>();
+    for each(CppSharp::Parser::AST::TypedefDecl^ _element in value)
+    {
+        auto _marshalElement = (::CppSharp::CppParser::AST::TypedefDecl*)_element->NativePtr;
+        _tmpvalue.push_back(_marshalElement);
+    }
+    ((::CppSharp::CppParser::AST::DeclarationContext*)NativePtr)->Typedefs = _tmpvalue;
+}
+
+System::Collections::Generic::List<CppSharp::Parser::AST::TypeAlias^>^ CppSharp::Parser::AST::DeclarationContext::TypeAliases::get()
+{
+    auto _tmp__TypeAliases = gcnew System::Collections::Generic::List<CppSharp::Parser::AST::TypeAlias^>();
+    for(auto _element : ((::CppSharp::CppParser::AST::DeclarationContext*)NativePtr)->TypeAliases)
+    {
+        auto _marshalElement = (_element == nullptr) ? nullptr : gcnew CppSharp::Parser::AST::TypeAlias((::CppSharp::CppParser::AST::TypeAlias*)_element);
+        _tmp__TypeAliases->Add(_marshalElement);
+    }
+    return _tmp__TypeAliases;
+}
+
+void CppSharp::Parser::AST::DeclarationContext::TypeAliases::set(System::Collections::Generic::List<CppSharp::Parser::AST::TypeAlias^>^ value)
+{
+    auto _tmpvalue = std::vector<::CppSharp::CppParser::AST::TypeAlias*>();
+    for each(CppSharp::Parser::AST::TypeAlias^ _element in value)
+    {
+        auto _marshalElement = (::CppSharp::CppParser::AST::TypeAlias*)_element->NativePtr;
+        _tmpvalue.push_back(_marshalElement);
+    }
+    ((::CppSharp::CppParser::AST::DeclarationContext*)NativePtr)->TypeAliases = _tmpvalue;
+}
+
+System::Collections::Generic::List<CppSharp::Parser::AST::Variable^>^ CppSharp::Parser::AST::DeclarationContext::Variables::get()
+{
+    auto _tmp__Variables = gcnew System::Collections::Generic::List<CppSharp::Parser::AST::Variable^>();
+    for(auto _element : ((::CppSharp::CppParser::AST::DeclarationContext*)NativePtr)->Variables)
+    {
+        auto _marshalElement = (_element == nullptr) ? nullptr : gcnew CppSharp::Parser::AST::Variable((::CppSharp::CppParser::AST::Variable*)_element);
+        _tmp__Variables->Add(_marshalElement);
+    }
+    return _tmp__Variables;
+}
+
+void CppSharp::Parser::AST::DeclarationContext::Variables::set(System::Collections::Generic::List<CppSharp::Parser::AST::Variable^>^ value)
+{
+    auto _tmpvalue = std::vector<::CppSharp::CppParser::AST::Variable*>();
+    for each(CppSharp::Parser::AST::Variable^ _element in value)
+    {
+        auto _marshalElement = (::CppSharp::CppParser::AST::Variable*)_element->NativePtr;
+        _tmpvalue.push_back(_marshalElement);
+    }
+    ((::CppSharp::CppParser::AST::DeclarationContext*)NativePtr)->Variables = _tmpvalue;
+}
+
+System::Collections::Generic::List<CppSharp::Parser::AST::Friend^>^ CppSharp::Parser::AST::DeclarationContext::Friends::get()
+{
+    auto _tmp__Friends = gcnew System::Collections::Generic::List<CppSharp::Parser::AST::Friend^>();
+    for(auto _element : ((::CppSharp::CppParser::AST::DeclarationContext*)NativePtr)->Friends)
+    {
+        auto _marshalElement = (_element == nullptr) ? nullptr : gcnew CppSharp::Parser::AST::Friend((::CppSharp::CppParser::AST::Friend*)_element);
+        _tmp__Friends->Add(_marshalElement);
+    }
+    return _tmp__Friends;
+}
+
+void CppSharp::Parser::AST::DeclarationContext::Friends::set(System::Collections::Generic::List<CppSharp::Parser::AST::Friend^>^ value)
+{
+    auto _tmpvalue = std::vector<::CppSharp::CppParser::AST::Friend*>();
+    for each(CppSharp::Parser::AST::Friend^ _element in value)
+    {
+        auto _marshalElement = (::CppSharp::CppParser::AST::Friend*)_element->NativePtr;
+        _tmpvalue.push_back(_marshalElement);
+    }
+    ((::CppSharp::CppParser::AST::DeclarationContext*)NativePtr)->Friends = _tmpvalue;
 }
 
 bool CppSharp::Parser::AST::DeclarationContext::IsAnonymous::get()
@@ -2635,6 +3017,15 @@ CppSharp::Parser::AST::Statement::~Statement()
     delete NativePtr;
 }
 
+CppSharp::Parser::AST::Statement::Statement(System::String^ str, CppSharp::Parser::AST::StatementClass Class, CppSharp::Parser::AST::Declaration^ decl)
+{
+    __ownsNativeInstance = true;
+    auto __arg0 = clix::marshalString<clix::E_UTF8>(str);
+    auto __arg1 = (::CppSharp::CppParser::AST::StatementClass)Class;
+    auto __arg2 = (::CppSharp::CppParser::AST::Declaration*)decl->NativePtr;
+    NativePtr = new ::CppSharp::CppParser::AST::Statement(__arg0, __arg1, __arg2);
+}
+
 CppSharp::Parser::AST::Statement::Statement(CppSharp::Parser::AST::Statement^ _0)
 {
     __ownsNativeInstance = true;
@@ -2676,16 +3067,12 @@ void CppSharp::Parser::AST::Statement::Decl::set(CppSharp::Parser::AST::Declarat
 
 System::String^ CppSharp::Parser::AST::Statement::String::get()
 {
-    auto __ret = ((::CppSharp::CppParser::AST::Statement*)NativePtr)->getString();
-    if (__ret == nullptr) return nullptr;
-    return (__ret == 0 ? nullptr : clix::marshalString<clix::E_UTF8>(__ret));
+    return clix::marshalString<clix::E_UTF8>(((::CppSharp::CppParser::AST::Statement*)NativePtr)->string);
 }
 
-void CppSharp::Parser::AST::Statement::String::set(System::String^ s)
+void CppSharp::Parser::AST::Statement::String::set(System::String^ value)
 {
-    auto ___arg0 = clix::marshalString<clix::E_UTF8>(s);
-    auto __arg0 = ___arg0.c_str();
-    ((::CppSharp::CppParser::AST::Statement*)NativePtr)->setString(__arg0);
+    ((::CppSharp::CppParser::AST::Statement*)NativePtr)->string = clix::marshalString<clix::E_UTF8>(value);
 }
 
 CppSharp::Parser::AST::Expression::Expression(::CppSharp::CppParser::AST::Expression* native)
@@ -2706,6 +3093,16 @@ CppSharp::Parser::AST::Expression::~Expression()
         NativePtr = 0;
         delete (::CppSharp::CppParser::AST::Expression*) __nativePtr;
     }
+}
+
+CppSharp::Parser::AST::Expression::Expression(System::String^ str, CppSharp::Parser::AST::StatementClass Class, CppSharp::Parser::AST::Declaration^ decl)
+    : CppSharp::Parser::AST::Statement((::CppSharp::CppParser::AST::Statement*)nullptr)
+{
+    __ownsNativeInstance = true;
+    auto __arg0 = clix::marshalString<clix::E_UTF8>(str);
+    auto __arg1 = (::CppSharp::CppParser::AST::StatementClass)Class;
+    auto __arg2 = (::CppSharp::CppParser::AST::Declaration*)decl->NativePtr;
+    NativePtr = new ::CppSharp::CppParser::AST::Expression(__arg0, __arg1, __arg2);
 }
 
 CppSharp::Parser::AST::Expression::Expression(CppSharp::Parser::AST::Expression^ _0)
@@ -2736,6 +3133,17 @@ CppSharp::Parser::AST::BinaryOperator::~BinaryOperator()
         NativePtr = 0;
         delete (::CppSharp::CppParser::AST::BinaryOperator*) __nativePtr;
     }
+}
+
+CppSharp::Parser::AST::BinaryOperator::BinaryOperator(System::String^ str, CppSharp::Parser::AST::Expression^ lhs, CppSharp::Parser::AST::Expression^ rhs, System::String^ opcodeStr)
+    : CppSharp::Parser::AST::Expression((::CppSharp::CppParser::AST::Expression*)nullptr)
+{
+    __ownsNativeInstance = true;
+    auto __arg0 = clix::marshalString<clix::E_UTF8>(str);
+    auto __arg1 = (::CppSharp::CppParser::AST::Expression*)lhs->NativePtr;
+    auto __arg2 = (::CppSharp::CppParser::AST::Expression*)rhs->NativePtr;
+    auto __arg3 = clix::marshalString<clix::E_UTF8>(opcodeStr);
+    NativePtr = new ::CppSharp::CppParser::AST::BinaryOperator(__arg0, __arg1, __arg2, __arg3);
 }
 
 CppSharp::Parser::AST::BinaryOperator::BinaryOperator(CppSharp::Parser::AST::BinaryOperator^ _0)
@@ -2770,16 +3178,12 @@ void CppSharp::Parser::AST::BinaryOperator::RHS::set(CppSharp::Parser::AST::Expr
 
 System::String^ CppSharp::Parser::AST::BinaryOperator::OpcodeStr::get()
 {
-    auto __ret = ((::CppSharp::CppParser::AST::BinaryOperator*)NativePtr)->getOpcodeStr();
-    if (__ret == nullptr) return nullptr;
-    return (__ret == 0 ? nullptr : clix::marshalString<clix::E_UTF8>(__ret));
+    return clix::marshalString<clix::E_UTF8>(((::CppSharp::CppParser::AST::BinaryOperator*)NativePtr)->opcodeStr);
 }
 
-void CppSharp::Parser::AST::BinaryOperator::OpcodeStr::set(System::String^ s)
+void CppSharp::Parser::AST::BinaryOperator::OpcodeStr::set(System::String^ value)
 {
-    auto ___arg0 = clix::marshalString<clix::E_UTF8>(s);
-    auto __arg0 = ___arg0.c_str();
-    ((::CppSharp::CppParser::AST::BinaryOperator*)NativePtr)->setOpcodeStr(__arg0);
+    ((::CppSharp::CppParser::AST::BinaryOperator*)NativePtr)->opcodeStr = clix::marshalString<clix::E_UTF8>(value);
 }
 
 CppSharp::Parser::AST::CallExpr::CallExpr(::CppSharp::CppParser::AST::CallExpr* native)
@@ -2800,6 +3204,15 @@ CppSharp::Parser::AST::CallExpr::~CallExpr()
         NativePtr = 0;
         delete (::CppSharp::CppParser::AST::CallExpr*) __nativePtr;
     }
+}
+
+CppSharp::Parser::AST::CallExpr::CallExpr(System::String^ str, CppSharp::Parser::AST::Declaration^ decl)
+    : CppSharp::Parser::AST::Expression((::CppSharp::CppParser::AST::Expression*)nullptr)
+{
+    __ownsNativeInstance = true;
+    auto __arg0 = clix::marshalString<clix::E_UTF8>(str);
+    auto __arg1 = (::CppSharp::CppParser::AST::Declaration*)decl->NativePtr;
+    NativePtr = new ::CppSharp::CppParser::AST::CallExpr(__arg0, __arg1);
 }
 
 CppSharp::Parser::AST::Expression^ CppSharp::Parser::AST::CallExpr::GetArguments(unsigned int i)
@@ -2832,6 +3245,28 @@ CppSharp::Parser::AST::CallExpr::CallExpr(CppSharp::Parser::AST::CallExpr^ _0)
     NativePtr = new ::CppSharp::CppParser::AST::CallExpr(__arg0);
 }
 
+System::Collections::Generic::List<CppSharp::Parser::AST::Expression^>^ CppSharp::Parser::AST::CallExpr::Arguments::get()
+{
+    auto _tmp__Arguments = gcnew System::Collections::Generic::List<CppSharp::Parser::AST::Expression^>();
+    for(auto _element : ((::CppSharp::CppParser::AST::CallExpr*)NativePtr)->Arguments)
+    {
+        auto _marshalElement = (_element == nullptr) ? nullptr : gcnew CppSharp::Parser::AST::Expression((::CppSharp::CppParser::AST::Expression*)_element);
+        _tmp__Arguments->Add(_marshalElement);
+    }
+    return _tmp__Arguments;
+}
+
+void CppSharp::Parser::AST::CallExpr::Arguments::set(System::Collections::Generic::List<CppSharp::Parser::AST::Expression^>^ value)
+{
+    auto _tmpvalue = std::vector<::CppSharp::CppParser::AST::Expression*>();
+    for each(CppSharp::Parser::AST::Expression^ _element in value)
+    {
+        auto _marshalElement = (::CppSharp::CppParser::AST::Expression*)_element->NativePtr;
+        _tmpvalue.push_back(_marshalElement);
+    }
+    ((::CppSharp::CppParser::AST::CallExpr*)NativePtr)->Arguments = _tmpvalue;
+}
+
 unsigned int CppSharp::Parser::AST::CallExpr::ArgumentsCount::get()
 {
     auto __ret = ((::CppSharp::CppParser::AST::CallExpr*)NativePtr)->getArgumentsCount();
@@ -2856,6 +3291,15 @@ CppSharp::Parser::AST::CXXConstructExpr::~CXXConstructExpr()
         NativePtr = 0;
         delete (::CppSharp::CppParser::AST::CXXConstructExpr*) __nativePtr;
     }
+}
+
+CppSharp::Parser::AST::CXXConstructExpr::CXXConstructExpr(System::String^ str, CppSharp::Parser::AST::Declaration^ decl)
+    : CppSharp::Parser::AST::Expression((::CppSharp::CppParser::AST::Expression*)nullptr)
+{
+    __ownsNativeInstance = true;
+    auto __arg0 = clix::marshalString<clix::E_UTF8>(str);
+    auto __arg1 = (::CppSharp::CppParser::AST::Declaration*)decl->NativePtr;
+    NativePtr = new ::CppSharp::CppParser::AST::CXXConstructExpr(__arg0, __arg1);
 }
 
 CppSharp::Parser::AST::Expression^ CppSharp::Parser::AST::CXXConstructExpr::GetArguments(unsigned int i)
@@ -2886,6 +3330,28 @@ CppSharp::Parser::AST::CXXConstructExpr::CXXConstructExpr(CppSharp::Parser::AST:
         throw gcnew ::System::ArgumentNullException("_0", "Cannot be null because it is a C++ reference (&).");
     auto &__arg0 = *(::CppSharp::CppParser::AST::CXXConstructExpr*)_0->NativePtr;
     NativePtr = new ::CppSharp::CppParser::AST::CXXConstructExpr(__arg0);
+}
+
+System::Collections::Generic::List<CppSharp::Parser::AST::Expression^>^ CppSharp::Parser::AST::CXXConstructExpr::Arguments::get()
+{
+    auto _tmp__Arguments = gcnew System::Collections::Generic::List<CppSharp::Parser::AST::Expression^>();
+    for(auto _element : ((::CppSharp::CppParser::AST::CXXConstructExpr*)NativePtr)->Arguments)
+    {
+        auto _marshalElement = (_element == nullptr) ? nullptr : gcnew CppSharp::Parser::AST::Expression((::CppSharp::CppParser::AST::Expression*)_element);
+        _tmp__Arguments->Add(_marshalElement);
+    }
+    return _tmp__Arguments;
+}
+
+void CppSharp::Parser::AST::CXXConstructExpr::Arguments::set(System::Collections::Generic::List<CppSharp::Parser::AST::Expression^>^ value)
+{
+    auto _tmpvalue = std::vector<::CppSharp::CppParser::AST::Expression*>();
+    for each(CppSharp::Parser::AST::Expression^ _element in value)
+    {
+        auto _marshalElement = (::CppSharp::CppParser::AST::Expression*)_element->NativePtr;
+        _tmpvalue.push_back(_marshalElement);
+    }
+    ((::CppSharp::CppParser::AST::CXXConstructExpr*)NativePtr)->Arguments = _tmpvalue;
 }
 
 unsigned int CppSharp::Parser::AST::CXXConstructExpr::ArgumentsCount::get()
@@ -3138,6 +3604,36 @@ void CppSharp::Parser::AST::Function::OperatorKind::set(CppSharp::Parser::AST::C
     ((::CppSharp::CppParser::AST::Function*)NativePtr)->operatorKind = (::CppSharp::CppParser::AST::CXXOperatorKind)value;
 }
 
+System::String^ CppSharp::Parser::AST::Function::Mangled::get()
+{
+    return clix::marshalString<clix::E_UTF8>(((::CppSharp::CppParser::AST::Function*)NativePtr)->mangled);
+}
+
+void CppSharp::Parser::AST::Function::Mangled::set(System::String^ value)
+{
+    ((::CppSharp::CppParser::AST::Function*)NativePtr)->mangled = clix::marshalString<clix::E_UTF8>(value);
+}
+
+System::String^ CppSharp::Parser::AST::Function::Signature::get()
+{
+    return clix::marshalString<clix::E_UTF8>(((::CppSharp::CppParser::AST::Function*)NativePtr)->signature);
+}
+
+void CppSharp::Parser::AST::Function::Signature::set(System::String^ value)
+{
+    ((::CppSharp::CppParser::AST::Function*)NativePtr)->signature = clix::marshalString<clix::E_UTF8>(value);
+}
+
+System::String^ CppSharp::Parser::AST::Function::Body::get()
+{
+    return clix::marshalString<clix::E_UTF8>(((::CppSharp::CppParser::AST::Function*)NativePtr)->body);
+}
+
+void CppSharp::Parser::AST::Function::Body::set(System::String^ value)
+{
+    ((::CppSharp::CppParser::AST::Function*)NativePtr)->body = clix::marshalString<clix::E_UTF8>(value);
+}
+
 CppSharp::Parser::AST::CallingConvention CppSharp::Parser::AST::Function::CallingConvention::get()
 {
     return (CppSharp::Parser::AST::CallingConvention)((::CppSharp::CppParser::AST::Function*)NativePtr)->callingConvention;
@@ -3146,6 +3642,28 @@ CppSharp::Parser::AST::CallingConvention CppSharp::Parser::AST::Function::Callin
 void CppSharp::Parser::AST::Function::CallingConvention::set(CppSharp::Parser::AST::CallingConvention value)
 {
     ((::CppSharp::CppParser::AST::Function*)NativePtr)->callingConvention = (::CppSharp::CppParser::AST::CallingConvention)value;
+}
+
+System::Collections::Generic::List<CppSharp::Parser::AST::Parameter^>^ CppSharp::Parser::AST::Function::Parameters::get()
+{
+    auto _tmp__Parameters = gcnew System::Collections::Generic::List<CppSharp::Parser::AST::Parameter^>();
+    for(auto _element : ((::CppSharp::CppParser::AST::Function*)NativePtr)->Parameters)
+    {
+        auto _marshalElement = (_element == nullptr) ? nullptr : gcnew CppSharp::Parser::AST::Parameter((::CppSharp::CppParser::AST::Parameter*)_element);
+        _tmp__Parameters->Add(_marshalElement);
+    }
+    return _tmp__Parameters;
+}
+
+void CppSharp::Parser::AST::Function::Parameters::set(System::Collections::Generic::List<CppSharp::Parser::AST::Parameter^>^ value)
+{
+    auto _tmpvalue = std::vector<::CppSharp::CppParser::AST::Parameter*>();
+    for each(CppSharp::Parser::AST::Parameter^ _element in value)
+    {
+        auto _marshalElement = (::CppSharp::CppParser::AST::Parameter*)_element->NativePtr;
+        _tmpvalue.push_back(_marshalElement);
+    }
+    ((::CppSharp::CppParser::AST::Function*)NativePtr)->Parameters = _tmpvalue;
 }
 
 CppSharp::Parser::AST::FunctionTemplateSpecialization^ CppSharp::Parser::AST::Function::SpecializationInfo::get()
@@ -3176,48 +3694,6 @@ CppSharp::Parser::AST::QualifiedType^ CppSharp::Parser::AST::Function::Qualified
 void CppSharp::Parser::AST::Function::QualifiedType::set(CppSharp::Parser::AST::QualifiedType^ value)
 {
     ((::CppSharp::CppParser::AST::Function*)NativePtr)->qualifiedType = *(::CppSharp::CppParser::AST::QualifiedType*)value->NativePtr;
-}
-
-System::String^ CppSharp::Parser::AST::Function::Mangled::get()
-{
-    auto __ret = ((::CppSharp::CppParser::AST::Function*)NativePtr)->getMangled();
-    if (__ret == nullptr) return nullptr;
-    return (__ret == 0 ? nullptr : clix::marshalString<clix::E_UTF8>(__ret));
-}
-
-void CppSharp::Parser::AST::Function::Mangled::set(System::String^ s)
-{
-    auto ___arg0 = clix::marshalString<clix::E_UTF8>(s);
-    auto __arg0 = ___arg0.c_str();
-    ((::CppSharp::CppParser::AST::Function*)NativePtr)->setMangled(__arg0);
-}
-
-System::String^ CppSharp::Parser::AST::Function::Signature::get()
-{
-    auto __ret = ((::CppSharp::CppParser::AST::Function*)NativePtr)->getSignature();
-    if (__ret == nullptr) return nullptr;
-    return (__ret == 0 ? nullptr : clix::marshalString<clix::E_UTF8>(__ret));
-}
-
-void CppSharp::Parser::AST::Function::Signature::set(System::String^ s)
-{
-    auto ___arg0 = clix::marshalString<clix::E_UTF8>(s);
-    auto __arg0 = ___arg0.c_str();
-    ((::CppSharp::CppParser::AST::Function*)NativePtr)->setSignature(__arg0);
-}
-
-System::String^ CppSharp::Parser::AST::Function::Body::get()
-{
-    auto __ret = ((::CppSharp::CppParser::AST::Function*)NativePtr)->getBody();
-    if (__ret == nullptr) return nullptr;
-    return (__ret == 0 ? nullptr : clix::marshalString<clix::E_UTF8>(__ret));
-}
-
-void CppSharp::Parser::AST::Function::Body::set(System::String^ s)
-{
-    auto ___arg0 = clix::marshalString<clix::E_UTF8>(s);
-    auto __arg0 = ___arg0.c_str();
-    ((::CppSharp::CppParser::AST::Function*)NativePtr)->setBody(__arg0);
 }
 
 unsigned int CppSharp::Parser::AST::Function::ParametersCount::get()
@@ -3410,6 +3886,16 @@ CppSharp::Parser::AST::Enumeration::Item::Item(CppSharp::Parser::AST::Enumeratio
     NativePtr = new ::CppSharp::CppParser::AST::Enumeration::Item(__arg0);
 }
 
+System::String^ CppSharp::Parser::AST::Enumeration::Item::Expression::get()
+{
+    return clix::marshalString<clix::E_UTF8>(((::CppSharp::CppParser::AST::Enumeration::Item*)NativePtr)->expression);
+}
+
+void CppSharp::Parser::AST::Enumeration::Item::Expression::set(System::String^ value)
+{
+    ((::CppSharp::CppParser::AST::Enumeration::Item*)NativePtr)->expression = clix::marshalString<clix::E_UTF8>(value);
+}
+
 unsigned long long CppSharp::Parser::AST::Enumeration::Item::Value::get()
 {
     return ((::CppSharp::CppParser::AST::Enumeration::Item*)NativePtr)->value;
@@ -3418,20 +3904,6 @@ unsigned long long CppSharp::Parser::AST::Enumeration::Item::Value::get()
 void CppSharp::Parser::AST::Enumeration::Item::Value::set(unsigned long long value)
 {
     ((::CppSharp::CppParser::AST::Enumeration::Item*)NativePtr)->value = (::uint64_t)value;
-}
-
-System::String^ CppSharp::Parser::AST::Enumeration::Item::Expression::get()
-{
-    auto __ret = ((::CppSharp::CppParser::AST::Enumeration::Item*)NativePtr)->getExpression();
-    if (__ret == nullptr) return nullptr;
-    return (__ret == 0 ? nullptr : clix::marshalString<clix::E_UTF8>(__ret));
-}
-
-void CppSharp::Parser::AST::Enumeration::Item::Expression::set(System::String^ s)
-{
-    auto ___arg0 = clix::marshalString<clix::E_UTF8>(s);
-    auto __arg0 = ___arg0.c_str();
-    ((::CppSharp::CppParser::AST::Enumeration::Item*)NativePtr)->setExpression(__arg0);
 }
 
 CppSharp::Parser::AST::Enumeration::Enumeration(::CppSharp::CppParser::AST::Enumeration* native)
@@ -3481,6 +3953,14 @@ void CppSharp::Parser::AST::Enumeration::ClearItems()
     ((::CppSharp::CppParser::AST::Enumeration*)NativePtr)->clearItems();
 }
 
+CppSharp::Parser::AST::Enumeration::Item^ CppSharp::Parser::AST::Enumeration::FindItemByName(System::String^ Name)
+{
+    auto __arg0 = clix::marshalString<clix::E_UTF8>(Name);
+    auto __ret = ((::CppSharp::CppParser::AST::Enumeration*)NativePtr)->FindItemByName(__arg0);
+    if (__ret == nullptr) return nullptr;
+    return (__ret == nullptr) ? nullptr : gcnew CppSharp::Parser::AST::Enumeration::Item((::CppSharp::CppParser::AST::Enumeration::Item*)__ret);
+}
+
 CppSharp::Parser::AST::Enumeration::Enumeration(CppSharp::Parser::AST::Enumeration^ _0)
     : CppSharp::Parser::AST::DeclarationContext((::CppSharp::CppParser::AST::DeclarationContext*)nullptr)
 {
@@ -3519,6 +3999,28 @@ CppSharp::Parser::AST::BuiltinType^ CppSharp::Parser::AST::Enumeration::BuiltinT
 void CppSharp::Parser::AST::Enumeration::BuiltinType::set(CppSharp::Parser::AST::BuiltinType^ value)
 {
     ((::CppSharp::CppParser::AST::Enumeration*)NativePtr)->builtinType = (::CppSharp::CppParser::AST::BuiltinType*)value->NativePtr;
+}
+
+System::Collections::Generic::List<CppSharp::Parser::AST::Enumeration::Item^>^ CppSharp::Parser::AST::Enumeration::Items::get()
+{
+    auto _tmp__Items = gcnew System::Collections::Generic::List<CppSharp::Parser::AST::Enumeration::Item^>();
+    for(auto _element : ((::CppSharp::CppParser::AST::Enumeration*)NativePtr)->Items)
+    {
+        auto _marshalElement = (_element == nullptr) ? nullptr : gcnew CppSharp::Parser::AST::Enumeration::Item((::CppSharp::CppParser::AST::Enumeration::Item*)_element);
+        _tmp__Items->Add(_marshalElement);
+    }
+    return _tmp__Items;
+}
+
+void CppSharp::Parser::AST::Enumeration::Items::set(System::Collections::Generic::List<CppSharp::Parser::AST::Enumeration::Item^>^ value)
+{
+    auto _tmpvalue = std::vector<::CppSharp::CppParser::AST::Enumeration::Item*>();
+    for each(CppSharp::Parser::AST::Enumeration::Item^ _element in value)
+    {
+        auto _marshalElement = (::CppSharp::CppParser::AST::Enumeration::Item*)_element->NativePtr;
+        _tmpvalue.push_back(_marshalElement);
+    }
+    ((::CppSharp::CppParser::AST::Enumeration*)NativePtr)->Items = _tmpvalue;
 }
 
 unsigned int CppSharp::Parser::AST::Enumeration::ItemsCount::get()
@@ -3564,6 +4066,16 @@ CppSharp::Parser::AST::Variable::Variable(CppSharp::Parser::AST::Variable^ _0)
     NativePtr = new ::CppSharp::CppParser::AST::Variable(__arg0);
 }
 
+System::String^ CppSharp::Parser::AST::Variable::Mangled::get()
+{
+    return clix::marshalString<clix::E_UTF8>(((::CppSharp::CppParser::AST::Variable*)NativePtr)->mangled);
+}
+
+void CppSharp::Parser::AST::Variable::Mangled::set(System::String^ value)
+{
+    ((::CppSharp::CppParser::AST::Variable*)NativePtr)->mangled = clix::marshalString<clix::E_UTF8>(value);
+}
+
 CppSharp::Parser::AST::QualifiedType^ CppSharp::Parser::AST::Variable::QualifiedType::get()
 {
     return (&((::CppSharp::CppParser::AST::Variable*)NativePtr)->qualifiedType == nullptr) ? nullptr : gcnew CppSharp::Parser::AST::QualifiedType((::CppSharp::CppParser::AST::QualifiedType*)&((::CppSharp::CppParser::AST::Variable*)NativePtr)->qualifiedType);
@@ -3572,20 +4084,6 @@ CppSharp::Parser::AST::QualifiedType^ CppSharp::Parser::AST::Variable::Qualified
 void CppSharp::Parser::AST::Variable::QualifiedType::set(CppSharp::Parser::AST::QualifiedType^ value)
 {
     ((::CppSharp::CppParser::AST::Variable*)NativePtr)->qualifiedType = *(::CppSharp::CppParser::AST::QualifiedType*)value->NativePtr;
-}
-
-System::String^ CppSharp::Parser::AST::Variable::Mangled::get()
-{
-    auto __ret = ((::CppSharp::CppParser::AST::Variable*)NativePtr)->getMangled();
-    if (__ret == nullptr) return nullptr;
-    return (__ret == 0 ? nullptr : clix::marshalString<clix::E_UTF8>(__ret));
-}
-
-void CppSharp::Parser::AST::Variable::Mangled::set(System::String^ s)
-{
-    auto ___arg0 = clix::marshalString<clix::E_UTF8>(s);
-    auto __arg0 = ___arg0.c_str();
-    ((::CppSharp::CppParser::AST::Variable*)NativePtr)->setMangled(__arg0);
 }
 
 CppSharp::Parser::AST::BaseClassSpecifier::BaseClassSpecifier(::CppSharp::CppParser::AST::BaseClassSpecifier* native)
@@ -3900,6 +4398,94 @@ CppSharp::Parser::AST::Class::Class(CppSharp::Parser::AST::Class^ _0)
     NativePtr = new ::CppSharp::CppParser::AST::Class(__arg0);
 }
 
+System::Collections::Generic::List<CppSharp::Parser::AST::BaseClassSpecifier^>^ CppSharp::Parser::AST::Class::Bases::get()
+{
+    auto _tmp__Bases = gcnew System::Collections::Generic::List<CppSharp::Parser::AST::BaseClassSpecifier^>();
+    for(auto _element : ((::CppSharp::CppParser::AST::Class*)NativePtr)->Bases)
+    {
+        auto _marshalElement = (_element == nullptr) ? nullptr : gcnew CppSharp::Parser::AST::BaseClassSpecifier((::CppSharp::CppParser::AST::BaseClassSpecifier*)_element);
+        _tmp__Bases->Add(_marshalElement);
+    }
+    return _tmp__Bases;
+}
+
+void CppSharp::Parser::AST::Class::Bases::set(System::Collections::Generic::List<CppSharp::Parser::AST::BaseClassSpecifier^>^ value)
+{
+    auto _tmpvalue = std::vector<::CppSharp::CppParser::AST::BaseClassSpecifier*>();
+    for each(CppSharp::Parser::AST::BaseClassSpecifier^ _element in value)
+    {
+        auto _marshalElement = (::CppSharp::CppParser::AST::BaseClassSpecifier*)_element->NativePtr;
+        _tmpvalue.push_back(_marshalElement);
+    }
+    ((::CppSharp::CppParser::AST::Class*)NativePtr)->Bases = _tmpvalue;
+}
+
+System::Collections::Generic::List<CppSharp::Parser::AST::Field^>^ CppSharp::Parser::AST::Class::Fields::get()
+{
+    auto _tmp__Fields = gcnew System::Collections::Generic::List<CppSharp::Parser::AST::Field^>();
+    for(auto _element : ((::CppSharp::CppParser::AST::Class*)NativePtr)->Fields)
+    {
+        auto _marshalElement = (_element == nullptr) ? nullptr : gcnew CppSharp::Parser::AST::Field((::CppSharp::CppParser::AST::Field*)_element);
+        _tmp__Fields->Add(_marshalElement);
+    }
+    return _tmp__Fields;
+}
+
+void CppSharp::Parser::AST::Class::Fields::set(System::Collections::Generic::List<CppSharp::Parser::AST::Field^>^ value)
+{
+    auto _tmpvalue = std::vector<::CppSharp::CppParser::AST::Field*>();
+    for each(CppSharp::Parser::AST::Field^ _element in value)
+    {
+        auto _marshalElement = (::CppSharp::CppParser::AST::Field*)_element->NativePtr;
+        _tmpvalue.push_back(_marshalElement);
+    }
+    ((::CppSharp::CppParser::AST::Class*)NativePtr)->Fields = _tmpvalue;
+}
+
+System::Collections::Generic::List<CppSharp::Parser::AST::Method^>^ CppSharp::Parser::AST::Class::Methods::get()
+{
+    auto _tmp__Methods = gcnew System::Collections::Generic::List<CppSharp::Parser::AST::Method^>();
+    for(auto _element : ((::CppSharp::CppParser::AST::Class*)NativePtr)->Methods)
+    {
+        auto _marshalElement = (_element == nullptr) ? nullptr : gcnew CppSharp::Parser::AST::Method((::CppSharp::CppParser::AST::Method*)_element);
+        _tmp__Methods->Add(_marshalElement);
+    }
+    return _tmp__Methods;
+}
+
+void CppSharp::Parser::AST::Class::Methods::set(System::Collections::Generic::List<CppSharp::Parser::AST::Method^>^ value)
+{
+    auto _tmpvalue = std::vector<::CppSharp::CppParser::AST::Method*>();
+    for each(CppSharp::Parser::AST::Method^ _element in value)
+    {
+        auto _marshalElement = (::CppSharp::CppParser::AST::Method*)_element->NativePtr;
+        _tmpvalue.push_back(_marshalElement);
+    }
+    ((::CppSharp::CppParser::AST::Class*)NativePtr)->Methods = _tmpvalue;
+}
+
+System::Collections::Generic::List<CppSharp::Parser::AST::AccessSpecifierDecl^>^ CppSharp::Parser::AST::Class::Specifiers::get()
+{
+    auto _tmp__Specifiers = gcnew System::Collections::Generic::List<CppSharp::Parser::AST::AccessSpecifierDecl^>();
+    for(auto _element : ((::CppSharp::CppParser::AST::Class*)NativePtr)->Specifiers)
+    {
+        auto _marshalElement = (_element == nullptr) ? nullptr : gcnew CppSharp::Parser::AST::AccessSpecifierDecl((::CppSharp::CppParser::AST::AccessSpecifierDecl*)_element);
+        _tmp__Specifiers->Add(_marshalElement);
+    }
+    return _tmp__Specifiers;
+}
+
+void CppSharp::Parser::AST::Class::Specifiers::set(System::Collections::Generic::List<CppSharp::Parser::AST::AccessSpecifierDecl^>^ value)
+{
+    auto _tmpvalue = std::vector<::CppSharp::CppParser::AST::AccessSpecifierDecl*>();
+    for each(CppSharp::Parser::AST::AccessSpecifierDecl^ _element in value)
+    {
+        auto _marshalElement = (::CppSharp::CppParser::AST::AccessSpecifierDecl*)_element->NativePtr;
+        _tmpvalue.push_back(_marshalElement);
+    }
+    ((::CppSharp::CppParser::AST::Class*)NativePtr)->Specifiers = _tmpvalue;
+}
+
 bool CppSharp::Parser::AST::Class::IsPOD::get()
 {
     return ((::CppSharp::CppParser::AST::Class*)NativePtr)->isPOD;
@@ -4115,6 +4701,28 @@ CppSharp::Parser::AST::Declaration^ CppSharp::Parser::AST::Template::TemplatedDe
 void CppSharp::Parser::AST::Template::TemplatedDecl::set(CppSharp::Parser::AST::Declaration^ value)
 {
     ((::CppSharp::CppParser::AST::Template*)NativePtr)->TemplatedDecl = (::CppSharp::CppParser::AST::Declaration*)value->NativePtr;
+}
+
+System::Collections::Generic::List<CppSharp::Parser::AST::Declaration^>^ CppSharp::Parser::AST::Template::Parameters::get()
+{
+    auto _tmp__Parameters = gcnew System::Collections::Generic::List<CppSharp::Parser::AST::Declaration^>();
+    for(auto _element : ((::CppSharp::CppParser::AST::Template*)NativePtr)->Parameters)
+    {
+        auto _marshalElement = (_element == nullptr) ? nullptr : gcnew CppSharp::Parser::AST::Declaration((::CppSharp::CppParser::AST::Declaration*)_element);
+        _tmp__Parameters->Add(_marshalElement);
+    }
+    return _tmp__Parameters;
+}
+
+void CppSharp::Parser::AST::Template::Parameters::set(System::Collections::Generic::List<CppSharp::Parser::AST::Declaration^>^ value)
+{
+    auto _tmpvalue = std::vector<::CppSharp::CppParser::AST::Declaration*>();
+    for each(CppSharp::Parser::AST::Declaration^ _element in value)
+    {
+        auto _marshalElement = (::CppSharp::CppParser::AST::Declaration*)_element->NativePtr;
+        _tmpvalue.push_back(_marshalElement);
+    }
+    ((::CppSharp::CppParser::AST::Template*)NativePtr)->Parameters = _tmpvalue;
 }
 
 unsigned int CppSharp::Parser::AST::Template::ParametersCount::get()
@@ -4474,6 +5082,22 @@ void CppSharp::Parser::AST::ClassTemplate::ClearSpecializations()
     ((::CppSharp::CppParser::AST::ClassTemplate*)NativePtr)->clearSpecializations();
 }
 
+CppSharp::Parser::AST::ClassTemplateSpecialization^ CppSharp::Parser::AST::ClassTemplate::FindSpecialization(System::String^ usr)
+{
+    auto __arg0 = clix::marshalString<clix::E_UTF8>(usr);
+    auto __ret = ((::CppSharp::CppParser::AST::ClassTemplate*)NativePtr)->FindSpecialization(__arg0);
+    if (__ret == nullptr) return nullptr;
+    return (__ret == nullptr) ? nullptr : gcnew CppSharp::Parser::AST::ClassTemplateSpecialization((::CppSharp::CppParser::AST::ClassTemplateSpecialization*)__ret);
+}
+
+CppSharp::Parser::AST::ClassTemplatePartialSpecialization^ CppSharp::Parser::AST::ClassTemplate::FindPartialSpecialization(System::String^ usr)
+{
+    auto __arg0 = clix::marshalString<clix::E_UTF8>(usr);
+    auto __ret = ((::CppSharp::CppParser::AST::ClassTemplate*)NativePtr)->FindPartialSpecialization(__arg0);
+    if (__ret == nullptr) return nullptr;
+    return (__ret == nullptr) ? nullptr : gcnew CppSharp::Parser::AST::ClassTemplatePartialSpecialization((::CppSharp::CppParser::AST::ClassTemplatePartialSpecialization*)__ret);
+}
+
 CppSharp::Parser::AST::ClassTemplate::ClassTemplate(CppSharp::Parser::AST::ClassTemplate^ _0)
     : CppSharp::Parser::AST::Template((::CppSharp::CppParser::AST::Template*)nullptr)
 {
@@ -4482,6 +5106,28 @@ CppSharp::Parser::AST::ClassTemplate::ClassTemplate(CppSharp::Parser::AST::Class
         throw gcnew ::System::ArgumentNullException("_0", "Cannot be null because it is a C++ reference (&).");
     auto &__arg0 = *(::CppSharp::CppParser::AST::ClassTemplate*)_0->NativePtr;
     NativePtr = new ::CppSharp::CppParser::AST::ClassTemplate(__arg0);
+}
+
+System::Collections::Generic::List<CppSharp::Parser::AST::ClassTemplateSpecialization^>^ CppSharp::Parser::AST::ClassTemplate::Specializations::get()
+{
+    auto _tmp__Specializations = gcnew System::Collections::Generic::List<CppSharp::Parser::AST::ClassTemplateSpecialization^>();
+    for(auto _element : ((::CppSharp::CppParser::AST::ClassTemplate*)NativePtr)->Specializations)
+    {
+        auto _marshalElement = (_element == nullptr) ? nullptr : gcnew CppSharp::Parser::AST::ClassTemplateSpecialization((::CppSharp::CppParser::AST::ClassTemplateSpecialization*)_element);
+        _tmp__Specializations->Add(_marshalElement);
+    }
+    return _tmp__Specializations;
+}
+
+void CppSharp::Parser::AST::ClassTemplate::Specializations::set(System::Collections::Generic::List<CppSharp::Parser::AST::ClassTemplateSpecialization^>^ value)
+{
+    auto _tmpvalue = std::vector<::CppSharp::CppParser::AST::ClassTemplateSpecialization*>();
+    for each(CppSharp::Parser::AST::ClassTemplateSpecialization^ _element in value)
+    {
+        auto _marshalElement = (::CppSharp::CppParser::AST::ClassTemplateSpecialization*)_element->NativePtr;
+        _tmpvalue.push_back(_marshalElement);
+    }
+    ((::CppSharp::CppParser::AST::ClassTemplate*)NativePtr)->Specializations = _tmpvalue;
 }
 
 unsigned int CppSharp::Parser::AST::ClassTemplate::SpecializationsCount::get()
@@ -4555,6 +5201,29 @@ CppSharp::Parser::AST::ClassTemplate^ CppSharp::Parser::AST::ClassTemplateSpecia
 void CppSharp::Parser::AST::ClassTemplateSpecialization::TemplatedDecl::set(CppSharp::Parser::AST::ClassTemplate^ value)
 {
     ((::CppSharp::CppParser::AST::ClassTemplateSpecialization*)NativePtr)->templatedDecl = (::CppSharp::CppParser::AST::ClassTemplate*)value->NativePtr;
+}
+
+System::Collections::Generic::List<CppSharp::Parser::AST::TemplateArgument^>^ CppSharp::Parser::AST::ClassTemplateSpecialization::Arguments::get()
+{
+    auto _tmp__Arguments = gcnew System::Collections::Generic::List<CppSharp::Parser::AST::TemplateArgument^>();
+    for(auto _element : ((::CppSharp::CppParser::AST::ClassTemplateSpecialization*)NativePtr)->Arguments)
+    {
+        auto ___element = new ::CppSharp::CppParser::AST::TemplateArgument(_element);
+        auto _marshalElement = (___element == nullptr) ? nullptr : gcnew CppSharp::Parser::AST::TemplateArgument((::CppSharp::CppParser::AST::TemplateArgument*)___element);
+        _tmp__Arguments->Add(_marshalElement);
+    }
+    return _tmp__Arguments;
+}
+
+void CppSharp::Parser::AST::ClassTemplateSpecialization::Arguments::set(System::Collections::Generic::List<CppSharp::Parser::AST::TemplateArgument^>^ value)
+{
+    auto _tmpvalue = std::vector<::CppSharp::CppParser::AST::TemplateArgument>();
+    for each(CppSharp::Parser::AST::TemplateArgument^ _element in value)
+    {
+        auto _marshalElement = *(::CppSharp::CppParser::AST::TemplateArgument*)_element->NativePtr;
+        _tmpvalue.push_back(_marshalElement);
+    }
+    ((::CppSharp::CppParser::AST::ClassTemplateSpecialization*)NativePtr)->Arguments = _tmpvalue;
 }
 
 CppSharp::Parser::AST::TemplateSpecializationKind CppSharp::Parser::AST::ClassTemplateSpecialization::SpecializationKind::get()
@@ -4657,6 +5326,14 @@ void CppSharp::Parser::AST::FunctionTemplate::ClearSpecializations()
     ((::CppSharp::CppParser::AST::FunctionTemplate*)NativePtr)->clearSpecializations();
 }
 
+CppSharp::Parser::AST::FunctionTemplateSpecialization^ CppSharp::Parser::AST::FunctionTemplate::FindSpecialization(System::String^ usr)
+{
+    auto __arg0 = clix::marshalString<clix::E_UTF8>(usr);
+    auto __ret = ((::CppSharp::CppParser::AST::FunctionTemplate*)NativePtr)->FindSpecialization(__arg0);
+    if (__ret == nullptr) return nullptr;
+    return (__ret == nullptr) ? nullptr : gcnew CppSharp::Parser::AST::FunctionTemplateSpecialization((::CppSharp::CppParser::AST::FunctionTemplateSpecialization*)__ret);
+}
+
 CppSharp::Parser::AST::FunctionTemplate::FunctionTemplate(CppSharp::Parser::AST::FunctionTemplate^ _0)
     : CppSharp::Parser::AST::Template((::CppSharp::CppParser::AST::Template*)nullptr)
 {
@@ -4665,6 +5342,28 @@ CppSharp::Parser::AST::FunctionTemplate::FunctionTemplate(CppSharp::Parser::AST:
         throw gcnew ::System::ArgumentNullException("_0", "Cannot be null because it is a C++ reference (&).");
     auto &__arg0 = *(::CppSharp::CppParser::AST::FunctionTemplate*)_0->NativePtr;
     NativePtr = new ::CppSharp::CppParser::AST::FunctionTemplate(__arg0);
+}
+
+System::Collections::Generic::List<CppSharp::Parser::AST::FunctionTemplateSpecialization^>^ CppSharp::Parser::AST::FunctionTemplate::Specializations::get()
+{
+    auto _tmp__Specializations = gcnew System::Collections::Generic::List<CppSharp::Parser::AST::FunctionTemplateSpecialization^>();
+    for(auto _element : ((::CppSharp::CppParser::AST::FunctionTemplate*)NativePtr)->Specializations)
+    {
+        auto _marshalElement = (_element == nullptr) ? nullptr : gcnew CppSharp::Parser::AST::FunctionTemplateSpecialization((::CppSharp::CppParser::AST::FunctionTemplateSpecialization*)_element);
+        _tmp__Specializations->Add(_marshalElement);
+    }
+    return _tmp__Specializations;
+}
+
+void CppSharp::Parser::AST::FunctionTemplate::Specializations::set(System::Collections::Generic::List<CppSharp::Parser::AST::FunctionTemplateSpecialization^>^ value)
+{
+    auto _tmpvalue = std::vector<::CppSharp::CppParser::AST::FunctionTemplateSpecialization*>();
+    for each(CppSharp::Parser::AST::FunctionTemplateSpecialization^ _element in value)
+    {
+        auto _marshalElement = (::CppSharp::CppParser::AST::FunctionTemplateSpecialization*)_element->NativePtr;
+        _tmpvalue.push_back(_marshalElement);
+    }
+    ((::CppSharp::CppParser::AST::FunctionTemplate*)NativePtr)->Specializations = _tmpvalue;
 }
 
 unsigned int CppSharp::Parser::AST::FunctionTemplate::SpecializationsCount::get()
@@ -4744,6 +5443,29 @@ void CppSharp::Parser::AST::FunctionTemplateSpecialization::Template::set(CppSha
     ((::CppSharp::CppParser::AST::FunctionTemplateSpecialization*)NativePtr)->_template = (::CppSharp::CppParser::AST::FunctionTemplate*)value->NativePtr;
 }
 
+System::Collections::Generic::List<CppSharp::Parser::AST::TemplateArgument^>^ CppSharp::Parser::AST::FunctionTemplateSpecialization::Arguments::get()
+{
+    auto _tmp__Arguments = gcnew System::Collections::Generic::List<CppSharp::Parser::AST::TemplateArgument^>();
+    for(auto _element : ((::CppSharp::CppParser::AST::FunctionTemplateSpecialization*)NativePtr)->Arguments)
+    {
+        auto ___element = new ::CppSharp::CppParser::AST::TemplateArgument(_element);
+        auto _marshalElement = (___element == nullptr) ? nullptr : gcnew CppSharp::Parser::AST::TemplateArgument((::CppSharp::CppParser::AST::TemplateArgument*)___element);
+        _tmp__Arguments->Add(_marshalElement);
+    }
+    return _tmp__Arguments;
+}
+
+void CppSharp::Parser::AST::FunctionTemplateSpecialization::Arguments::set(System::Collections::Generic::List<CppSharp::Parser::AST::TemplateArgument^>^ value)
+{
+    auto _tmpvalue = std::vector<::CppSharp::CppParser::AST::TemplateArgument>();
+    for each(CppSharp::Parser::AST::TemplateArgument^ _element in value)
+    {
+        auto _marshalElement = *(::CppSharp::CppParser::AST::TemplateArgument*)_element->NativePtr;
+        _tmpvalue.push_back(_marshalElement);
+    }
+    ((::CppSharp::CppParser::AST::FunctionTemplateSpecialization*)NativePtr)->Arguments = _tmpvalue;
+}
+
 CppSharp::Parser::AST::Function^ CppSharp::Parser::AST::FunctionTemplateSpecialization::SpecializedFunction::get()
 {
     return (((::CppSharp::CppParser::AST::FunctionTemplateSpecialization*)NativePtr)->specializedFunction == nullptr) ? nullptr : gcnew CppSharp::Parser::AST::Function((::CppSharp::CppParser::AST::Function*)((::CppSharp::CppParser::AST::FunctionTemplateSpecialization*)NativePtr)->specializedFunction);
@@ -4817,6 +5539,22 @@ void CppSharp::Parser::AST::VarTemplate::ClearSpecializations()
     ((::CppSharp::CppParser::AST::VarTemplate*)NativePtr)->clearSpecializations();
 }
 
+CppSharp::Parser::AST::VarTemplateSpecialization^ CppSharp::Parser::AST::VarTemplate::FindSpecialization(System::String^ usr)
+{
+    auto __arg0 = clix::marshalString<clix::E_UTF8>(usr);
+    auto __ret = ((::CppSharp::CppParser::AST::VarTemplate*)NativePtr)->FindSpecialization(__arg0);
+    if (__ret == nullptr) return nullptr;
+    return (__ret == nullptr) ? nullptr : gcnew CppSharp::Parser::AST::VarTemplateSpecialization((::CppSharp::CppParser::AST::VarTemplateSpecialization*)__ret);
+}
+
+CppSharp::Parser::AST::VarTemplatePartialSpecialization^ CppSharp::Parser::AST::VarTemplate::FindPartialSpecialization(System::String^ usr)
+{
+    auto __arg0 = clix::marshalString<clix::E_UTF8>(usr);
+    auto __ret = ((::CppSharp::CppParser::AST::VarTemplate*)NativePtr)->FindPartialSpecialization(__arg0);
+    if (__ret == nullptr) return nullptr;
+    return (__ret == nullptr) ? nullptr : gcnew CppSharp::Parser::AST::VarTemplatePartialSpecialization((::CppSharp::CppParser::AST::VarTemplatePartialSpecialization*)__ret);
+}
+
 CppSharp::Parser::AST::VarTemplate::VarTemplate(CppSharp::Parser::AST::VarTemplate^ _0)
     : CppSharp::Parser::AST::Template((::CppSharp::CppParser::AST::Template*)nullptr)
 {
@@ -4825,6 +5563,28 @@ CppSharp::Parser::AST::VarTemplate::VarTemplate(CppSharp::Parser::AST::VarTempla
         throw gcnew ::System::ArgumentNullException("_0", "Cannot be null because it is a C++ reference (&).");
     auto &__arg0 = *(::CppSharp::CppParser::AST::VarTemplate*)_0->NativePtr;
     NativePtr = new ::CppSharp::CppParser::AST::VarTemplate(__arg0);
+}
+
+System::Collections::Generic::List<CppSharp::Parser::AST::VarTemplateSpecialization^>^ CppSharp::Parser::AST::VarTemplate::Specializations::get()
+{
+    auto _tmp__Specializations = gcnew System::Collections::Generic::List<CppSharp::Parser::AST::VarTemplateSpecialization^>();
+    for(auto _element : ((::CppSharp::CppParser::AST::VarTemplate*)NativePtr)->Specializations)
+    {
+        auto _marshalElement = (_element == nullptr) ? nullptr : gcnew CppSharp::Parser::AST::VarTemplateSpecialization((::CppSharp::CppParser::AST::VarTemplateSpecialization*)_element);
+        _tmp__Specializations->Add(_marshalElement);
+    }
+    return _tmp__Specializations;
+}
+
+void CppSharp::Parser::AST::VarTemplate::Specializations::set(System::Collections::Generic::List<CppSharp::Parser::AST::VarTemplateSpecialization^>^ value)
+{
+    auto _tmpvalue = std::vector<::CppSharp::CppParser::AST::VarTemplateSpecialization*>();
+    for each(CppSharp::Parser::AST::VarTemplateSpecialization^ _element in value)
+    {
+        auto _marshalElement = (::CppSharp::CppParser::AST::VarTemplateSpecialization*)_element->NativePtr;
+        _tmpvalue.push_back(_marshalElement);
+    }
+    ((::CppSharp::CppParser::AST::VarTemplate*)NativePtr)->Specializations = _tmpvalue;
 }
 
 unsigned int CppSharp::Parser::AST::VarTemplate::SpecializationsCount::get()
@@ -4898,6 +5658,29 @@ CppSharp::Parser::AST::VarTemplate^ CppSharp::Parser::AST::VarTemplateSpecializa
 void CppSharp::Parser::AST::VarTemplateSpecialization::TemplatedDecl::set(CppSharp::Parser::AST::VarTemplate^ value)
 {
     ((::CppSharp::CppParser::AST::VarTemplateSpecialization*)NativePtr)->templatedDecl = (::CppSharp::CppParser::AST::VarTemplate*)value->NativePtr;
+}
+
+System::Collections::Generic::List<CppSharp::Parser::AST::TemplateArgument^>^ CppSharp::Parser::AST::VarTemplateSpecialization::Arguments::get()
+{
+    auto _tmp__Arguments = gcnew System::Collections::Generic::List<CppSharp::Parser::AST::TemplateArgument^>();
+    for(auto _element : ((::CppSharp::CppParser::AST::VarTemplateSpecialization*)NativePtr)->Arguments)
+    {
+        auto ___element = new ::CppSharp::CppParser::AST::TemplateArgument(_element);
+        auto _marshalElement = (___element == nullptr) ? nullptr : gcnew CppSharp::Parser::AST::TemplateArgument((::CppSharp::CppParser::AST::TemplateArgument*)___element);
+        _tmp__Arguments->Add(_marshalElement);
+    }
+    return _tmp__Arguments;
+}
+
+void CppSharp::Parser::AST::VarTemplateSpecialization::Arguments::set(System::Collections::Generic::List<CppSharp::Parser::AST::TemplateArgument^>^ value)
+{
+    auto _tmpvalue = std::vector<::CppSharp::CppParser::AST::TemplateArgument>();
+    for each(CppSharp::Parser::AST::TemplateArgument^ _element in value)
+    {
+        auto _marshalElement = *(::CppSharp::CppParser::AST::TemplateArgument*)_element->NativePtr;
+        _tmpvalue.push_back(_marshalElement);
+    }
+    ((::CppSharp::CppParser::AST::VarTemplateSpecialization*)NativePtr)->Arguments = _tmpvalue;
 }
 
 CppSharp::Parser::AST::TemplateSpecializationKind CppSharp::Parser::AST::VarTemplateSpecialization::SpecializationKind::get()
@@ -5108,6 +5891,26 @@ CppSharp::Parser::AST::MacroDefinition::MacroDefinition(CppSharp::Parser::AST::M
     NativePtr = new ::CppSharp::CppParser::AST::MacroDefinition(__arg0);
 }
 
+System::String^ CppSharp::Parser::AST::MacroDefinition::Name::get()
+{
+    return clix::marshalString<clix::E_UTF8>(((::CppSharp::CppParser::AST::MacroDefinition*)NativePtr)->name);
+}
+
+void CppSharp::Parser::AST::MacroDefinition::Name::set(System::String^ value)
+{
+    ((::CppSharp::CppParser::AST::MacroDefinition*)NativePtr)->name = clix::marshalString<clix::E_UTF8>(value);
+}
+
+System::String^ CppSharp::Parser::AST::MacroDefinition::Expression::get()
+{
+    return clix::marshalString<clix::E_UTF8>(((::CppSharp::CppParser::AST::MacroDefinition*)NativePtr)->expression);
+}
+
+void CppSharp::Parser::AST::MacroDefinition::Expression::set(System::String^ value)
+{
+    ((::CppSharp::CppParser::AST::MacroDefinition*)NativePtr)->expression = clix::marshalString<clix::E_UTF8>(value);
+}
+
 int CppSharp::Parser::AST::MacroDefinition::LineNumberStart::get()
 {
     return ((::CppSharp::CppParser::AST::MacroDefinition*)NativePtr)->lineNumberStart;
@@ -5126,34 +5929,6 @@ int CppSharp::Parser::AST::MacroDefinition::LineNumberEnd::get()
 void CppSharp::Parser::AST::MacroDefinition::LineNumberEnd::set(int value)
 {
     ((::CppSharp::CppParser::AST::MacroDefinition*)NativePtr)->lineNumberEnd = value;
-}
-
-System::String^ CppSharp::Parser::AST::MacroDefinition::Name::get()
-{
-    auto __ret = ((::CppSharp::CppParser::AST::MacroDefinition*)NativePtr)->getName();
-    if (__ret == nullptr) return nullptr;
-    return (__ret == 0 ? nullptr : clix::marshalString<clix::E_UTF8>(__ret));
-}
-
-void CppSharp::Parser::AST::MacroDefinition::Name::set(System::String^ s)
-{
-    auto ___arg0 = clix::marshalString<clix::E_UTF8>(s);
-    auto __arg0 = ___arg0.c_str();
-    ((::CppSharp::CppParser::AST::MacroDefinition*)NativePtr)->setName(__arg0);
-}
-
-System::String^ CppSharp::Parser::AST::MacroDefinition::Expression::get()
-{
-    auto __ret = ((::CppSharp::CppParser::AST::MacroDefinition*)NativePtr)->getExpression();
-    if (__ret == nullptr) return nullptr;
-    return (__ret == 0 ? nullptr : clix::marshalString<clix::E_UTF8>(__ret));
-}
-
-void CppSharp::Parser::AST::MacroDefinition::Expression::set(System::String^ s)
-{
-    auto ___arg0 = clix::marshalString<clix::E_UTF8>(s);
-    auto __arg0 = ___arg0.c_str();
-    ((::CppSharp::CppParser::AST::MacroDefinition*)NativePtr)->setExpression(__arg0);
 }
 
 CppSharp::Parser::AST::MacroExpansion::MacroExpansion(::CppSharp::CppParser::AST::MacroExpansion* native)
@@ -5193,6 +5968,26 @@ CppSharp::Parser::AST::MacroExpansion::MacroExpansion(CppSharp::Parser::AST::Mac
     NativePtr = new ::CppSharp::CppParser::AST::MacroExpansion(__arg0);
 }
 
+System::String^ CppSharp::Parser::AST::MacroExpansion::Name::get()
+{
+    return clix::marshalString<clix::E_UTF8>(((::CppSharp::CppParser::AST::MacroExpansion*)NativePtr)->name);
+}
+
+void CppSharp::Parser::AST::MacroExpansion::Name::set(System::String^ value)
+{
+    ((::CppSharp::CppParser::AST::MacroExpansion*)NativePtr)->name = clix::marshalString<clix::E_UTF8>(value);
+}
+
+System::String^ CppSharp::Parser::AST::MacroExpansion::Text::get()
+{
+    return clix::marshalString<clix::E_UTF8>(((::CppSharp::CppParser::AST::MacroExpansion*)NativePtr)->text);
+}
+
+void CppSharp::Parser::AST::MacroExpansion::Text::set(System::String^ value)
+{
+    ((::CppSharp::CppParser::AST::MacroExpansion*)NativePtr)->text = clix::marshalString<clix::E_UTF8>(value);
+}
+
 CppSharp::Parser::AST::MacroDefinition^ CppSharp::Parser::AST::MacroExpansion::Definition::get()
 {
     return (((::CppSharp::CppParser::AST::MacroExpansion*)NativePtr)->definition == nullptr) ? nullptr : gcnew CppSharp::Parser::AST::MacroDefinition((::CppSharp::CppParser::AST::MacroDefinition*)((::CppSharp::CppParser::AST::MacroExpansion*)NativePtr)->definition);
@@ -5201,34 +5996,6 @@ CppSharp::Parser::AST::MacroDefinition^ CppSharp::Parser::AST::MacroExpansion::D
 void CppSharp::Parser::AST::MacroExpansion::Definition::set(CppSharp::Parser::AST::MacroDefinition^ value)
 {
     ((::CppSharp::CppParser::AST::MacroExpansion*)NativePtr)->definition = (::CppSharp::CppParser::AST::MacroDefinition*)value->NativePtr;
-}
-
-System::String^ CppSharp::Parser::AST::MacroExpansion::Name::get()
-{
-    auto __ret = ((::CppSharp::CppParser::AST::MacroExpansion*)NativePtr)->getName();
-    if (__ret == nullptr) return nullptr;
-    return (__ret == 0 ? nullptr : clix::marshalString<clix::E_UTF8>(__ret));
-}
-
-void CppSharp::Parser::AST::MacroExpansion::Name::set(System::String^ s)
-{
-    auto ___arg0 = clix::marshalString<clix::E_UTF8>(s);
-    auto __arg0 = ___arg0.c_str();
-    ((::CppSharp::CppParser::AST::MacroExpansion*)NativePtr)->setName(__arg0);
-}
-
-System::String^ CppSharp::Parser::AST::MacroExpansion::Text::get()
-{
-    auto __ret = ((::CppSharp::CppParser::AST::MacroExpansion*)NativePtr)->getText();
-    if (__ret == nullptr) return nullptr;
-    return (__ret == 0 ? nullptr : clix::marshalString<clix::E_UTF8>(__ret));
-}
-
-void CppSharp::Parser::AST::MacroExpansion::Text::set(System::String^ s)
-{
-    auto ___arg0 = clix::marshalString<clix::E_UTF8>(s);
-    auto __arg0 = ___arg0.c_str();
-    ((::CppSharp::CppParser::AST::MacroExpansion*)NativePtr)->setText(__arg0);
 }
 
 CppSharp::Parser::AST::TranslationUnit::TranslationUnit(::CppSharp::CppParser::AST::TranslationUnit* native)
@@ -5288,6 +6055,16 @@ CppSharp::Parser::AST::TranslationUnit::TranslationUnit(CppSharp::Parser::AST::T
     NativePtr = new ::CppSharp::CppParser::AST::TranslationUnit(__arg0);
 }
 
+System::String^ CppSharp::Parser::AST::TranslationUnit::FileName::get()
+{
+    return clix::marshalString<clix::E_UTF8>(((::CppSharp::CppParser::AST::TranslationUnit*)NativePtr)->fileName);
+}
+
+void CppSharp::Parser::AST::TranslationUnit::FileName::set(System::String^ value)
+{
+    ((::CppSharp::CppParser::AST::TranslationUnit*)NativePtr)->fileName = clix::marshalString<clix::E_UTF8>(value);
+}
+
 bool CppSharp::Parser::AST::TranslationUnit::IsSystemHeader::get()
 {
     return ((::CppSharp::CppParser::AST::TranslationUnit*)NativePtr)->isSystemHeader;
@@ -5298,18 +6075,26 @@ void CppSharp::Parser::AST::TranslationUnit::IsSystemHeader::set(bool value)
     ((::CppSharp::CppParser::AST::TranslationUnit*)NativePtr)->isSystemHeader = value;
 }
 
-System::String^ CppSharp::Parser::AST::TranslationUnit::FileName::get()
+System::Collections::Generic::List<CppSharp::Parser::AST::MacroDefinition^>^ CppSharp::Parser::AST::TranslationUnit::Macros::get()
 {
-    auto __ret = ((::CppSharp::CppParser::AST::TranslationUnit*)NativePtr)->getFileName();
-    if (__ret == nullptr) return nullptr;
-    return (__ret == 0 ? nullptr : clix::marshalString<clix::E_UTF8>(__ret));
+    auto _tmp__Macros = gcnew System::Collections::Generic::List<CppSharp::Parser::AST::MacroDefinition^>();
+    for(auto _element : ((::CppSharp::CppParser::AST::TranslationUnit*)NativePtr)->Macros)
+    {
+        auto _marshalElement = (_element == nullptr) ? nullptr : gcnew CppSharp::Parser::AST::MacroDefinition((::CppSharp::CppParser::AST::MacroDefinition*)_element);
+        _tmp__Macros->Add(_marshalElement);
+    }
+    return _tmp__Macros;
 }
 
-void CppSharp::Parser::AST::TranslationUnit::FileName::set(System::String^ s)
+void CppSharp::Parser::AST::TranslationUnit::Macros::set(System::Collections::Generic::List<CppSharp::Parser::AST::MacroDefinition^>^ value)
 {
-    auto ___arg0 = clix::marshalString<clix::E_UTF8>(s);
-    auto __arg0 = ___arg0.c_str();
-    ((::CppSharp::CppParser::AST::TranslationUnit*)NativePtr)->setFileName(__arg0);
+    auto _tmpvalue = std::vector<::CppSharp::CppParser::AST::MacroDefinition*>();
+    for each(CppSharp::Parser::AST::MacroDefinition^ _element in value)
+    {
+        auto _marshalElement = (::CppSharp::CppParser::AST::MacroDefinition*)_element->NativePtr;
+        _tmpvalue.push_back(_marshalElement);
+    }
+    ((::CppSharp::CppParser::AST::TranslationUnit*)NativePtr)->Macros = _tmpvalue;
 }
 
 unsigned int CppSharp::Parser::AST::TranslationUnit::MacrosCount::get()
@@ -5397,6 +6182,16 @@ void CppSharp::Parser::AST::NativeLibrary::__Instance::set(System::IntPtr object
     NativePtr = (::CppSharp::CppParser::AST::NativeLibrary*)object.ToPointer();
 }
 
+System::String^ CppSharp::Parser::AST::NativeLibrary::FileName::get()
+{
+    return clix::marshalString<clix::E_UTF8>(((::CppSharp::CppParser::AST::NativeLibrary*)NativePtr)->fileName);
+}
+
+void CppSharp::Parser::AST::NativeLibrary::FileName::set(System::String^ value)
+{
+    ((::CppSharp::CppParser::AST::NativeLibrary*)NativePtr)->fileName = clix::marshalString<clix::E_UTF8>(value);
+}
+
 CppSharp::Parser::AST::ArchType CppSharp::Parser::AST::NativeLibrary::ArchType::get()
 {
     return (CppSharp::Parser::AST::ArchType)((::CppSharp::CppParser::AST::NativeLibrary*)NativePtr)->archType;
@@ -5407,18 +6202,48 @@ void CppSharp::Parser::AST::NativeLibrary::ArchType::set(CppSharp::Parser::AST::
     ((::CppSharp::CppParser::AST::NativeLibrary*)NativePtr)->archType = (::CppSharp::CppParser::AST::ArchType)value;
 }
 
-System::String^ CppSharp::Parser::AST::NativeLibrary::FileName::get()
+System::Collections::Generic::List<System::String^>^ CppSharp::Parser::AST::NativeLibrary::Symbols::get()
 {
-    auto __ret = ((::CppSharp::CppParser::AST::NativeLibrary*)NativePtr)->getFileName();
-    if (__ret == nullptr) return nullptr;
-    return (__ret == 0 ? nullptr : clix::marshalString<clix::E_UTF8>(__ret));
+    auto _tmp__Symbols = gcnew System::Collections::Generic::List<System::String^>();
+    for(auto _element : ((::CppSharp::CppParser::AST::NativeLibrary*)NativePtr)->Symbols)
+    {
+        auto _marshalElement = clix::marshalString<clix::E_UTF8>(_element);
+        _tmp__Symbols->Add(_marshalElement);
+    }
+    return _tmp__Symbols;
 }
 
-void CppSharp::Parser::AST::NativeLibrary::FileName::set(System::String^ s)
+void CppSharp::Parser::AST::NativeLibrary::Symbols::set(System::Collections::Generic::List<System::String^>^ value)
 {
-    auto ___arg0 = clix::marshalString<clix::E_UTF8>(s);
-    auto __arg0 = ___arg0.c_str();
-    ((::CppSharp::CppParser::AST::NativeLibrary*)NativePtr)->setFileName(__arg0);
+    auto _tmpvalue = std::vector<::std::string>();
+    for each(System::String^ _element in value)
+    {
+        auto _marshalElement = clix::marshalString<clix::E_UTF8>(_element);
+        _tmpvalue.push_back(_marshalElement);
+    }
+    ((::CppSharp::CppParser::AST::NativeLibrary*)NativePtr)->Symbols = _tmpvalue;
+}
+
+System::Collections::Generic::List<System::String^>^ CppSharp::Parser::AST::NativeLibrary::Dependencies::get()
+{
+    auto _tmp__Dependencies = gcnew System::Collections::Generic::List<System::String^>();
+    for(auto _element : ((::CppSharp::CppParser::AST::NativeLibrary*)NativePtr)->Dependencies)
+    {
+        auto _marshalElement = clix::marshalString<clix::E_UTF8>(_element);
+        _tmp__Dependencies->Add(_marshalElement);
+    }
+    return _tmp__Dependencies;
+}
+
+void CppSharp::Parser::AST::NativeLibrary::Dependencies::set(System::Collections::Generic::List<System::String^>^ value)
+{
+    auto _tmpvalue = std::vector<::std::string>();
+    for each(System::String^ _element in value)
+    {
+        auto _marshalElement = clix::marshalString<clix::E_UTF8>(_element);
+        _tmpvalue.push_back(_marshalElement);
+    }
+    ((::CppSharp::CppParser::AST::NativeLibrary*)NativePtr)->Dependencies = _tmpvalue;
 }
 
 unsigned int CppSharp::Parser::AST::NativeLibrary::SymbolsCount::get()
@@ -5453,6 +6278,14 @@ CppSharp::Parser::AST::ASTContext::ASTContext()
 {
     __ownsNativeInstance = true;
     NativePtr = new ::CppSharp::CppParser::AST::ASTContext();
+}
+
+CppSharp::Parser::AST::TranslationUnit^ CppSharp::Parser::AST::ASTContext::FindOrCreateModule(System::String^ File)
+{
+    auto __arg0 = clix::marshalString<clix::E_UTF8>(File);
+    auto __ret = ((::CppSharp::CppParser::AST::ASTContext*)NativePtr)->FindOrCreateModule(__arg0);
+    if (__ret == nullptr) return nullptr;
+    return (__ret == nullptr) ? nullptr : gcnew CppSharp::Parser::AST::TranslationUnit((::CppSharp::CppParser::AST::TranslationUnit*)__ret);
 }
 
 CppSharp::Parser::AST::TranslationUnit^ CppSharp::Parser::AST::ASTContext::GetTranslationUnits(unsigned int i)
@@ -5492,6 +6325,28 @@ System::IntPtr CppSharp::Parser::AST::ASTContext::__Instance::get()
 void CppSharp::Parser::AST::ASTContext::__Instance::set(System::IntPtr object)
 {
     NativePtr = (::CppSharp::CppParser::AST::ASTContext*)object.ToPointer();
+}
+
+System::Collections::Generic::List<CppSharp::Parser::AST::TranslationUnit^>^ CppSharp::Parser::AST::ASTContext::TranslationUnits::get()
+{
+    auto _tmp__TranslationUnits = gcnew System::Collections::Generic::List<CppSharp::Parser::AST::TranslationUnit^>();
+    for(auto _element : ((::CppSharp::CppParser::AST::ASTContext*)NativePtr)->TranslationUnits)
+    {
+        auto _marshalElement = (_element == nullptr) ? nullptr : gcnew CppSharp::Parser::AST::TranslationUnit((::CppSharp::CppParser::AST::TranslationUnit*)_element);
+        _tmp__TranslationUnits->Add(_marshalElement);
+    }
+    return _tmp__TranslationUnits;
+}
+
+void CppSharp::Parser::AST::ASTContext::TranslationUnits::set(System::Collections::Generic::List<CppSharp::Parser::AST::TranslationUnit^>^ value)
+{
+    auto _tmpvalue = std::vector<::CppSharp::CppParser::AST::TranslationUnit*>();
+    for each(CppSharp::Parser::AST::TranslationUnit^ _element in value)
+    {
+        auto _marshalElement = (::CppSharp::CppParser::AST::TranslationUnit*)_element->NativePtr;
+        _tmpvalue.push_back(_marshalElement);
+    }
+    ((::CppSharp::CppParser::AST::ASTContext*)NativePtr)->TranslationUnits = _tmpvalue;
 }
 
 unsigned int CppSharp::Parser::AST::ASTContext::TranslationUnitsCount::get()
@@ -5664,6 +6519,28 @@ CppSharp::Parser::AST::FullComment::FullComment(CppSharp::Parser::AST::FullComme
     NativePtr = new ::CppSharp::CppParser::AST::FullComment(__arg0);
 }
 
+System::Collections::Generic::List<CppSharp::Parser::AST::BlockContentComment^>^ CppSharp::Parser::AST::FullComment::Blocks::get()
+{
+    auto _tmp__Blocks = gcnew System::Collections::Generic::List<CppSharp::Parser::AST::BlockContentComment^>();
+    for(auto _element : ((::CppSharp::CppParser::AST::FullComment*)NativePtr)->Blocks)
+    {
+        auto _marshalElement = (_element == nullptr) ? nullptr : gcnew CppSharp::Parser::AST::BlockContentComment((::CppSharp::CppParser::AST::BlockContentComment*)_element);
+        _tmp__Blocks->Add(_marshalElement);
+    }
+    return _tmp__Blocks;
+}
+
+void CppSharp::Parser::AST::FullComment::Blocks::set(System::Collections::Generic::List<CppSharp::Parser::AST::BlockContentComment^>^ value)
+{
+    auto _tmpvalue = std::vector<::CppSharp::CppParser::AST::BlockContentComment*>();
+    for each(CppSharp::Parser::AST::BlockContentComment^ _element in value)
+    {
+        auto _marshalElement = (::CppSharp::CppParser::AST::BlockContentComment*)_element->NativePtr;
+        _tmpvalue.push_back(_marshalElement);
+    }
+    ((::CppSharp::CppParser::AST::FullComment*)NativePtr)->Blocks = _tmpvalue;
+}
+
 unsigned int CppSharp::Parser::AST::FullComment::BlocksCount::get()
 {
     auto __ret = ((::CppSharp::CppParser::AST::FullComment*)NativePtr)->getBlocksCount();
@@ -5794,6 +6671,28 @@ void CppSharp::Parser::AST::ParagraphComment::IsWhitespace::set(bool value)
     ((::CppSharp::CppParser::AST::ParagraphComment*)NativePtr)->isWhitespace = value;
 }
 
+System::Collections::Generic::List<CppSharp::Parser::AST::InlineContentComment^>^ CppSharp::Parser::AST::ParagraphComment::Content::get()
+{
+    auto _tmp__Content = gcnew System::Collections::Generic::List<CppSharp::Parser::AST::InlineContentComment^>();
+    for(auto _element : ((::CppSharp::CppParser::AST::ParagraphComment*)NativePtr)->Content)
+    {
+        auto _marshalElement = (_element == nullptr) ? nullptr : gcnew CppSharp::Parser::AST::InlineContentComment((::CppSharp::CppParser::AST::InlineContentComment*)_element);
+        _tmp__Content->Add(_marshalElement);
+    }
+    return _tmp__Content;
+}
+
+void CppSharp::Parser::AST::ParagraphComment::Content::set(System::Collections::Generic::List<CppSharp::Parser::AST::InlineContentComment^>^ value)
+{
+    auto _tmpvalue = std::vector<::CppSharp::CppParser::AST::InlineContentComment*>();
+    for each(CppSharp::Parser::AST::InlineContentComment^ _element in value)
+    {
+        auto _marshalElement = (::CppSharp::CppParser::AST::InlineContentComment*)_element->NativePtr;
+        _tmpvalue.push_back(_marshalElement);
+    }
+    ((::CppSharp::CppParser::AST::ParagraphComment*)NativePtr)->Content = _tmpvalue;
+}
+
 unsigned int CppSharp::Parser::AST::ParagraphComment::ContentCount::get()
 {
     auto __ret = ((::CppSharp::CppParser::AST::ParagraphComment*)NativePtr)->getContentCount();
@@ -5843,16 +6742,12 @@ void CppSharp::Parser::AST::BlockCommandComment::Argument::__Instance::set(Syste
 
 System::String^ CppSharp::Parser::AST::BlockCommandComment::Argument::Text::get()
 {
-    auto __ret = ((::CppSharp::CppParser::AST::BlockCommandComment::Argument*)NativePtr)->getText();
-    if (__ret == nullptr) return nullptr;
-    return (__ret == 0 ? nullptr : clix::marshalString<clix::E_UTF8>(__ret));
+    return clix::marshalString<clix::E_UTF8>(((::CppSharp::CppParser::AST::BlockCommandComment::Argument*)NativePtr)->text);
 }
 
-void CppSharp::Parser::AST::BlockCommandComment::Argument::Text::set(System::String^ s)
+void CppSharp::Parser::AST::BlockCommandComment::Argument::Text::set(System::String^ value)
 {
-    auto ___arg0 = clix::marshalString<clix::E_UTF8>(s);
-    auto __arg0 = ___arg0.c_str();
-    ((::CppSharp::CppParser::AST::BlockCommandComment::Argument*)NativePtr)->setText(__arg0);
+    ((::CppSharp::CppParser::AST::BlockCommandComment::Argument*)NativePtr)->text = clix::marshalString<clix::E_UTF8>(value);
 }
 
 CppSharp::Parser::AST::BlockCommandComment::BlockCommandComment(::CppSharp::CppParser::AST::BlockCommandComment* native)
@@ -5946,6 +6841,29 @@ CppSharp::Parser::AST::ParagraphComment^ CppSharp::Parser::AST::BlockCommandComm
 void CppSharp::Parser::AST::BlockCommandComment::ParagraphComment::set(CppSharp::Parser::AST::ParagraphComment^ value)
 {
     ((::CppSharp::CppParser::AST::BlockCommandComment*)NativePtr)->paragraphComment = (::CppSharp::CppParser::AST::ParagraphComment*)value->NativePtr;
+}
+
+System::Collections::Generic::List<CppSharp::Parser::AST::BlockCommandComment::Argument^>^ CppSharp::Parser::AST::BlockCommandComment::Arguments::get()
+{
+    auto _tmp__Arguments = gcnew System::Collections::Generic::List<CppSharp::Parser::AST::BlockCommandComment::Argument^>();
+    for(auto _element : ((::CppSharp::CppParser::AST::BlockCommandComment*)NativePtr)->Arguments)
+    {
+        auto ___element = new ::CppSharp::CppParser::AST::BlockCommandComment::Argument(_element);
+        auto _marshalElement = (___element == nullptr) ? nullptr : gcnew CppSharp::Parser::AST::BlockCommandComment::Argument((::CppSharp::CppParser::AST::BlockCommandComment::Argument*)___element);
+        _tmp__Arguments->Add(_marshalElement);
+    }
+    return _tmp__Arguments;
+}
+
+void CppSharp::Parser::AST::BlockCommandComment::Arguments::set(System::Collections::Generic::List<CppSharp::Parser::AST::BlockCommandComment::Argument^>^ value)
+{
+    auto _tmpvalue = std::vector<::CppSharp::CppParser::AST::BlockCommandComment::Argument>();
+    for each(CppSharp::Parser::AST::BlockCommandComment::Argument^ _element in value)
+    {
+        auto _marshalElement = *(::CppSharp::CppParser::AST::BlockCommandComment::Argument*)_element->NativePtr;
+        _tmpvalue.push_back(_marshalElement);
+    }
+    ((::CppSharp::CppParser::AST::BlockCommandComment*)NativePtr)->Arguments = _tmpvalue;
 }
 
 unsigned int CppSharp::Parser::AST::BlockCommandComment::ArgumentsCount::get()
@@ -6066,6 +6984,28 @@ CppSharp::Parser::AST::TParamCommandComment::TParamCommandComment(CppSharp::Pars
     NativePtr = new ::CppSharp::CppParser::AST::TParamCommandComment(__arg0);
 }
 
+System::Collections::Generic::List<unsigned int>^ CppSharp::Parser::AST::TParamCommandComment::Position::get()
+{
+    auto _tmp__Position = gcnew System::Collections::Generic::List<unsigned int>();
+    for(auto _element : ((::CppSharp::CppParser::AST::TParamCommandComment*)NativePtr)->Position)
+    {
+        auto _marshalElement = _element;
+        _tmp__Position->Add(_marshalElement);
+    }
+    return _tmp__Position;
+}
+
+void CppSharp::Parser::AST::TParamCommandComment::Position::set(System::Collections::Generic::List<unsigned int>^ value)
+{
+    auto _tmpvalue = std::vector<unsigned int>();
+    for each(unsigned int _element in value)
+    {
+        auto _marshalElement = _element;
+        _tmpvalue.push_back(_marshalElement);
+    }
+    ((::CppSharp::CppParser::AST::TParamCommandComment*)NativePtr)->Position = _tmpvalue;
+}
+
 unsigned int CppSharp::Parser::AST::TParamCommandComment::PositionCount::get()
 {
     auto __ret = ((::CppSharp::CppParser::AST::TParamCommandComment*)NativePtr)->getPositionCount();
@@ -6111,16 +7051,12 @@ CppSharp::Parser::AST::VerbatimBlockLineComment::VerbatimBlockLineComment(CppSha
 
 System::String^ CppSharp::Parser::AST::VerbatimBlockLineComment::Text::get()
 {
-    auto __ret = ((::CppSharp::CppParser::AST::VerbatimBlockLineComment*)NativePtr)->getText();
-    if (__ret == nullptr) return nullptr;
-    return (__ret == 0 ? nullptr : clix::marshalString<clix::E_UTF8>(__ret));
+    return clix::marshalString<clix::E_UTF8>(((::CppSharp::CppParser::AST::VerbatimBlockLineComment*)NativePtr)->text);
 }
 
-void CppSharp::Parser::AST::VerbatimBlockLineComment::Text::set(System::String^ s)
+void CppSharp::Parser::AST::VerbatimBlockLineComment::Text::set(System::String^ value)
 {
-    auto ___arg0 = clix::marshalString<clix::E_UTF8>(s);
-    auto __arg0 = ___arg0.c_str();
-    ((::CppSharp::CppParser::AST::VerbatimBlockLineComment*)NativePtr)->setText(__arg0);
+    ((::CppSharp::CppParser::AST::VerbatimBlockLineComment*)NativePtr)->text = clix::marshalString<clix::E_UTF8>(value);
 }
 
 CppSharp::Parser::AST::VerbatimBlockComment::VerbatimBlockComment(::CppSharp::CppParser::AST::VerbatimBlockComment* native)
@@ -6180,6 +7116,28 @@ CppSharp::Parser::AST::VerbatimBlockComment::VerbatimBlockComment(CppSharp::Pars
     NativePtr = new ::CppSharp::CppParser::AST::VerbatimBlockComment(__arg0);
 }
 
+System::Collections::Generic::List<CppSharp::Parser::AST::VerbatimBlockLineComment^>^ CppSharp::Parser::AST::VerbatimBlockComment::Lines::get()
+{
+    auto _tmp__Lines = gcnew System::Collections::Generic::List<CppSharp::Parser::AST::VerbatimBlockLineComment^>();
+    for(auto _element : ((::CppSharp::CppParser::AST::VerbatimBlockComment*)NativePtr)->Lines)
+    {
+        auto _marshalElement = (_element == nullptr) ? nullptr : gcnew CppSharp::Parser::AST::VerbatimBlockLineComment((::CppSharp::CppParser::AST::VerbatimBlockLineComment*)_element);
+        _tmp__Lines->Add(_marshalElement);
+    }
+    return _tmp__Lines;
+}
+
+void CppSharp::Parser::AST::VerbatimBlockComment::Lines::set(System::Collections::Generic::List<CppSharp::Parser::AST::VerbatimBlockLineComment^>^ value)
+{
+    auto _tmpvalue = std::vector<::CppSharp::CppParser::AST::VerbatimBlockLineComment*>();
+    for each(CppSharp::Parser::AST::VerbatimBlockLineComment^ _element in value)
+    {
+        auto _marshalElement = (::CppSharp::CppParser::AST::VerbatimBlockLineComment*)_element->NativePtr;
+        _tmpvalue.push_back(_marshalElement);
+    }
+    ((::CppSharp::CppParser::AST::VerbatimBlockComment*)NativePtr)->Lines = _tmpvalue;
+}
+
 unsigned int CppSharp::Parser::AST::VerbatimBlockComment::LinesCount::get()
 {
     auto __ret = ((::CppSharp::CppParser::AST::VerbatimBlockComment*)NativePtr)->getLinesCount();
@@ -6225,16 +7183,12 @@ CppSharp::Parser::AST::VerbatimLineComment::VerbatimLineComment(CppSharp::Parser
 
 System::String^ CppSharp::Parser::AST::VerbatimLineComment::Text::get()
 {
-    auto __ret = ((::CppSharp::CppParser::AST::VerbatimLineComment*)NativePtr)->getText();
-    if (__ret == nullptr) return nullptr;
-    return (__ret == 0 ? nullptr : clix::marshalString<clix::E_UTF8>(__ret));
+    return clix::marshalString<clix::E_UTF8>(((::CppSharp::CppParser::AST::VerbatimLineComment*)NativePtr)->text);
 }
 
-void CppSharp::Parser::AST::VerbatimLineComment::Text::set(System::String^ s)
+void CppSharp::Parser::AST::VerbatimLineComment::Text::set(System::String^ value)
 {
-    auto ___arg0 = clix::marshalString<clix::E_UTF8>(s);
-    auto __arg0 = ___arg0.c_str();
-    ((::CppSharp::CppParser::AST::VerbatimLineComment*)NativePtr)->setText(__arg0);
+    ((::CppSharp::CppParser::AST::VerbatimLineComment*)NativePtr)->text = clix::marshalString<clix::E_UTF8>(value);
 }
 
 CppSharp::Parser::AST::InlineCommandComment::Argument::Argument(::CppSharp::CppParser::AST::InlineCommandComment::Argument* native)
@@ -6280,16 +7234,12 @@ void CppSharp::Parser::AST::InlineCommandComment::Argument::__Instance::set(Syst
 
 System::String^ CppSharp::Parser::AST::InlineCommandComment::Argument::Text::get()
 {
-    auto __ret = ((::CppSharp::CppParser::AST::InlineCommandComment::Argument*)NativePtr)->getText();
-    if (__ret == nullptr) return nullptr;
-    return (__ret == 0 ? nullptr : clix::marshalString<clix::E_UTF8>(__ret));
+    return clix::marshalString<clix::E_UTF8>(((::CppSharp::CppParser::AST::InlineCommandComment::Argument*)NativePtr)->text);
 }
 
-void CppSharp::Parser::AST::InlineCommandComment::Argument::Text::set(System::String^ s)
+void CppSharp::Parser::AST::InlineCommandComment::Argument::Text::set(System::String^ value)
 {
-    auto ___arg0 = clix::marshalString<clix::E_UTF8>(s);
-    auto __arg0 = ___arg0.c_str();
-    ((::CppSharp::CppParser::AST::InlineCommandComment::Argument*)NativePtr)->setText(__arg0);
+    ((::CppSharp::CppParser::AST::InlineCommandComment::Argument*)NativePtr)->text = clix::marshalString<clix::E_UTF8>(value);
 }
 
 CppSharp::Parser::AST::InlineCommandComment::InlineCommandComment(::CppSharp::CppParser::AST::InlineCommandComment* native)
@@ -6367,6 +7317,29 @@ CppSharp::Parser::AST::InlineCommandComment::RenderKind CppSharp::Parser::AST::I
 void CppSharp::Parser::AST::InlineCommandComment::CommentRenderKind::set(CppSharp::Parser::AST::InlineCommandComment::RenderKind value)
 {
     ((::CppSharp::CppParser::AST::InlineCommandComment*)NativePtr)->commentRenderKind = (::CppSharp::CppParser::AST::InlineCommandComment::RenderKind)value;
+}
+
+System::Collections::Generic::List<CppSharp::Parser::AST::InlineCommandComment::Argument^>^ CppSharp::Parser::AST::InlineCommandComment::Arguments::get()
+{
+    auto _tmp__Arguments = gcnew System::Collections::Generic::List<CppSharp::Parser::AST::InlineCommandComment::Argument^>();
+    for(auto _element : ((::CppSharp::CppParser::AST::InlineCommandComment*)NativePtr)->Arguments)
+    {
+        auto ___element = new ::CppSharp::CppParser::AST::InlineCommandComment::Argument(_element);
+        auto _marshalElement = (___element == nullptr) ? nullptr : gcnew CppSharp::Parser::AST::InlineCommandComment::Argument((::CppSharp::CppParser::AST::InlineCommandComment::Argument*)___element);
+        _tmp__Arguments->Add(_marshalElement);
+    }
+    return _tmp__Arguments;
+}
+
+void CppSharp::Parser::AST::InlineCommandComment::Arguments::set(System::Collections::Generic::List<CppSharp::Parser::AST::InlineCommandComment::Argument^>^ value)
+{
+    auto _tmpvalue = std::vector<::CppSharp::CppParser::AST::InlineCommandComment::Argument>();
+    for each(CppSharp::Parser::AST::InlineCommandComment::Argument^ _element in value)
+    {
+        auto _marshalElement = *(::CppSharp::CppParser::AST::InlineCommandComment::Argument*)_element->NativePtr;
+        _tmpvalue.push_back(_marshalElement);
+    }
+    ((::CppSharp::CppParser::AST::InlineCommandComment*)NativePtr)->Arguments = _tmpvalue;
 }
 
 unsigned int CppSharp::Parser::AST::InlineCommandComment::ArgumentsCount::get()
@@ -6465,30 +7438,22 @@ void CppSharp::Parser::AST::HTMLStartTagComment::Attribute::__Instance::set(Syst
 
 System::String^ CppSharp::Parser::AST::HTMLStartTagComment::Attribute::Name::get()
 {
-    auto __ret = ((::CppSharp::CppParser::AST::HTMLStartTagComment::Attribute*)NativePtr)->getName();
-    if (__ret == nullptr) return nullptr;
-    return (__ret == 0 ? nullptr : clix::marshalString<clix::E_UTF8>(__ret));
+    return clix::marshalString<clix::E_UTF8>(((::CppSharp::CppParser::AST::HTMLStartTagComment::Attribute*)NativePtr)->name);
 }
 
-void CppSharp::Parser::AST::HTMLStartTagComment::Attribute::Name::set(System::String^ s)
+void CppSharp::Parser::AST::HTMLStartTagComment::Attribute::Name::set(System::String^ value)
 {
-    auto ___arg0 = clix::marshalString<clix::E_UTF8>(s);
-    auto __arg0 = ___arg0.c_str();
-    ((::CppSharp::CppParser::AST::HTMLStartTagComment::Attribute*)NativePtr)->setName(__arg0);
+    ((::CppSharp::CppParser::AST::HTMLStartTagComment::Attribute*)NativePtr)->name = clix::marshalString<clix::E_UTF8>(value);
 }
 
 System::String^ CppSharp::Parser::AST::HTMLStartTagComment::Attribute::Value::get()
 {
-    auto __ret = ((::CppSharp::CppParser::AST::HTMLStartTagComment::Attribute*)NativePtr)->getValue();
-    if (__ret == nullptr) return nullptr;
-    return (__ret == 0 ? nullptr : clix::marshalString<clix::E_UTF8>(__ret));
+    return clix::marshalString<clix::E_UTF8>(((::CppSharp::CppParser::AST::HTMLStartTagComment::Attribute*)NativePtr)->value);
 }
 
-void CppSharp::Parser::AST::HTMLStartTagComment::Attribute::Value::set(System::String^ s)
+void CppSharp::Parser::AST::HTMLStartTagComment::Attribute::Value::set(System::String^ value)
 {
-    auto ___arg0 = clix::marshalString<clix::E_UTF8>(s);
-    auto __arg0 = ___arg0.c_str();
-    ((::CppSharp::CppParser::AST::HTMLStartTagComment::Attribute*)NativePtr)->setValue(__arg0);
+    ((::CppSharp::CppParser::AST::HTMLStartTagComment::Attribute*)NativePtr)->value = clix::marshalString<clix::E_UTF8>(value);
 }
 
 CppSharp::Parser::AST::HTMLStartTagComment::HTMLStartTagComment(::CppSharp::CppParser::AST::HTMLStartTagComment* native)
@@ -6550,16 +7515,35 @@ CppSharp::Parser::AST::HTMLStartTagComment::HTMLStartTagComment(CppSharp::Parser
 
 System::String^ CppSharp::Parser::AST::HTMLStartTagComment::TagName::get()
 {
-    auto __ret = ((::CppSharp::CppParser::AST::HTMLStartTagComment*)NativePtr)->getTagName();
-    if (__ret == nullptr) return nullptr;
-    return (__ret == 0 ? nullptr : clix::marshalString<clix::E_UTF8>(__ret));
+    return clix::marshalString<clix::E_UTF8>(((::CppSharp::CppParser::AST::HTMLStartTagComment*)NativePtr)->tagName);
 }
 
-void CppSharp::Parser::AST::HTMLStartTagComment::TagName::set(System::String^ s)
+void CppSharp::Parser::AST::HTMLStartTagComment::TagName::set(System::String^ value)
 {
-    auto ___arg0 = clix::marshalString<clix::E_UTF8>(s);
-    auto __arg0 = ___arg0.c_str();
-    ((::CppSharp::CppParser::AST::HTMLStartTagComment*)NativePtr)->setTagName(__arg0);
+    ((::CppSharp::CppParser::AST::HTMLStartTagComment*)NativePtr)->tagName = clix::marshalString<clix::E_UTF8>(value);
+}
+
+System::Collections::Generic::List<CppSharp::Parser::AST::HTMLStartTagComment::Attribute^>^ CppSharp::Parser::AST::HTMLStartTagComment::Attributes::get()
+{
+    auto _tmp__Attributes = gcnew System::Collections::Generic::List<CppSharp::Parser::AST::HTMLStartTagComment::Attribute^>();
+    for(auto _element : ((::CppSharp::CppParser::AST::HTMLStartTagComment*)NativePtr)->Attributes)
+    {
+        auto ___element = new ::CppSharp::CppParser::AST::HTMLStartTagComment::Attribute(_element);
+        auto _marshalElement = (___element == nullptr) ? nullptr : gcnew CppSharp::Parser::AST::HTMLStartTagComment::Attribute((::CppSharp::CppParser::AST::HTMLStartTagComment::Attribute*)___element);
+        _tmp__Attributes->Add(_marshalElement);
+    }
+    return _tmp__Attributes;
+}
+
+void CppSharp::Parser::AST::HTMLStartTagComment::Attributes::set(System::Collections::Generic::List<CppSharp::Parser::AST::HTMLStartTagComment::Attribute^>^ value)
+{
+    auto _tmpvalue = std::vector<::CppSharp::CppParser::AST::HTMLStartTagComment::Attribute>();
+    for each(CppSharp::Parser::AST::HTMLStartTagComment::Attribute^ _element in value)
+    {
+        auto _marshalElement = *(::CppSharp::CppParser::AST::HTMLStartTagComment::Attribute*)_element->NativePtr;
+        _tmpvalue.push_back(_marshalElement);
+    }
+    ((::CppSharp::CppParser::AST::HTMLStartTagComment*)NativePtr)->Attributes = _tmpvalue;
 }
 
 unsigned int CppSharp::Parser::AST::HTMLStartTagComment::AttributesCount::get()
@@ -6607,16 +7591,12 @@ CppSharp::Parser::AST::HTMLEndTagComment::HTMLEndTagComment(CppSharp::Parser::AS
 
 System::String^ CppSharp::Parser::AST::HTMLEndTagComment::TagName::get()
 {
-    auto __ret = ((::CppSharp::CppParser::AST::HTMLEndTagComment*)NativePtr)->getTagName();
-    if (__ret == nullptr) return nullptr;
-    return (__ret == 0 ? nullptr : clix::marshalString<clix::E_UTF8>(__ret));
+    return clix::marshalString<clix::E_UTF8>(((::CppSharp::CppParser::AST::HTMLEndTagComment*)NativePtr)->tagName);
 }
 
-void CppSharp::Parser::AST::HTMLEndTagComment::TagName::set(System::String^ s)
+void CppSharp::Parser::AST::HTMLEndTagComment::TagName::set(System::String^ value)
 {
-    auto ___arg0 = clix::marshalString<clix::E_UTF8>(s);
-    auto __arg0 = ___arg0.c_str();
-    ((::CppSharp::CppParser::AST::HTMLEndTagComment*)NativePtr)->setTagName(__arg0);
+    ((::CppSharp::CppParser::AST::HTMLEndTagComment*)NativePtr)->tagName = clix::marshalString<clix::E_UTF8>(value);
 }
 
 CppSharp::Parser::AST::TextComment::TextComment(::CppSharp::CppParser::AST::TextComment* native)
@@ -6658,16 +7638,12 @@ CppSharp::Parser::AST::TextComment::TextComment(CppSharp::Parser::AST::TextComme
 
 System::String^ CppSharp::Parser::AST::TextComment::Text::get()
 {
-    auto __ret = ((::CppSharp::CppParser::AST::TextComment*)NativePtr)->getText();
-    if (__ret == nullptr) return nullptr;
-    return (__ret == 0 ? nullptr : clix::marshalString<clix::E_UTF8>(__ret));
+    return clix::marshalString<clix::E_UTF8>(((::CppSharp::CppParser::AST::TextComment*)NativePtr)->text);
 }
 
-void CppSharp::Parser::AST::TextComment::Text::set(System::String^ s)
+void CppSharp::Parser::AST::TextComment::Text::set(System::String^ value)
 {
-    auto ___arg0 = clix::marshalString<clix::E_UTF8>(s);
-    auto __arg0 = ___arg0.c_str();
-    ((::CppSharp::CppParser::AST::TextComment*)NativePtr)->setText(__arg0);
+    ((::CppSharp::CppParser::AST::TextComment*)NativePtr)->text = clix::marshalString<clix::E_UTF8>(value);
 }
 
 CppSharp::Parser::AST::RawComment::RawComment(::CppSharp::CppParser::AST::RawComment* native)
@@ -6721,6 +7697,26 @@ void CppSharp::Parser::AST::RawComment::Kind::set(CppSharp::Parser::AST::RawComm
     ((::CppSharp::CppParser::AST::RawComment*)NativePtr)->kind = (::CppSharp::CppParser::AST::RawCommentKind)value;
 }
 
+System::String^ CppSharp::Parser::AST::RawComment::Text::get()
+{
+    return clix::marshalString<clix::E_UTF8>(((::CppSharp::CppParser::AST::RawComment*)NativePtr)->text);
+}
+
+void CppSharp::Parser::AST::RawComment::Text::set(System::String^ value)
+{
+    ((::CppSharp::CppParser::AST::RawComment*)NativePtr)->text = clix::marshalString<clix::E_UTF8>(value);
+}
+
+System::String^ CppSharp::Parser::AST::RawComment::BriefText::get()
+{
+    return clix::marshalString<clix::E_UTF8>(((::CppSharp::CppParser::AST::RawComment*)NativePtr)->briefText);
+}
+
+void CppSharp::Parser::AST::RawComment::BriefText::set(System::String^ value)
+{
+    ((::CppSharp::CppParser::AST::RawComment*)NativePtr)->briefText = clix::marshalString<clix::E_UTF8>(value);
+}
+
 CppSharp::Parser::AST::FullComment^ CppSharp::Parser::AST::RawComment::FullCommentBlock::get()
 {
     return (((::CppSharp::CppParser::AST::RawComment*)NativePtr)->fullCommentBlock == nullptr) ? nullptr : gcnew CppSharp::Parser::AST::FullComment((::CppSharp::CppParser::AST::FullComment*)((::CppSharp::CppParser::AST::RawComment*)NativePtr)->fullCommentBlock);
@@ -6729,33 +7725,5 @@ CppSharp::Parser::AST::FullComment^ CppSharp::Parser::AST::RawComment::FullComme
 void CppSharp::Parser::AST::RawComment::FullCommentBlock::set(CppSharp::Parser::AST::FullComment^ value)
 {
     ((::CppSharp::CppParser::AST::RawComment*)NativePtr)->fullCommentBlock = (::CppSharp::CppParser::AST::FullComment*)value->NativePtr;
-}
-
-System::String^ CppSharp::Parser::AST::RawComment::Text::get()
-{
-    auto __ret = ((::CppSharp::CppParser::AST::RawComment*)NativePtr)->getText();
-    if (__ret == nullptr) return nullptr;
-    return (__ret == 0 ? nullptr : clix::marshalString<clix::E_UTF8>(__ret));
-}
-
-void CppSharp::Parser::AST::RawComment::Text::set(System::String^ s)
-{
-    auto ___arg0 = clix::marshalString<clix::E_UTF8>(s);
-    auto __arg0 = ___arg0.c_str();
-    ((::CppSharp::CppParser::AST::RawComment*)NativePtr)->setText(__arg0);
-}
-
-System::String^ CppSharp::Parser::AST::RawComment::BriefText::get()
-{
-    auto __ret = ((::CppSharp::CppParser::AST::RawComment*)NativePtr)->getBriefText();
-    if (__ret == nullptr) return nullptr;
-    return (__ret == 0 ? nullptr : clix::marshalString<clix::E_UTF8>(__ret));
-}
-
-void CppSharp::Parser::AST::RawComment::BriefText::set(System::String^ s)
-{
-    auto ___arg0 = clix::marshalString<clix::E_UTF8>(s);
-    auto __arg0 = ___arg0.c_str();
-    ((::CppSharp::CppParser::AST::RawComment*)NativePtr)->setBriefText(__arg0);
 }
 

--- a/src/CppParser/Bindings/CLI/AST.h
+++ b/src/CppParser/Bindings/CLI/AST.h
@@ -615,6 +615,12 @@ namespace CppSharp
                     void set(CppSharp::Parser::AST::ExceptionSpecType);
                 }
 
+                property System::Collections::Generic::List<CppSharp::Parser::AST::Parameter^>^ Parameters
+                {
+                    System::Collections::Generic::List<CppSharp::Parser::AST::Parameter^>^ get();
+                    void set(System::Collections::Generic::List<CppSharp::Parser::AST::Parameter^>^);
+                }
+
                 property unsigned int ParametersCount
                 {
                     unsigned int get();
@@ -825,6 +831,12 @@ namespace CppSharp
 
                 ~TemplateSpecializationType();
 
+                property System::Collections::Generic::List<CppSharp::Parser::AST::TemplateArgument^>^ Arguments
+                {
+                    System::Collections::Generic::List<CppSharp::Parser::AST::TemplateArgument^>^ get();
+                    void set(System::Collections::Generic::List<CppSharp::Parser::AST::TemplateArgument^>^);
+                }
+
                 property CppSharp::Parser::AST::Template^ Template
                 {
                     CppSharp::Parser::AST::Template^ get();
@@ -860,6 +872,12 @@ namespace CppSharp
                 DependentTemplateSpecializationType(CppSharp::Parser::AST::DependentTemplateSpecializationType^ _0);
 
                 ~DependentTemplateSpecializationType();
+
+                property System::Collections::Generic::List<CppSharp::Parser::AST::TemplateArgument^>^ Arguments
+                {
+                    System::Collections::Generic::List<CppSharp::Parser::AST::TemplateArgument^>^ get();
+                    void set(System::Collections::Generic::List<CppSharp::Parser::AST::TemplateArgument^>^);
+                }
 
                 property CppSharp::Parser::AST::QualifiedType^ Desugared
                 {
@@ -1133,6 +1151,12 @@ namespace CppSharp
 
                 ~VTableLayout();
 
+                property System::Collections::Generic::List<CppSharp::Parser::AST::VTableComponent^>^ Components
+                {
+                    System::Collections::Generic::List<CppSharp::Parser::AST::VTableComponent^>^ get();
+                    void set(System::Collections::Generic::List<CppSharp::Parser::AST::VTableComponent^>^);
+                }
+
                 property unsigned int ComponentsCount
                 {
                     unsigned int get();
@@ -1220,6 +1244,12 @@ namespace CppSharp
                     void set(unsigned int);
                 }
 
+                property System::String^ Name
+                {
+                    System::String^ get();
+                    void set(System::String^);
+                }
+
                 property CppSharp::Parser::AST::QualifiedType^ QualifiedType
                 {
                     CppSharp::Parser::AST::QualifiedType^ get();
@@ -1230,12 +1260,6 @@ namespace CppSharp
                 {
                     ::System::IntPtr get();
                     void set(::System::IntPtr);
-                }
-
-                property System::String^ Name
-                {
-                    System::String^ get();
-                    void set(System::String^);
                 }
 
                 protected:
@@ -1302,6 +1326,12 @@ namespace CppSharp
                     void set(CppSharp::Parser::AST::CppAbi);
                 }
 
+                property System::Collections::Generic::List<CppSharp::Parser::AST::VFTableInfo^>^ VFTables
+                {
+                    System::Collections::Generic::List<CppSharp::Parser::AST::VFTableInfo^>^ get();
+                    void set(System::Collections::Generic::List<CppSharp::Parser::AST::VFTableInfo^>^);
+                }
+
                 property CppSharp::Parser::AST::VTableLayout^ Layout
                 {
                     CppSharp::Parser::AST::VTableLayout^ get();
@@ -1336,6 +1366,18 @@ namespace CppSharp
                 {
                     int get();
                     void set(int);
+                }
+
+                property System::Collections::Generic::List<CppSharp::Parser::AST::LayoutField^>^ Fields
+                {
+                    System::Collections::Generic::List<CppSharp::Parser::AST::LayoutField^>^ get();
+                    void set(System::Collections::Generic::List<CppSharp::Parser::AST::LayoutField^>^);
+                }
+
+                property System::Collections::Generic::List<CppSharp::Parser::AST::LayoutBase^>^ Bases
+                {
+                    System::Collections::Generic::List<CppSharp::Parser::AST::LayoutBase^>^ get();
+                    void set(System::Collections::Generic::List<CppSharp::Parser::AST::LayoutBase^>^);
                 }
 
                 property unsigned int VFTablesCount
@@ -1430,6 +1472,24 @@ namespace CppSharp
                     void set(int);
                 }
 
+                property System::String^ Name
+                {
+                    System::String^ get();
+                    void set(System::String^);
+                }
+
+                property System::String^ USR
+                {
+                    System::String^ get();
+                    void set(System::String^);
+                }
+
+                property System::String^ DebugText
+                {
+                    System::String^ get();
+                    void set(System::String^);
+                }
+
                 property bool IsIncomplete
                 {
                     bool get();
@@ -1460,6 +1520,18 @@ namespace CppSharp
                     void set(unsigned int);
                 }
 
+                property System::Collections::Generic::List<CppSharp::Parser::AST::PreprocessedEntity^>^ PreprocessedEntities
+                {
+                    System::Collections::Generic::List<CppSharp::Parser::AST::PreprocessedEntity^>^ get();
+                    void set(System::Collections::Generic::List<CppSharp::Parser::AST::PreprocessedEntity^>^);
+                }
+
+                property System::Collections::Generic::List<CppSharp::Parser::AST::Declaration^>^ Redeclarations
+                {
+                    System::Collections::Generic::List<CppSharp::Parser::AST::Declaration^>^ get();
+                    void set(System::Collections::Generic::List<CppSharp::Parser::AST::Declaration^>^);
+                }
+
                 property ::System::IntPtr OriginalPtr
                 {
                     ::System::IntPtr get();
@@ -1470,24 +1542,6 @@ namespace CppSharp
                 {
                     CppSharp::Parser::AST::RawComment^ get();
                     void set(CppSharp::Parser::AST::RawComment^);
-                }
-
-                property System::String^ Name
-                {
-                    System::String^ get();
-                    void set(System::String^);
-                }
-
-                property System::String^ USR
-                {
-                    System::String^ get();
-                    void set(System::String^);
-                }
-
-                property System::String^ DebugText
-                {
-                    System::String^ get();
-                    void set(System::String^);
                 }
 
                 property unsigned int PreprocessedEntitiesCount
@@ -1529,6 +1583,60 @@ namespace CppSharp
                 DeclarationContext(CppSharp::Parser::AST::DeclarationContext^ _0);
 
                 ~DeclarationContext();
+
+                property System::Collections::Generic::List<CppSharp::Parser::AST::Namespace^>^ Namespaces
+                {
+                    System::Collections::Generic::List<CppSharp::Parser::AST::Namespace^>^ get();
+                    void set(System::Collections::Generic::List<CppSharp::Parser::AST::Namespace^>^);
+                }
+
+                property System::Collections::Generic::List<CppSharp::Parser::AST::Enumeration^>^ Enums
+                {
+                    System::Collections::Generic::List<CppSharp::Parser::AST::Enumeration^>^ get();
+                    void set(System::Collections::Generic::List<CppSharp::Parser::AST::Enumeration^>^);
+                }
+
+                property System::Collections::Generic::List<CppSharp::Parser::AST::Function^>^ Functions
+                {
+                    System::Collections::Generic::List<CppSharp::Parser::AST::Function^>^ get();
+                    void set(System::Collections::Generic::List<CppSharp::Parser::AST::Function^>^);
+                }
+
+                property System::Collections::Generic::List<CppSharp::Parser::AST::Class^>^ Classes
+                {
+                    System::Collections::Generic::List<CppSharp::Parser::AST::Class^>^ get();
+                    void set(System::Collections::Generic::List<CppSharp::Parser::AST::Class^>^);
+                }
+
+                property System::Collections::Generic::List<CppSharp::Parser::AST::Template^>^ Templates
+                {
+                    System::Collections::Generic::List<CppSharp::Parser::AST::Template^>^ get();
+                    void set(System::Collections::Generic::List<CppSharp::Parser::AST::Template^>^);
+                }
+
+                property System::Collections::Generic::List<CppSharp::Parser::AST::TypedefDecl^>^ Typedefs
+                {
+                    System::Collections::Generic::List<CppSharp::Parser::AST::TypedefDecl^>^ get();
+                    void set(System::Collections::Generic::List<CppSharp::Parser::AST::TypedefDecl^>^);
+                }
+
+                property System::Collections::Generic::List<CppSharp::Parser::AST::TypeAlias^>^ TypeAliases
+                {
+                    System::Collections::Generic::List<CppSharp::Parser::AST::TypeAlias^>^ get();
+                    void set(System::Collections::Generic::List<CppSharp::Parser::AST::TypeAlias^>^);
+                }
+
+                property System::Collections::Generic::List<CppSharp::Parser::AST::Variable^>^ Variables
+                {
+                    System::Collections::Generic::List<CppSharp::Parser::AST::Variable^>^ get();
+                    void set(System::Collections::Generic::List<CppSharp::Parser::AST::Variable^>^);
+                }
+
+                property System::Collections::Generic::List<CppSharp::Parser::AST::Friend^>^ Friends
+                {
+                    System::Collections::Generic::List<CppSharp::Parser::AST::Friend^>^ get();
+                    void set(System::Collections::Generic::List<CppSharp::Parser::AST::Friend^>^);
+                }
 
                 property bool IsAnonymous
                 {
@@ -1723,6 +1831,8 @@ namespace CppSharp
 
                 Statement(::CppSharp::CppParser::AST::Statement* native);
                 static Statement^ __CreateInstance(::System::IntPtr native);
+                Statement(System::String^ str, CppSharp::Parser::AST::StatementClass Class, CppSharp::Parser::AST::Declaration^ decl);
+
                 Statement(CppSharp::Parser::AST::Statement^ _0);
 
                 ~Statement();
@@ -1755,6 +1865,8 @@ namespace CppSharp
 
                 Expression(::CppSharp::CppParser::AST::Expression* native);
                 static Expression^ __CreateInstance(::System::IntPtr native);
+                Expression(System::String^ str, CppSharp::Parser::AST::StatementClass Class, CppSharp::Parser::AST::Declaration^ decl);
+
                 Expression(CppSharp::Parser::AST::Expression^ _0);
 
                 ~Expression();
@@ -1766,6 +1878,8 @@ namespace CppSharp
 
                 BinaryOperator(::CppSharp::CppParser::AST::BinaryOperator* native);
                 static BinaryOperator^ __CreateInstance(::System::IntPtr native);
+                BinaryOperator(System::String^ str, CppSharp::Parser::AST::Expression^ lhs, CppSharp::Parser::AST::Expression^ rhs, System::String^ opcodeStr);
+
                 BinaryOperator(CppSharp::Parser::AST::BinaryOperator^ _0);
 
                 ~BinaryOperator();
@@ -1795,9 +1909,17 @@ namespace CppSharp
 
                 CallExpr(::CppSharp::CppParser::AST::CallExpr* native);
                 static CallExpr^ __CreateInstance(::System::IntPtr native);
+                CallExpr(System::String^ str, CppSharp::Parser::AST::Declaration^ decl);
+
                 CallExpr(CppSharp::Parser::AST::CallExpr^ _0);
 
                 ~CallExpr();
+
+                property System::Collections::Generic::List<CppSharp::Parser::AST::Expression^>^ Arguments
+                {
+                    System::Collections::Generic::List<CppSharp::Parser::AST::Expression^>^ get();
+                    void set(System::Collections::Generic::List<CppSharp::Parser::AST::Expression^>^);
+                }
 
                 property unsigned int ArgumentsCount
                 {
@@ -1817,9 +1939,17 @@ namespace CppSharp
 
                 CXXConstructExpr(::CppSharp::CppParser::AST::CXXConstructExpr* native);
                 static CXXConstructExpr^ __CreateInstance(::System::IntPtr native);
+                CXXConstructExpr(System::String^ str, CppSharp::Parser::AST::Declaration^ decl);
+
                 CXXConstructExpr(CppSharp::Parser::AST::CXXConstructExpr^ _0);
 
                 ~CXXConstructExpr();
+
+                property System::Collections::Generic::List<CppSharp::Parser::AST::Expression^>^ Arguments
+                {
+                    System::Collections::Generic::List<CppSharp::Parser::AST::Expression^>^ get();
+                    void set(System::Collections::Generic::List<CppSharp::Parser::AST::Expression^>^);
+                }
 
                 property unsigned int ArgumentsCount
                 {
@@ -1948,10 +2078,34 @@ namespace CppSharp
                     void set(CppSharp::Parser::AST::CXXOperatorKind);
                 }
 
+                property System::String^ Mangled
+                {
+                    System::String^ get();
+                    void set(System::String^);
+                }
+
+                property System::String^ Signature
+                {
+                    System::String^ get();
+                    void set(System::String^);
+                }
+
+                property System::String^ Body
+                {
+                    System::String^ get();
+                    void set(System::String^);
+                }
+
                 property CppSharp::Parser::AST::CallingConvention CallingConvention
                 {
                     CppSharp::Parser::AST::CallingConvention get();
                     void set(CppSharp::Parser::AST::CallingConvention);
+                }
+
+                property System::Collections::Generic::List<CppSharp::Parser::AST::Parameter^>^ Parameters
+                {
+                    System::Collections::Generic::List<CppSharp::Parser::AST::Parameter^>^ get();
+                    void set(System::Collections::Generic::List<CppSharp::Parser::AST::Parameter^>^);
                 }
 
                 property CppSharp::Parser::AST::FunctionTemplateSpecialization^ SpecializationInfo
@@ -1970,24 +2124,6 @@ namespace CppSharp
                 {
                     CppSharp::Parser::AST::QualifiedType^ get();
                     void set(CppSharp::Parser::AST::QualifiedType^);
-                }
-
-                property System::String^ Mangled
-                {
-                    System::String^ get();
-                    void set(System::String^);
-                }
-
-                property System::String^ Signature
-                {
-                    System::String^ get();
-                    void set(System::String^);
-                }
-
-                property System::String^ Body
-                {
-                    System::String^ get();
-                    void set(System::String^);
                 }
 
                 property unsigned int ParametersCount
@@ -2105,16 +2241,16 @@ namespace CppSharp
 
                     ~Item();
 
-                    property unsigned long long Value
-                    {
-                        unsigned long long get();
-                        void set(unsigned long long);
-                    }
-
                     property System::String^ Expression
                     {
                         System::String^ get();
                         void set(System::String^);
+                    }
+
+                    property unsigned long long Value
+                    {
+                        unsigned long long get();
+                        void set(unsigned long long);
                     }
                 };
 
@@ -2144,6 +2280,12 @@ namespace CppSharp
                     void set(CppSharp::Parser::AST::BuiltinType^);
                 }
 
+                property System::Collections::Generic::List<CppSharp::Parser::AST::Enumeration::Item^>^ Items
+                {
+                    System::Collections::Generic::List<CppSharp::Parser::AST::Enumeration::Item^>^ get();
+                    void set(System::Collections::Generic::List<CppSharp::Parser::AST::Enumeration::Item^>^);
+                }
+
                 property unsigned int ItemsCount
                 {
                     unsigned int get();
@@ -2154,6 +2296,8 @@ namespace CppSharp
                 void AddItems(CppSharp::Parser::AST::Enumeration::Item^ s);
 
                 void ClearItems();
+
+                CppSharp::Parser::AST::Enumeration::Item^ FindItemByName(System::String^ Name);
             };
 
             public ref class Variable : CppSharp::Parser::AST::Declaration
@@ -2168,16 +2312,16 @@ namespace CppSharp
 
                 ~Variable();
 
-                property CppSharp::Parser::AST::QualifiedType^ QualifiedType
-                {
-                    CppSharp::Parser::AST::QualifiedType^ get();
-                    void set(CppSharp::Parser::AST::QualifiedType^);
-                }
-
                 property System::String^ Mangled
                 {
                     System::String^ get();
                     void set(System::String^);
+                }
+
+                property CppSharp::Parser::AST::QualifiedType^ QualifiedType
+                {
+                    CppSharp::Parser::AST::QualifiedType^ get();
+                    void set(CppSharp::Parser::AST::QualifiedType^);
                 }
             };
 
@@ -2289,6 +2433,30 @@ namespace CppSharp
                 Class(CppSharp::Parser::AST::Class^ _0);
 
                 ~Class();
+
+                property System::Collections::Generic::List<CppSharp::Parser::AST::BaseClassSpecifier^>^ Bases
+                {
+                    System::Collections::Generic::List<CppSharp::Parser::AST::BaseClassSpecifier^>^ get();
+                    void set(System::Collections::Generic::List<CppSharp::Parser::AST::BaseClassSpecifier^>^);
+                }
+
+                property System::Collections::Generic::List<CppSharp::Parser::AST::Field^>^ Fields
+                {
+                    System::Collections::Generic::List<CppSharp::Parser::AST::Field^>^ get();
+                    void set(System::Collections::Generic::List<CppSharp::Parser::AST::Field^>^);
+                }
+
+                property System::Collections::Generic::List<CppSharp::Parser::AST::Method^>^ Methods
+                {
+                    System::Collections::Generic::List<CppSharp::Parser::AST::Method^>^ get();
+                    void set(System::Collections::Generic::List<CppSharp::Parser::AST::Method^>^);
+                }
+
+                property System::Collections::Generic::List<CppSharp::Parser::AST::AccessSpecifierDecl^>^ Specifiers
+                {
+                    System::Collections::Generic::List<CppSharp::Parser::AST::AccessSpecifierDecl^>^ get();
+                    void set(System::Collections::Generic::List<CppSharp::Parser::AST::AccessSpecifierDecl^>^);
+                }
 
                 property bool IsPOD
                 {
@@ -2419,6 +2587,12 @@ namespace CppSharp
                 {
                     CppSharp::Parser::AST::Declaration^ get();
                     void set(CppSharp::Parser::AST::Declaration^);
+                }
+
+                property System::Collections::Generic::List<CppSharp::Parser::AST::Declaration^>^ Parameters
+                {
+                    System::Collections::Generic::List<CppSharp::Parser::AST::Declaration^>^ get();
+                    void set(System::Collections::Generic::List<CppSharp::Parser::AST::Declaration^>^);
                 }
 
                 property unsigned int ParametersCount
@@ -2580,6 +2754,12 @@ namespace CppSharp
 
                 ~ClassTemplate();
 
+                property System::Collections::Generic::List<CppSharp::Parser::AST::ClassTemplateSpecialization^>^ Specializations
+                {
+                    System::Collections::Generic::List<CppSharp::Parser::AST::ClassTemplateSpecialization^>^ get();
+                    void set(System::Collections::Generic::List<CppSharp::Parser::AST::ClassTemplateSpecialization^>^);
+                }
+
                 property unsigned int SpecializationsCount
                 {
                     unsigned int get();
@@ -2590,6 +2770,10 @@ namespace CppSharp
                 void AddSpecializations(CppSharp::Parser::AST::ClassTemplateSpecialization^ s);
 
                 void ClearSpecializations();
+
+                CppSharp::Parser::AST::ClassTemplateSpecialization^ FindSpecialization(System::String^ usr);
+
+                CppSharp::Parser::AST::ClassTemplatePartialSpecialization^ FindPartialSpecialization(System::String^ usr);
             };
 
             public ref class ClassTemplateSpecialization : CppSharp::Parser::AST::Class
@@ -2608,6 +2792,12 @@ namespace CppSharp
                 {
                     CppSharp::Parser::AST::ClassTemplate^ get();
                     void set(CppSharp::Parser::AST::ClassTemplate^);
+                }
+
+                property System::Collections::Generic::List<CppSharp::Parser::AST::TemplateArgument^>^ Arguments
+                {
+                    System::Collections::Generic::List<CppSharp::Parser::AST::TemplateArgument^>^ get();
+                    void set(System::Collections::Generic::List<CppSharp::Parser::AST::TemplateArgument^>^);
                 }
 
                 property CppSharp::Parser::AST::TemplateSpecializationKind SpecializationKind
@@ -2653,6 +2843,12 @@ namespace CppSharp
 
                 ~FunctionTemplate();
 
+                property System::Collections::Generic::List<CppSharp::Parser::AST::FunctionTemplateSpecialization^>^ Specializations
+                {
+                    System::Collections::Generic::List<CppSharp::Parser::AST::FunctionTemplateSpecialization^>^ get();
+                    void set(System::Collections::Generic::List<CppSharp::Parser::AST::FunctionTemplateSpecialization^>^);
+                }
+
                 property unsigned int SpecializationsCount
                 {
                     unsigned int get();
@@ -2663,6 +2859,8 @@ namespace CppSharp
                 void AddSpecializations(CppSharp::Parser::AST::FunctionTemplateSpecialization^ s);
 
                 void ClearSpecializations();
+
+                CppSharp::Parser::AST::FunctionTemplateSpecialization^ FindSpecialization(System::String^ usr);
             };
 
             public ref class FunctionTemplateSpecialization : ICppInstance
@@ -2688,6 +2886,12 @@ namespace CppSharp
                 {
                     CppSharp::Parser::AST::FunctionTemplate^ get();
                     void set(CppSharp::Parser::AST::FunctionTemplate^);
+                }
+
+                property System::Collections::Generic::List<CppSharp::Parser::AST::TemplateArgument^>^ Arguments
+                {
+                    System::Collections::Generic::List<CppSharp::Parser::AST::TemplateArgument^>^ get();
+                    void set(System::Collections::Generic::List<CppSharp::Parser::AST::TemplateArgument^>^);
                 }
 
                 property CppSharp::Parser::AST::Function^ SpecializedFunction
@@ -2729,6 +2933,12 @@ namespace CppSharp
 
                 ~VarTemplate();
 
+                property System::Collections::Generic::List<CppSharp::Parser::AST::VarTemplateSpecialization^>^ Specializations
+                {
+                    System::Collections::Generic::List<CppSharp::Parser::AST::VarTemplateSpecialization^>^ get();
+                    void set(System::Collections::Generic::List<CppSharp::Parser::AST::VarTemplateSpecialization^>^);
+                }
+
                 property unsigned int SpecializationsCount
                 {
                     unsigned int get();
@@ -2739,6 +2949,10 @@ namespace CppSharp
                 void AddSpecializations(CppSharp::Parser::AST::VarTemplateSpecialization^ s);
 
                 void ClearSpecializations();
+
+                CppSharp::Parser::AST::VarTemplateSpecialization^ FindSpecialization(System::String^ usr);
+
+                CppSharp::Parser::AST::VarTemplatePartialSpecialization^ FindPartialSpecialization(System::String^ usr);
             };
 
             public ref class VarTemplateSpecialization : CppSharp::Parser::AST::Variable
@@ -2757,6 +2971,12 @@ namespace CppSharp
                 {
                     CppSharp::Parser::AST::VarTemplate^ get();
                     void set(CppSharp::Parser::AST::VarTemplate^);
+                }
+
+                property System::Collections::Generic::List<CppSharp::Parser::AST::TemplateArgument^>^ Arguments
+                {
+                    System::Collections::Generic::List<CppSharp::Parser::AST::TemplateArgument^>^ get();
+                    void set(System::Collections::Generic::List<CppSharp::Parser::AST::TemplateArgument^>^);
                 }
 
                 property CppSharp::Parser::AST::TemplateSpecializationKind SpecializationKind
@@ -2862,18 +3082,6 @@ namespace CppSharp
 
                 ~MacroDefinition();
 
-                property int LineNumberStart
-                {
-                    int get();
-                    void set(int);
-                }
-
-                property int LineNumberEnd
-                {
-                    int get();
-                    void set(int);
-                }
-
                 property System::String^ Name
                 {
                     System::String^ get();
@@ -2884,6 +3092,18 @@ namespace CppSharp
                 {
                     System::String^ get();
                     void set(System::String^);
+                }
+
+                property int LineNumberStart
+                {
+                    int get();
+                    void set(int);
+                }
+
+                property int LineNumberEnd
+                {
+                    int get();
+                    void set(int);
                 }
             };
 
@@ -2899,12 +3119,6 @@ namespace CppSharp
 
                 ~MacroExpansion();
 
-                property CppSharp::Parser::AST::MacroDefinition^ Definition
-                {
-                    CppSharp::Parser::AST::MacroDefinition^ get();
-                    void set(CppSharp::Parser::AST::MacroDefinition^);
-                }
-
                 property System::String^ Name
                 {
                     System::String^ get();
@@ -2915,6 +3129,12 @@ namespace CppSharp
                 {
                     System::String^ get();
                     void set(System::String^);
+                }
+
+                property CppSharp::Parser::AST::MacroDefinition^ Definition
+                {
+                    CppSharp::Parser::AST::MacroDefinition^ get();
+                    void set(CppSharp::Parser::AST::MacroDefinition^);
                 }
             };
 
@@ -2930,16 +3150,22 @@ namespace CppSharp
 
                 ~TranslationUnit();
 
+                property System::String^ FileName
+                {
+                    System::String^ get();
+                    void set(System::String^);
+                }
+
                 property bool IsSystemHeader
                 {
                     bool get();
                     void set(bool);
                 }
 
-                property System::String^ FileName
+                property System::Collections::Generic::List<CppSharp::Parser::AST::MacroDefinition^>^ Macros
                 {
-                    System::String^ get();
-                    void set(System::String^);
+                    System::Collections::Generic::List<CppSharp::Parser::AST::MacroDefinition^>^ get();
+                    void set(System::Collections::Generic::List<CppSharp::Parser::AST::MacroDefinition^>^);
                 }
 
                 property unsigned int MacrosCount
@@ -2973,16 +3199,28 @@ namespace CppSharp
 
                 ~NativeLibrary();
 
+                property System::String^ FileName
+                {
+                    System::String^ get();
+                    void set(System::String^);
+                }
+
                 property CppSharp::Parser::AST::ArchType ArchType
                 {
                     CppSharp::Parser::AST::ArchType get();
                     void set(CppSharp::Parser::AST::ArchType);
                 }
 
-                property System::String^ FileName
+                property System::Collections::Generic::List<System::String^>^ Symbols
                 {
-                    System::String^ get();
-                    void set(System::String^);
+                    System::Collections::Generic::List<System::String^>^ get();
+                    void set(System::Collections::Generic::List<System::String^>^);
+                }
+
+                property System::Collections::Generic::List<System::String^>^ Dependencies
+                {
+                    System::Collections::Generic::List<System::String^>^ get();
+                    void set(System::Collections::Generic::List<System::String^>^);
                 }
 
                 property unsigned int SymbolsCount
@@ -3030,10 +3268,18 @@ namespace CppSharp
 
                 ~ASTContext();
 
+                property System::Collections::Generic::List<CppSharp::Parser::AST::TranslationUnit^>^ TranslationUnits
+                {
+                    System::Collections::Generic::List<CppSharp::Parser::AST::TranslationUnit^>^ get();
+                    void set(System::Collections::Generic::List<CppSharp::Parser::AST::TranslationUnit^>^);
+                }
+
                 property unsigned int TranslationUnitsCount
                 {
                     unsigned int get();
                 }
+
+                CppSharp::Parser::AST::TranslationUnit^ FindOrCreateModule(System::String^ File);
 
                 CppSharp::Parser::AST::TranslationUnit^ GetTranslationUnits(unsigned int i);
 
@@ -3105,6 +3351,12 @@ namespace CppSharp
 
                 ~FullComment();
 
+                property System::Collections::Generic::List<CppSharp::Parser::AST::BlockContentComment^>^ Blocks
+                {
+                    System::Collections::Generic::List<CppSharp::Parser::AST::BlockContentComment^>^ get();
+                    void set(System::Collections::Generic::List<CppSharp::Parser::AST::BlockContentComment^>^);
+                }
+
                 property unsigned int BlocksCount
                 {
                     unsigned int get();
@@ -3156,6 +3408,12 @@ namespace CppSharp
                 {
                     bool get();
                     void set(bool);
+                }
+
+                property System::Collections::Generic::List<CppSharp::Parser::AST::InlineContentComment^>^ Content
+                {
+                    System::Collections::Generic::List<CppSharp::Parser::AST::InlineContentComment^>^ get();
+                    void set(System::Collections::Generic::List<CppSharp::Parser::AST::InlineContentComment^>^);
                 }
 
                 property unsigned int ContentCount
@@ -3225,6 +3483,12 @@ namespace CppSharp
                     void set(CppSharp::Parser::AST::ParagraphComment^);
                 }
 
+                property System::Collections::Generic::List<CppSharp::Parser::AST::BlockCommandComment::Argument^>^ Arguments
+                {
+                    System::Collections::Generic::List<CppSharp::Parser::AST::BlockCommandComment::Argument^>^ get();
+                    void set(System::Collections::Generic::List<CppSharp::Parser::AST::BlockCommandComment::Argument^>^);
+                }
+
                 property unsigned int ArgumentsCount
                 {
                     unsigned int get();
@@ -3283,6 +3547,12 @@ namespace CppSharp
 
                 ~TParamCommandComment();
 
+                property System::Collections::Generic::List<unsigned int>^ Position
+                {
+                    System::Collections::Generic::List<unsigned int>^ get();
+                    void set(System::Collections::Generic::List<unsigned int>^);
+                }
+
                 property unsigned int PositionCount
                 {
                     unsigned int get();
@@ -3325,6 +3595,12 @@ namespace CppSharp
                 VerbatimBlockComment(CppSharp::Parser::AST::VerbatimBlockComment^ _0);
 
                 ~VerbatimBlockComment();
+
+                property System::Collections::Generic::List<CppSharp::Parser::AST::VerbatimBlockLineComment^>^ Lines
+                {
+                    System::Collections::Generic::List<CppSharp::Parser::AST::VerbatimBlockLineComment^>^ get();
+                    void set(System::Collections::Generic::List<CppSharp::Parser::AST::VerbatimBlockLineComment^>^);
+                }
 
                 property unsigned int LinesCount
                 {
@@ -3418,6 +3694,12 @@ namespace CppSharp
                     void set(CppSharp::Parser::AST::InlineCommandComment::RenderKind);
                 }
 
+                property System::Collections::Generic::List<CppSharp::Parser::AST::InlineCommandComment::Argument^>^ Arguments
+                {
+                    System::Collections::Generic::List<CppSharp::Parser::AST::InlineCommandComment::Argument^>^ get();
+                    void set(System::Collections::Generic::List<CppSharp::Parser::AST::InlineCommandComment::Argument^>^);
+                }
+
                 property unsigned int ArgumentsCount
                 {
                     unsigned int get();
@@ -3500,6 +3782,12 @@ namespace CppSharp
                     void set(System::String^);
                 }
 
+                property System::Collections::Generic::List<CppSharp::Parser::AST::HTMLStartTagComment::Attribute^>^ Attributes
+                {
+                    System::Collections::Generic::List<CppSharp::Parser::AST::HTMLStartTagComment::Attribute^>^ get();
+                    void set(System::Collections::Generic::List<CppSharp::Parser::AST::HTMLStartTagComment::Attribute^>^);
+                }
+
                 property unsigned int AttributesCount
                 {
                     unsigned int get();
@@ -3575,12 +3863,6 @@ namespace CppSharp
                     void set(CppSharp::Parser::AST::RawCommentKind);
                 }
 
-                property CppSharp::Parser::AST::FullComment^ FullCommentBlock
-                {
-                    CppSharp::Parser::AST::FullComment^ get();
-                    void set(CppSharp::Parser::AST::FullComment^);
-                }
-
                 property System::String^ Text
                 {
                     System::String^ get();
@@ -3591,6 +3873,12 @@ namespace CppSharp
                 {
                     System::String^ get();
                     void set(System::String^);
+                }
+
+                property CppSharp::Parser::AST::FullComment^ FullCommentBlock
+                {
+                    CppSharp::Parser::AST::FullComment^ get();
+                    void set(CppSharp::Parser::AST::FullComment^);
                 }
 
                 protected:

--- a/src/CppParser/Bindings/CLI/CppParser.cpp
+++ b/src/CppParser/Bindings/CLI/CppParser.cpp
@@ -185,6 +185,170 @@ void CppSharp::Parser::CppParserOptions::__Instance::set(System::IntPtr object)
     NativePtr = (::CppSharp::CppParser::CppParserOptions*)object.ToPointer();
 }
 
+System::Collections::Generic::List<System::String^>^ CppSharp::Parser::CppParserOptions::Arguments::get()
+{
+    auto _tmp__Arguments = gcnew System::Collections::Generic::List<System::String^>();
+    for(auto _element : ((::CppSharp::CppParser::CppParserOptions*)NativePtr)->Arguments)
+    {
+        auto _marshalElement = clix::marshalString<clix::E_UTF8>(_element);
+        _tmp__Arguments->Add(_marshalElement);
+    }
+    return _tmp__Arguments;
+}
+
+void CppSharp::Parser::CppParserOptions::Arguments::set(System::Collections::Generic::List<System::String^>^ value)
+{
+    auto _tmpvalue = std::vector<::std::string>();
+    for each(System::String^ _element in value)
+    {
+        auto _marshalElement = clix::marshalString<clix::E_UTF8>(_element);
+        _tmpvalue.push_back(_marshalElement);
+    }
+    ((::CppSharp::CppParser::CppParserOptions*)NativePtr)->Arguments = _tmpvalue;
+}
+
+System::String^ CppSharp::Parser::CppParserOptions::LibraryFile::get()
+{
+    return clix::marshalString<clix::E_UTF8>(((::CppSharp::CppParser::CppParserOptions*)NativePtr)->libraryFile);
+}
+
+void CppSharp::Parser::CppParserOptions::LibraryFile::set(System::String^ value)
+{
+    ((::CppSharp::CppParser::CppParserOptions*)NativePtr)->libraryFile = clix::marshalString<clix::E_UTF8>(value);
+}
+
+System::Collections::Generic::List<System::String^>^ CppSharp::Parser::CppParserOptions::SourceFiles::get()
+{
+    auto _tmp__SourceFiles = gcnew System::Collections::Generic::List<System::String^>();
+    for(auto _element : ((::CppSharp::CppParser::CppParserOptions*)NativePtr)->SourceFiles)
+    {
+        auto _marshalElement = clix::marshalString<clix::E_UTF8>(_element);
+        _tmp__SourceFiles->Add(_marshalElement);
+    }
+    return _tmp__SourceFiles;
+}
+
+void CppSharp::Parser::CppParserOptions::SourceFiles::set(System::Collections::Generic::List<System::String^>^ value)
+{
+    auto _tmpvalue = std::vector<::std::string>();
+    for each(System::String^ _element in value)
+    {
+        auto _marshalElement = clix::marshalString<clix::E_UTF8>(_element);
+        _tmpvalue.push_back(_marshalElement);
+    }
+    ((::CppSharp::CppParser::CppParserOptions*)NativePtr)->SourceFiles = _tmpvalue;
+}
+
+System::Collections::Generic::List<System::String^>^ CppSharp::Parser::CppParserOptions::IncludeDirs::get()
+{
+    auto _tmp__IncludeDirs = gcnew System::Collections::Generic::List<System::String^>();
+    for(auto _element : ((::CppSharp::CppParser::CppParserOptions*)NativePtr)->IncludeDirs)
+    {
+        auto _marshalElement = clix::marshalString<clix::E_UTF8>(_element);
+        _tmp__IncludeDirs->Add(_marshalElement);
+    }
+    return _tmp__IncludeDirs;
+}
+
+void CppSharp::Parser::CppParserOptions::IncludeDirs::set(System::Collections::Generic::List<System::String^>^ value)
+{
+    auto _tmpvalue = std::vector<::std::string>();
+    for each(System::String^ _element in value)
+    {
+        auto _marshalElement = clix::marshalString<clix::E_UTF8>(_element);
+        _tmpvalue.push_back(_marshalElement);
+    }
+    ((::CppSharp::CppParser::CppParserOptions*)NativePtr)->IncludeDirs = _tmpvalue;
+}
+
+System::Collections::Generic::List<System::String^>^ CppSharp::Parser::CppParserOptions::SystemIncludeDirs::get()
+{
+    auto _tmp__SystemIncludeDirs = gcnew System::Collections::Generic::List<System::String^>();
+    for(auto _element : ((::CppSharp::CppParser::CppParserOptions*)NativePtr)->SystemIncludeDirs)
+    {
+        auto _marshalElement = clix::marshalString<clix::E_UTF8>(_element);
+        _tmp__SystemIncludeDirs->Add(_marshalElement);
+    }
+    return _tmp__SystemIncludeDirs;
+}
+
+void CppSharp::Parser::CppParserOptions::SystemIncludeDirs::set(System::Collections::Generic::List<System::String^>^ value)
+{
+    auto _tmpvalue = std::vector<::std::string>();
+    for each(System::String^ _element in value)
+    {
+        auto _marshalElement = clix::marshalString<clix::E_UTF8>(_element);
+        _tmpvalue.push_back(_marshalElement);
+    }
+    ((::CppSharp::CppParser::CppParserOptions*)NativePtr)->SystemIncludeDirs = _tmpvalue;
+}
+
+System::Collections::Generic::List<System::String^>^ CppSharp::Parser::CppParserOptions::Defines::get()
+{
+    auto _tmp__Defines = gcnew System::Collections::Generic::List<System::String^>();
+    for(auto _element : ((::CppSharp::CppParser::CppParserOptions*)NativePtr)->Defines)
+    {
+        auto _marshalElement = clix::marshalString<clix::E_UTF8>(_element);
+        _tmp__Defines->Add(_marshalElement);
+    }
+    return _tmp__Defines;
+}
+
+void CppSharp::Parser::CppParserOptions::Defines::set(System::Collections::Generic::List<System::String^>^ value)
+{
+    auto _tmpvalue = std::vector<::std::string>();
+    for each(System::String^ _element in value)
+    {
+        auto _marshalElement = clix::marshalString<clix::E_UTF8>(_element);
+        _tmpvalue.push_back(_marshalElement);
+    }
+    ((::CppSharp::CppParser::CppParserOptions*)NativePtr)->Defines = _tmpvalue;
+}
+
+System::Collections::Generic::List<System::String^>^ CppSharp::Parser::CppParserOptions::Undefines::get()
+{
+    auto _tmp__Undefines = gcnew System::Collections::Generic::List<System::String^>();
+    for(auto _element : ((::CppSharp::CppParser::CppParserOptions*)NativePtr)->Undefines)
+    {
+        auto _marshalElement = clix::marshalString<clix::E_UTF8>(_element);
+        _tmp__Undefines->Add(_marshalElement);
+    }
+    return _tmp__Undefines;
+}
+
+void CppSharp::Parser::CppParserOptions::Undefines::set(System::Collections::Generic::List<System::String^>^ value)
+{
+    auto _tmpvalue = std::vector<::std::string>();
+    for each(System::String^ _element in value)
+    {
+        auto _marshalElement = clix::marshalString<clix::E_UTF8>(_element);
+        _tmpvalue.push_back(_marshalElement);
+    }
+    ((::CppSharp::CppParser::CppParserOptions*)NativePtr)->Undefines = _tmpvalue;
+}
+
+System::Collections::Generic::List<System::String^>^ CppSharp::Parser::CppParserOptions::LibraryDirs::get()
+{
+    auto _tmp__LibraryDirs = gcnew System::Collections::Generic::List<System::String^>();
+    for(auto _element : ((::CppSharp::CppParser::CppParserOptions*)NativePtr)->LibraryDirs)
+    {
+        auto _marshalElement = clix::marshalString<clix::E_UTF8>(_element);
+        _tmp__LibraryDirs->Add(_marshalElement);
+    }
+    return _tmp__LibraryDirs;
+}
+
+void CppSharp::Parser::CppParserOptions::LibraryDirs::set(System::Collections::Generic::List<System::String^>^ value)
+{
+    auto _tmpvalue = std::vector<::std::string>();
+    for each(System::String^ _element in value)
+    {
+        auto _marshalElement = clix::marshalString<clix::E_UTF8>(_element);
+        _tmpvalue.push_back(_marshalElement);
+    }
+    ((::CppSharp::CppParser::CppParserOptions*)NativePtr)->LibraryDirs = _tmpvalue;
+}
+
 CppSharp::Parser::AST::ASTContext^ CppSharp::Parser::CppParserOptions::ASTContext::get()
 {
     return (((::CppSharp::CppParser::CppParserOptions*)NativePtr)->ASTContext == nullptr) ? nullptr : gcnew CppSharp::Parser::AST::ASTContext((::CppSharp::CppParser::AST::ASTContext*)((::CppSharp::CppParser::CppParserOptions*)NativePtr)->ASTContext);
@@ -203,6 +367,16 @@ int CppSharp::Parser::CppParserOptions::ToolSetToUse::get()
 void CppSharp::Parser::CppParserOptions::ToolSetToUse::set(int value)
 {
     ((::CppSharp::CppParser::CppParserOptions*)NativePtr)->toolSetToUse = value;
+}
+
+System::String^ CppSharp::Parser::CppParserOptions::TargetTriple::get()
+{
+    return clix::marshalString<clix::E_UTF8>(((::CppSharp::CppParser::CppParserOptions*)NativePtr)->targetTriple);
+}
+
+void CppSharp::Parser::CppParserOptions::TargetTriple::set(System::String^ value)
+{
+    ((::CppSharp::CppParser::CppParserOptions*)NativePtr)->targetTriple = clix::marshalString<clix::E_UTF8>(value);
 }
 
 CppSharp::Parser::AST::CppAbi CppSharp::Parser::CppParserOptions::Abi::get()
@@ -273,34 +447,6 @@ CppSharp::Parser::ParserTargetInfo^ CppSharp::Parser::CppParserOptions::TargetIn
 void CppSharp::Parser::CppParserOptions::TargetInfo::set(CppSharp::Parser::ParserTargetInfo^ value)
 {
     ((::CppSharp::CppParser::CppParserOptions*)NativePtr)->targetInfo = (::CppSharp::CppParser::ParserTargetInfo*)value->NativePtr;
-}
-
-System::String^ CppSharp::Parser::CppParserOptions::LibraryFile::get()
-{
-    auto __ret = ((::CppSharp::CppParser::CppParserOptions*)NativePtr)->getLibraryFile();
-    if (__ret == nullptr) return nullptr;
-    return (__ret == 0 ? nullptr : clix::marshalString<clix::E_UTF8>(__ret));
-}
-
-void CppSharp::Parser::CppParserOptions::LibraryFile::set(System::String^ s)
-{
-    auto ___arg0 = clix::marshalString<clix::E_UTF8>(s);
-    auto __arg0 = ___arg0.c_str();
-    ((::CppSharp::CppParser::CppParserOptions*)NativePtr)->setLibraryFile(__arg0);
-}
-
-System::String^ CppSharp::Parser::CppParserOptions::TargetTriple::get()
-{
-    auto __ret = ((::CppSharp::CppParser::CppParserOptions*)NativePtr)->getTargetTriple();
-    if (__ret == nullptr) return nullptr;
-    return (__ret == 0 ? nullptr : clix::marshalString<clix::E_UTF8>(__ret));
-}
-
-void CppSharp::Parser::CppParserOptions::TargetTriple::set(System::String^ s)
-{
-    auto ___arg0 = clix::marshalString<clix::E_UTF8>(s);
-    auto __arg0 = ___arg0.c_str();
-    ((::CppSharp::CppParser::CppParserOptions*)NativePtr)->setTargetTriple(__arg0);
 }
 
 unsigned int CppSharp::Parser::CppParserOptions::ArgumentsCount::get()
@@ -386,6 +532,26 @@ void CppSharp::Parser::ParserDiagnostic::__Instance::set(System::IntPtr object)
     NativePtr = (::CppSharp::CppParser::ParserDiagnostic*)object.ToPointer();
 }
 
+System::String^ CppSharp::Parser::ParserDiagnostic::FileName::get()
+{
+    return clix::marshalString<clix::E_UTF8>(((::CppSharp::CppParser::ParserDiagnostic*)NativePtr)->fileName);
+}
+
+void CppSharp::Parser::ParserDiagnostic::FileName::set(System::String^ value)
+{
+    ((::CppSharp::CppParser::ParserDiagnostic*)NativePtr)->fileName = clix::marshalString<clix::E_UTF8>(value);
+}
+
+System::String^ CppSharp::Parser::ParserDiagnostic::Message::get()
+{
+    return clix::marshalString<clix::E_UTF8>(((::CppSharp::CppParser::ParserDiagnostic*)NativePtr)->message);
+}
+
+void CppSharp::Parser::ParserDiagnostic::Message::set(System::String^ value)
+{
+    ((::CppSharp::CppParser::ParserDiagnostic*)NativePtr)->message = clix::marshalString<clix::E_UTF8>(value);
+}
+
 CppSharp::Parser::ParserDiagnosticLevel CppSharp::Parser::ParserDiagnostic::Level::get()
 {
     return (CppSharp::Parser::ParserDiagnosticLevel)((::CppSharp::CppParser::ParserDiagnostic*)NativePtr)->level;
@@ -414,34 +580,6 @@ int CppSharp::Parser::ParserDiagnostic::ColumnNumber::get()
 void CppSharp::Parser::ParserDiagnostic::ColumnNumber::set(int value)
 {
     ((::CppSharp::CppParser::ParserDiagnostic*)NativePtr)->columnNumber = value;
-}
-
-System::String^ CppSharp::Parser::ParserDiagnostic::FileName::get()
-{
-    auto __ret = ((::CppSharp::CppParser::ParserDiagnostic*)NativePtr)->getFileName();
-    if (__ret == nullptr) return nullptr;
-    return (__ret == 0 ? nullptr : clix::marshalString<clix::E_UTF8>(__ret));
-}
-
-void CppSharp::Parser::ParserDiagnostic::FileName::set(System::String^ s)
-{
-    auto ___arg0 = clix::marshalString<clix::E_UTF8>(s);
-    auto __arg0 = ___arg0.c_str();
-    ((::CppSharp::CppParser::ParserDiagnostic*)NativePtr)->setFileName(__arg0);
-}
-
-System::String^ CppSharp::Parser::ParserDiagnostic::Message::get()
-{
-    auto __ret = ((::CppSharp::CppParser::ParserDiagnostic*)NativePtr)->getMessage();
-    if (__ret == nullptr) return nullptr;
-    return (__ret == 0 ? nullptr : clix::marshalString<clix::E_UTF8>(__ret));
-}
-
-void CppSharp::Parser::ParserDiagnostic::Message::set(System::String^ s)
-{
-    auto ___arg0 = clix::marshalString<clix::E_UTF8>(s);
-    auto __arg0 = ___arg0.c_str();
-    ((::CppSharp::CppParser::ParserDiagnostic*)NativePtr)->setMessage(__arg0);
 }
 
 CppSharp::Parser::ParserResult::ParserResult(::CppSharp::CppParser::ParserResult* native)
@@ -513,6 +651,29 @@ CppSharp::Parser::ParserResultKind CppSharp::Parser::ParserResult::Kind::get()
 void CppSharp::Parser::ParserResult::Kind::set(CppSharp::Parser::ParserResultKind value)
 {
     ((::CppSharp::CppParser::ParserResult*)NativePtr)->kind = (::CppSharp::CppParser::ParserResultKind)value;
+}
+
+System::Collections::Generic::List<CppSharp::Parser::ParserDiagnostic^>^ CppSharp::Parser::ParserResult::Diagnostics::get()
+{
+    auto _tmp__Diagnostics = gcnew System::Collections::Generic::List<CppSharp::Parser::ParserDiagnostic^>();
+    for(auto _element : ((::CppSharp::CppParser::ParserResult*)NativePtr)->Diagnostics)
+    {
+        auto ___element = new ::CppSharp::CppParser::ParserDiagnostic(_element);
+        auto _marshalElement = (___element == nullptr) ? nullptr : gcnew CppSharp::Parser::ParserDiagnostic((::CppSharp::CppParser::ParserDiagnostic*)___element);
+        _tmp__Diagnostics->Add(_marshalElement);
+    }
+    return _tmp__Diagnostics;
+}
+
+void CppSharp::Parser::ParserResult::Diagnostics::set(System::Collections::Generic::List<CppSharp::Parser::ParserDiagnostic^>^ value)
+{
+    auto _tmpvalue = std::vector<::CppSharp::CppParser::ParserDiagnostic>();
+    for each(CppSharp::Parser::ParserDiagnostic^ _element in value)
+    {
+        auto _marshalElement = *(::CppSharp::CppParser::ParserDiagnostic*)_element->NativePtr;
+        _tmpvalue.push_back(_marshalElement);
+    }
+    ((::CppSharp::CppParser::ParserResult*)NativePtr)->Diagnostics = _tmpvalue;
 }
 
 CppSharp::Parser::AST::ASTContext^ CppSharp::Parser::ParserResult::ASTContext::get()

--- a/src/CppParser/Bindings/CLI/CppParser.h
+++ b/src/CppParser/Bindings/CLI/CppParser.h
@@ -96,6 +96,54 @@ namespace CppSharp
 
             ~CppParserOptions();
 
+            property System::Collections::Generic::List<System::String^>^ Arguments
+            {
+                System::Collections::Generic::List<System::String^>^ get();
+                void set(System::Collections::Generic::List<System::String^>^);
+            }
+
+            property System::String^ LibraryFile
+            {
+                System::String^ get();
+                void set(System::String^);
+            }
+
+            property System::Collections::Generic::List<System::String^>^ SourceFiles
+            {
+                System::Collections::Generic::List<System::String^>^ get();
+                void set(System::Collections::Generic::List<System::String^>^);
+            }
+
+            property System::Collections::Generic::List<System::String^>^ IncludeDirs
+            {
+                System::Collections::Generic::List<System::String^>^ get();
+                void set(System::Collections::Generic::List<System::String^>^);
+            }
+
+            property System::Collections::Generic::List<System::String^>^ SystemIncludeDirs
+            {
+                System::Collections::Generic::List<System::String^>^ get();
+                void set(System::Collections::Generic::List<System::String^>^);
+            }
+
+            property System::Collections::Generic::List<System::String^>^ Defines
+            {
+                System::Collections::Generic::List<System::String^>^ get();
+                void set(System::Collections::Generic::List<System::String^>^);
+            }
+
+            property System::Collections::Generic::List<System::String^>^ Undefines
+            {
+                System::Collections::Generic::List<System::String^>^ get();
+                void set(System::Collections::Generic::List<System::String^>^);
+            }
+
+            property System::Collections::Generic::List<System::String^>^ LibraryDirs
+            {
+                System::Collections::Generic::List<System::String^>^ get();
+                void set(System::Collections::Generic::List<System::String^>^);
+            }
+
             property CppSharp::Parser::AST::ASTContext^ ASTContext
             {
                 CppSharp::Parser::AST::ASTContext^ get();
@@ -106,6 +154,12 @@ namespace CppSharp
             {
                 int get();
                 void set(int);
+            }
+
+            property System::String^ TargetTriple
+            {
+                System::String^ get();
+                void set(System::String^);
             }
 
             property CppSharp::Parser::AST::CppAbi Abi
@@ -148,18 +202,6 @@ namespace CppSharp
             {
                 CppSharp::Parser::ParserTargetInfo^ get();
                 void set(CppSharp::Parser::ParserTargetInfo^);
-            }
-
-            property System::String^ LibraryFile
-            {
-                System::String^ get();
-                void set(System::String^);
-            }
-
-            property System::String^ TargetTriple
-            {
-                System::String^ get();
-                void set(System::String^);
             }
 
             property unsigned int ArgumentsCount
@@ -262,6 +304,18 @@ namespace CppSharp
 
             ~ParserDiagnostic();
 
+            property System::String^ FileName
+            {
+                System::String^ get();
+                void set(System::String^);
+            }
+
+            property System::String^ Message
+            {
+                System::String^ get();
+                void set(System::String^);
+            }
+
             property CppSharp::Parser::ParserDiagnosticLevel Level
             {
                 CppSharp::Parser::ParserDiagnosticLevel get();
@@ -278,18 +332,6 @@ namespace CppSharp
             {
                 int get();
                 void set(int);
-            }
-
-            property System::String^ FileName
-            {
-                System::String^ get();
-                void set(System::String^);
-            }
-
-            property System::String^ Message
-            {
-                System::String^ get();
-                void set(System::String^);
             }
 
             protected:
@@ -319,6 +361,12 @@ namespace CppSharp
             {
                 CppSharp::Parser::ParserResultKind get();
                 void set(CppSharp::Parser::ParserResultKind);
+            }
+
+            property System::Collections::Generic::List<CppSharp::Parser::ParserDiagnostic^>^ Diagnostics
+            {
+                System::Collections::Generic::List<CppSharp::Parser::ParserDiagnostic^>^ get();
+                void set(System::Collections::Generic::List<CppSharp::Parser::ParserDiagnostic^>^);
             }
 
             property CppSharp::Parser::AST::ASTContext^ ASTContext

--- a/src/CppParser/Bindings/CLI/Target.cpp
+++ b/src/CppParser/Bindings/CLI/Target.cpp
@@ -50,6 +50,16 @@ void CppSharp::Parser::ParserTargetInfo::__Instance::set(System::IntPtr object)
     NativePtr = (::CppSharp::CppParser::ParserTargetInfo*)object.ToPointer();
 }
 
+System::String^ CppSharp::Parser::ParserTargetInfo::ABI::get()
+{
+    return clix::marshalString<clix::E_UTF8>(((::CppSharp::CppParser::ParserTargetInfo*)NativePtr)->ABI);
+}
+
+void CppSharp::Parser::ParserTargetInfo::ABI::set(System::String^ value)
+{
+    ((::CppSharp::CppParser::ParserTargetInfo*)NativePtr)->ABI = clix::marshalString<clix::E_UTF8>(value);
+}
+
 CppSharp::Parser::ParserIntType CppSharp::Parser::ParserTargetInfo::Char16Type::get()
 {
     return (CppSharp::Parser::ParserIntType)((::CppSharp::CppParser::ParserTargetInfo*)NativePtr)->char16Type;
@@ -448,19 +458,5 @@ unsigned int CppSharp::Parser::ParserTargetInfo::Float128Width::get()
 void CppSharp::Parser::ParserTargetInfo::Float128Width::set(unsigned int value)
 {
     ((::CppSharp::CppParser::ParserTargetInfo*)NativePtr)->float128Width = value;
-}
-
-System::String^ CppSharp::Parser::ParserTargetInfo::ABI::get()
-{
-    auto __ret = ((::CppSharp::CppParser::ParserTargetInfo*)NativePtr)->getABI();
-    if (__ret == nullptr) return nullptr;
-    return (__ret == 0 ? nullptr : clix::marshalString<clix::E_UTF8>(__ret));
-}
-
-void CppSharp::Parser::ParserTargetInfo::ABI::set(System::String^ s)
-{
-    auto ___arg0 = clix::marshalString<clix::E_UTF8>(s);
-    auto __arg0 = ___arg0.c_str();
-    ((::CppSharp::CppParser::ParserTargetInfo*)NativePtr)->setABI(__arg0);
 }
 

--- a/src/CppParser/Bindings/CLI/Target.h
+++ b/src/CppParser/Bindings/CLI/Target.h
@@ -56,6 +56,12 @@ namespace CppSharp
 
             ~ParserTargetInfo();
 
+            property System::String^ ABI
+            {
+                System::String^ get();
+                void set(System::String^);
+            }
+
             property CppSharp::Parser::ParserIntType Char16Type
             {
                 CppSharp::Parser::ParserIntType get();
@@ -294,12 +300,6 @@ namespace CppSharp
             {
                 unsigned int get();
                 void set(unsigned int);
-            }
-
-            property System::String^ ABI
-            {
-                System::String^ get();
-                void set(System::String^);
             }
 
             protected:

--- a/src/CppParser/Bindings/CSharp/i686-apple-darwin12.4.0/CppSharp.CppParser.cs
+++ b/src/CppParser/Bindings/CSharp/i686-apple-darwin12.4.0/CppSharp.CppParser.cs
@@ -2589,7 +2589,7 @@ namespace CppSharp
                     internal global::CppSharp.Parser.AST.QualifiedType.__Internal qualifier;
 
                     [FieldOffset(16)]
-                    internal global::Std.__1.BasicString.__Internal Identifier;
+                    internal global::Std.__1.BasicString.__Internal identifier;
 
                     [SuppressUnmanagedCodeSecurity]
                     [DllImport("CppSharp.CppParser", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
@@ -2605,16 +2605,6 @@ namespace CppSharp
                     [DllImport("CppSharp.CppParser", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
                         EntryPoint="_ZN8CppSharp9CppParser3AST17DependentNameTypeD2Ev")]
                     internal static extern void dtor_0(global::System.IntPtr instance);
-
-                    [SuppressUnmanagedCodeSecurity]
-                    [DllImport("CppSharp.CppParser", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
-                        EntryPoint="_ZN8CppSharp9CppParser3AST17DependentNameType13getIdentifierEv")]
-                    internal static extern global::System.IntPtr GetIdentifier(global::System.IntPtr instance);
-
-                    [SuppressUnmanagedCodeSecurity]
-                    [DllImport("CppSharp.CppParser", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
-                        EntryPoint="_ZN8CppSharp9CppParser3AST17DependentNameType13setIdentifierEPKc")]
-                    internal static extern void SetIdentifier(global::System.IntPtr instance, [MarshalAs(UnmanagedType.LPStr)] string s);
                 }
 
                 internal static new global::CppSharp.Parser.AST.DependentNameType __CreateInstance(global::System.IntPtr native, bool skipVTables = false)
@@ -2701,13 +2691,14 @@ namespace CppSharp
                 {
                     get
                     {
-                        var __ret = __Internal.GetIdentifier((__Instance + __PointerAdjustment));
-                        return Marshal.PtrToStringAnsi(__ret);
+                        return global::Std.__1.BasicString.__CreateInstance(((global::CppSharp.Parser.AST.DependentNameType.__Internal*) __Instance)->identifier).CStr();
                     }
 
                     set
                     {
-                        __Internal.SetIdentifier((__Instance + __PointerAdjustment), value);
+                        var __allocator0 = new global::Std.__1.Allocator();
+                        var __basicString0 = new global::Std.__1.BasicString(value, __allocator0);
+                        ((global::CppSharp.Parser.AST.DependentNameType.__Internal*) __Instance)->identifier = *(global::Std.__1.BasicString.__Internal*) __basicString0.__Instance;
                     }
                 }
             }
@@ -3562,7 +3553,7 @@ namespace CppSharp
                     internal uint offset;
 
                     [FieldOffset(4)]
-                    internal global::Std.__1.BasicString.__Internal Name;
+                    internal global::Std.__1.BasicString.__Internal name;
 
                     [FieldOffset(16)]
                     internal global::CppSharp.Parser.AST.QualifiedType.__Internal qualifiedType;
@@ -3584,16 +3575,6 @@ namespace CppSharp
                     [DllImport("CppSharp.CppParser", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
                         EntryPoint="_ZN8CppSharp9CppParser3AST11LayoutFieldD2Ev")]
                     internal static extern void dtor_0(global::System.IntPtr instance);
-
-                    [SuppressUnmanagedCodeSecurity]
-                    [DllImport("CppSharp.CppParser", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
-                        EntryPoint="_ZN8CppSharp9CppParser3AST11LayoutField7getNameEv")]
-                    internal static extern global::System.IntPtr GetName(global::System.IntPtr instance);
-
-                    [SuppressUnmanagedCodeSecurity]
-                    [DllImport("CppSharp.CppParser", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
-                        EntryPoint="_ZN8CppSharp9CppParser3AST11LayoutField7setNameEPKc")]
-                    internal static extern void SetName(global::System.IntPtr instance, [MarshalAs(UnmanagedType.LPStr)] string s);
                 }
 
                 public global::System.IntPtr __Instance { get; protected set; }
@@ -3685,6 +3666,21 @@ namespace CppSharp
                     }
                 }
 
+                public string Name
+                {
+                    get
+                    {
+                        return global::Std.__1.BasicString.__CreateInstance(((global::CppSharp.Parser.AST.LayoutField.__Internal*) __Instance)->name).CStr();
+                    }
+
+                    set
+                    {
+                        var __allocator0 = new global::Std.__1.Allocator();
+                        var __basicString0 = new global::Std.__1.BasicString(value, __allocator0);
+                        ((global::CppSharp.Parser.AST.LayoutField.__Internal*) __Instance)->name = *(global::Std.__1.BasicString.__Internal*) __basicString0.__Instance;
+                    }
+                }
+
                 public global::CppSharp.Parser.AST.QualifiedType QualifiedType
                 {
                     get
@@ -3708,20 +3704,6 @@ namespace CppSharp
                     set
                     {
                         ((global::CppSharp.Parser.AST.LayoutField.__Internal*) __Instance)->fieldPtr = (global::System.IntPtr) value;
-                    }
-                }
-
-                public string Name
-                {
-                    get
-                    {
-                        var __ret = __Internal.GetName((__Instance + __PointerAdjustment));
-                        return Marshal.PtrToStringAnsi(__ret);
-                    }
-
-                    set
-                    {
-                        __Internal.SetName((__Instance + __PointerAdjustment), value);
                     }
                 }
             }
@@ -4251,13 +4233,13 @@ namespace CppSharp
                     internal int lineNumberEnd;
 
                     [FieldOffset(24)]
-                    internal global::Std.__1.BasicString.__Internal Name;
+                    internal global::Std.__1.BasicString.__Internal name;
 
                     [FieldOffset(36)]
                     internal global::Std.__1.BasicString.__Internal USR;
 
                     [FieldOffset(48)]
-                    internal global::Std.__1.BasicString.__Internal DebugText;
+                    internal global::Std.__1.BasicString.__Internal debugText;
 
                     [FieldOffset(60)]
                     internal byte isIncomplete;
@@ -4330,36 +4312,6 @@ namespace CppSharp
                     [DllImport("CppSharp.CppParser", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
                         EntryPoint="_ZN8CppSharp9CppParser3AST11Declaration19clearRedeclarationsEv")]
                     internal static extern void ClearRedeclarations_0(global::System.IntPtr instance);
-
-                    [SuppressUnmanagedCodeSecurity]
-                    [DllImport("CppSharp.CppParser", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
-                        EntryPoint="_ZN8CppSharp9CppParser3AST11Declaration7getNameEv")]
-                    internal static extern global::System.IntPtr GetName(global::System.IntPtr instance);
-
-                    [SuppressUnmanagedCodeSecurity]
-                    [DllImport("CppSharp.CppParser", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
-                        EntryPoint="_ZN8CppSharp9CppParser3AST11Declaration7setNameEPKc")]
-                    internal static extern void SetName(global::System.IntPtr instance, [MarshalAs(UnmanagedType.LPStr)] string s);
-
-                    [SuppressUnmanagedCodeSecurity]
-                    [DllImport("CppSharp.CppParser", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
-                        EntryPoint="_ZN8CppSharp9CppParser3AST11Declaration6getUSREv")]
-                    internal static extern global::System.IntPtr GetUSR(global::System.IntPtr instance);
-
-                    [SuppressUnmanagedCodeSecurity]
-                    [DllImport("CppSharp.CppParser", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
-                        EntryPoint="_ZN8CppSharp9CppParser3AST11Declaration6setUSREPKc")]
-                    internal static extern void SetUSR(global::System.IntPtr instance, [MarshalAs(UnmanagedType.LPStr)] string s);
-
-                    [SuppressUnmanagedCodeSecurity]
-                    [DllImport("CppSharp.CppParser", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
-                        EntryPoint="_ZN8CppSharp9CppParser3AST11Declaration12getDebugTextEv")]
-                    internal static extern global::System.IntPtr GetDebugText(global::System.IntPtr instance);
-
-                    [SuppressUnmanagedCodeSecurity]
-                    [DllImport("CppSharp.CppParser", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
-                        EntryPoint="_ZN8CppSharp9CppParser3AST11Declaration12setDebugTextEPKc")]
-                    internal static extern void SetDebugText(global::System.IntPtr instance, [MarshalAs(UnmanagedType.LPStr)] string s);
 
                     [SuppressUnmanagedCodeSecurity]
                     [DllImport("CppSharp.CppParser", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
@@ -4584,6 +4536,51 @@ namespace CppSharp
                     }
                 }
 
+                public string Name
+                {
+                    get
+                    {
+                        return global::Std.__1.BasicString.__CreateInstance(((global::CppSharp.Parser.AST.Declaration.__Internal*) __Instance)->name).CStr();
+                    }
+
+                    set
+                    {
+                        var __allocator0 = new global::Std.__1.Allocator();
+                        var __basicString0 = new global::Std.__1.BasicString(value, __allocator0);
+                        ((global::CppSharp.Parser.AST.Declaration.__Internal*) __Instance)->name = *(global::Std.__1.BasicString.__Internal*) __basicString0.__Instance;
+                    }
+                }
+
+                public string USR
+                {
+                    get
+                    {
+                        return global::Std.__1.BasicString.__CreateInstance(((global::CppSharp.Parser.AST.Declaration.__Internal*) __Instance)->USR).CStr();
+                    }
+
+                    set
+                    {
+                        var __allocator0 = new global::Std.__1.Allocator();
+                        var __basicString0 = new global::Std.__1.BasicString(value, __allocator0);
+                        ((global::CppSharp.Parser.AST.Declaration.__Internal*) __Instance)->USR = *(global::Std.__1.BasicString.__Internal*) __basicString0.__Instance;
+                    }
+                }
+
+                public string DebugText
+                {
+                    get
+                    {
+                        return global::Std.__1.BasicString.__CreateInstance(((global::CppSharp.Parser.AST.Declaration.__Internal*) __Instance)->debugText).CStr();
+                    }
+
+                    set
+                    {
+                        var __allocator0 = new global::Std.__1.Allocator();
+                        var __basicString0 = new global::Std.__1.BasicString(value, __allocator0);
+                        ((global::CppSharp.Parser.AST.Declaration.__Internal*) __Instance)->debugText = *(global::Std.__1.BasicString.__Internal*) __basicString0.__Instance;
+                    }
+                }
+
                 public bool IsIncomplete
                 {
                     get
@@ -4685,48 +4682,6 @@ namespace CppSharp
                     }
                 }
 
-                public string Name
-                {
-                    get
-                    {
-                        var __ret = __Internal.GetName((__Instance + __PointerAdjustment));
-                        return Marshal.PtrToStringAnsi(__ret);
-                    }
-
-                    set
-                    {
-                        __Internal.SetName((__Instance + __PointerAdjustment), value);
-                    }
-                }
-
-                public string USR
-                {
-                    get
-                    {
-                        var __ret = __Internal.GetUSR((__Instance + __PointerAdjustment));
-                        return Marshal.PtrToStringAnsi(__ret);
-                    }
-
-                    set
-                    {
-                        __Internal.SetUSR((__Instance + __PointerAdjustment), value);
-                    }
-                }
-
-                public string DebugText
-                {
-                    get
-                    {
-                        var __ret = __Internal.GetDebugText((__Instance + __PointerAdjustment));
-                        return Marshal.PtrToStringAnsi(__ret);
-                    }
-
-                    set
-                    {
-                        __Internal.SetDebugText((__Instance + __PointerAdjustment), value);
-                    }
-                }
-
                 public uint PreprocessedEntitiesCount
                 {
                     get
@@ -4770,13 +4725,13 @@ namespace CppSharp
                     internal int lineNumberEnd;
 
                     [FieldOffset(24)]
-                    internal global::Std.__1.BasicString.__Internal Name;
+                    internal global::Std.__1.BasicString.__Internal name;
 
                     [FieldOffset(36)]
                     internal global::Std.__1.BasicString.__Internal USR;
 
                     [FieldOffset(48)]
-                    internal global::Std.__1.BasicString.__Internal DebugText;
+                    internal global::Std.__1.BasicString.__Internal debugText;
 
                     [FieldOffset(60)]
                     internal byte isIncomplete;
@@ -5441,13 +5396,13 @@ namespace CppSharp
                     internal int lineNumberEnd;
 
                     [FieldOffset(24)]
-                    internal global::Std.__1.BasicString.__Internal Name;
+                    internal global::Std.__1.BasicString.__Internal name;
 
                     [FieldOffset(36)]
                     internal global::Std.__1.BasicString.__Internal USR;
 
                     [FieldOffset(48)]
-                    internal global::Std.__1.BasicString.__Internal DebugText;
+                    internal global::Std.__1.BasicString.__Internal debugText;
 
                     [FieldOffset(60)]
                     internal byte isIncomplete;
@@ -5605,13 +5560,13 @@ namespace CppSharp
                     internal int lineNumberEnd;
 
                     [FieldOffset(24)]
-                    internal global::Std.__1.BasicString.__Internal Name;
+                    internal global::Std.__1.BasicString.__Internal name;
 
                     [FieldOffset(36)]
                     internal global::Std.__1.BasicString.__Internal USR;
 
                     [FieldOffset(48)]
-                    internal global::Std.__1.BasicString.__Internal DebugText;
+                    internal global::Std.__1.BasicString.__Internal debugText;
 
                     [FieldOffset(60)]
                     internal byte isIncomplete;
@@ -5751,13 +5706,13 @@ namespace CppSharp
                     internal int lineNumberEnd;
 
                     [FieldOffset(24)]
-                    internal global::Std.__1.BasicString.__Internal Name;
+                    internal global::Std.__1.BasicString.__Internal name;
 
                     [FieldOffset(36)]
                     internal global::Std.__1.BasicString.__Internal USR;
 
                     [FieldOffset(48)]
-                    internal global::Std.__1.BasicString.__Internal DebugText;
+                    internal global::Std.__1.BasicString.__Internal debugText;
 
                     [FieldOffset(60)]
                     internal byte isIncomplete;
@@ -5918,13 +5873,13 @@ namespace CppSharp
                     internal int lineNumberEnd;
 
                     [FieldOffset(24)]
-                    internal global::Std.__1.BasicString.__Internal Name;
+                    internal global::Std.__1.BasicString.__Internal name;
 
                     [FieldOffset(36)]
                     internal global::Std.__1.BasicString.__Internal USR;
 
                     [FieldOffset(48)]
-                    internal global::Std.__1.BasicString.__Internal DebugText;
+                    internal global::Std.__1.BasicString.__Internal debugText;
 
                     [FieldOffset(60)]
                     internal byte isIncomplete;
@@ -6070,27 +6025,22 @@ namespace CppSharp
                     internal global::System.IntPtr decl;
 
                     [FieldOffset(8)]
-                    internal global::Std.__1.BasicString.__Internal String;
+                    internal global::Std.__1.BasicString.__Internal @string;
+
+                    [SuppressUnmanagedCodeSecurity]
+                    [DllImport("CppSharp.CppParser", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
+                        EntryPoint="_ZN8CppSharp9CppParser3AST9StatementC2ERKNSt3__112basic_stringIcNS3_11char_traitsIcEENS3_9allocatorIcEEEENS1_14StatementClassEPNS1_11DeclarationE")]
+                    internal static extern void ctor_0(global::System.IntPtr instance, global::System.IntPtr str, global::CppSharp.Parser.AST.StatementClass Class, global::System.IntPtr decl);
 
                     [SuppressUnmanagedCodeSecurity]
                     [DllImport("CppSharp.CppParser", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
                         EntryPoint="_ZN8CppSharp9CppParser3AST9StatementC2ERKS2_")]
-                    internal static extern void cctor_0(global::System.IntPtr instance, global::System.IntPtr _0);
+                    internal static extern void cctor_1(global::System.IntPtr instance, global::System.IntPtr _0);
 
                     [SuppressUnmanagedCodeSecurity]
                     [DllImport("CppSharp.CppParser", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
                         EntryPoint="_ZN8CppSharp9CppParser3AST9StatementD2Ev")]
                     internal static extern void dtor_0(global::System.IntPtr instance);
-
-                    [SuppressUnmanagedCodeSecurity]
-                    [DllImport("CppSharp.CppParser", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
-                        EntryPoint="_ZN8CppSharp9CppParser3AST9Statement9getStringEv")]
-                    internal static extern global::System.IntPtr GetString(global::System.IntPtr instance);
-
-                    [SuppressUnmanagedCodeSecurity]
-                    [DllImport("CppSharp.CppParser", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
-                        EntryPoint="_ZN8CppSharp9CppParser3AST9Statement9setStringEPKc")]
-                    internal static extern void SetString(global::System.IntPtr instance, [MarshalAs(UnmanagedType.LPStr)] string s);
                 }
 
                 public global::System.IntPtr __Instance { get; protected set; }
@@ -6114,7 +6064,7 @@ namespace CppSharp
                 private static void* __CopyValue(global::CppSharp.Parser.AST.Statement.__Internal native)
                 {
                     var ret = Marshal.AllocHGlobal(sizeof(global::CppSharp.Parser.AST.Statement.__Internal));
-                    global::CppSharp.Parser.AST.Statement.__Internal.cctor_0(ret, new global::System.IntPtr(&native));
+                    global::CppSharp.Parser.AST.Statement.__Internal.cctor_1(ret, new global::System.IntPtr(&native));
                     return ret.ToPointer();
                 }
 
@@ -6132,6 +6082,20 @@ namespace CppSharp
                     __Instance = new global::System.IntPtr(native);
                 }
 
+                public Statement(string str, global::CppSharp.Parser.AST.StatementClass Class, global::CppSharp.Parser.AST.Declaration decl)
+                {
+                    __Instance = Marshal.AllocHGlobal(sizeof(global::CppSharp.Parser.AST.Statement.__Internal));
+                    __ownsNativeInstance = true;
+                    NativeToManagedMap[__Instance] = this;
+                    var __allocator0 = new global::Std.__1.Allocator();
+                    var __basicString0 = new global::Std.__1.BasicString(str, __allocator0);
+                    var __arg0 = __basicString0.__Instance;
+                    var __arg2 = ReferenceEquals(decl, null) ? global::System.IntPtr.Zero : decl.__Instance;
+                    __Internal.ctor_0((__Instance + __PointerAdjustment), __arg0, Class, __arg2);
+                    __basicString0.Dispose(false);
+                    __allocator0.Dispose();
+                }
+
                 public Statement(global::CppSharp.Parser.AST.Statement _0)
                 {
                     __Instance = Marshal.AllocHGlobal(sizeof(global::CppSharp.Parser.AST.Statement.__Internal));
@@ -6140,7 +6104,7 @@ namespace CppSharp
                     if (ReferenceEquals(_0, null))
                         throw new global::System.ArgumentNullException("_0", "Cannot be null because it is a C++ reference (&).");
                     var __arg0 = _0.__Instance;
-                    __Internal.cctor_0((__Instance + __PointerAdjustment), __arg0);
+                    __Internal.cctor_1((__Instance + __PointerAdjustment), __arg0);
                 }
 
                 public void Dispose()
@@ -6196,13 +6160,14 @@ namespace CppSharp
                 {
                     get
                     {
-                        var __ret = __Internal.GetString((__Instance + __PointerAdjustment));
-                        return Marshal.PtrToStringAnsi(__ret);
+                        return global::Std.__1.BasicString.__CreateInstance(((global::CppSharp.Parser.AST.Statement.__Internal*) __Instance)->@string).CStr();
                     }
 
                     set
                     {
-                        __Internal.SetString((__Instance + __PointerAdjustment), value);
+                        var __allocator0 = new global::Std.__1.Allocator();
+                        var __basicString0 = new global::Std.__1.BasicString(value, __allocator0);
+                        ((global::CppSharp.Parser.AST.Statement.__Internal*) __Instance)->@string = *(global::Std.__1.BasicString.__Internal*) __basicString0.__Instance;
                     }
                 }
             }
@@ -6219,12 +6184,17 @@ namespace CppSharp
                     internal global::System.IntPtr decl;
 
                     [FieldOffset(8)]
-                    internal global::Std.__1.BasicString.__Internal String;
+                    internal global::Std.__1.BasicString.__Internal @string;
+
+                    [SuppressUnmanagedCodeSecurity]
+                    [DllImport("CppSharp.CppParser", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
+                        EntryPoint="_ZN8CppSharp9CppParser3AST10ExpressionC2ERKNSt3__112basic_stringIcNS3_11char_traitsIcEENS3_9allocatorIcEEEENS1_14StatementClassEPNS1_11DeclarationE")]
+                    internal static extern void ctor_0(global::System.IntPtr instance, global::System.IntPtr str, global::CppSharp.Parser.AST.StatementClass Class, global::System.IntPtr decl);
 
                     [SuppressUnmanagedCodeSecurity]
                     [DllImport("CppSharp.CppParser", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
                         EntryPoint="_ZN8CppSharp9CppParser3AST10ExpressionC2ERKS2_")]
-                    internal static extern void cctor_0(global::System.IntPtr instance, global::System.IntPtr _0);
+                    internal static extern void cctor_1(global::System.IntPtr instance, global::System.IntPtr _0);
 
                     [SuppressUnmanagedCodeSecurity]
                     [DllImport("CppSharp.CppParser", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
@@ -6245,7 +6215,7 @@ namespace CppSharp
                 private static void* __CopyValue(global::CppSharp.Parser.AST.Expression.__Internal native)
                 {
                     var ret = Marshal.AllocHGlobal(sizeof(global::CppSharp.Parser.AST.Expression.__Internal));
-                    global::CppSharp.Parser.AST.Expression.__Internal.cctor_0(ret, new global::System.IntPtr(&native));
+                    global::CppSharp.Parser.AST.Expression.__Internal.cctor_1(ret, new global::System.IntPtr(&native));
                     return ret.ToPointer();
                 }
 
@@ -6265,6 +6235,21 @@ namespace CppSharp
                     __Instance = new global::System.IntPtr(native);
                 }
 
+                public Expression(string str, global::CppSharp.Parser.AST.StatementClass Class, global::CppSharp.Parser.AST.Declaration decl)
+                    : this((void*) null)
+                {
+                    __Instance = Marshal.AllocHGlobal(sizeof(global::CppSharp.Parser.AST.Expression.__Internal));
+                    __ownsNativeInstance = true;
+                    NativeToManagedMap[__Instance] = this;
+                    var __allocator0 = new global::Std.__1.Allocator();
+                    var __basicString0 = new global::Std.__1.BasicString(str, __allocator0);
+                    var __arg0 = __basicString0.__Instance;
+                    var __arg2 = ReferenceEquals(decl, null) ? global::System.IntPtr.Zero : decl.__Instance;
+                    __Internal.ctor_0((__Instance + __PointerAdjustment), __arg0, Class, __arg2);
+                    __basicString0.Dispose(false);
+                    __allocator0.Dispose();
+                }
+
                 public Expression(global::CppSharp.Parser.AST.Expression _0)
                     : this((void*) null)
                 {
@@ -6274,7 +6259,7 @@ namespace CppSharp
                     if (ReferenceEquals(_0, null))
                         throw new global::System.ArgumentNullException("_0", "Cannot be null because it is a C++ reference (&).");
                     var __arg0 = _0.__Instance;
-                    __Internal.cctor_0((__Instance + __PointerAdjustment), __arg0);
+                    __Internal.cctor_1((__Instance + __PointerAdjustment), __arg0);
                 }
 
                 public override void Dispose(bool disposing)
@@ -6303,7 +6288,7 @@ namespace CppSharp
                     internal global::System.IntPtr decl;
 
                     [FieldOffset(8)]
-                    internal global::Std.__1.BasicString.__Internal String;
+                    internal global::Std.__1.BasicString.__Internal @string;
 
                     [FieldOffset(20)]
                     internal global::System.IntPtr LHS;
@@ -6312,27 +6297,22 @@ namespace CppSharp
                     internal global::System.IntPtr RHS;
 
                     [FieldOffset(28)]
-                    internal global::Std.__1.BasicString.__Internal OpcodeStr;
+                    internal global::Std.__1.BasicString.__Internal opcodeStr;
+
+                    [SuppressUnmanagedCodeSecurity]
+                    [DllImport("CppSharp.CppParser", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
+                        EntryPoint="_ZN8CppSharp9CppParser3AST14BinaryOperatorC2ERKNSt3__112basic_stringIcNS3_11char_traitsIcEENS3_9allocatorIcEEEEPNS1_10ExpressionESD_SB_")]
+                    internal static extern void ctor_0(global::System.IntPtr instance, global::System.IntPtr str, global::System.IntPtr lhs, global::System.IntPtr rhs, global::System.IntPtr opcodeStr);
 
                     [SuppressUnmanagedCodeSecurity]
                     [DllImport("CppSharp.CppParser", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
                         EntryPoint="_ZN8CppSharp9CppParser3AST14BinaryOperatorC2ERKS2_")]
-                    internal static extern void cctor_0(global::System.IntPtr instance, global::System.IntPtr _0);
+                    internal static extern void cctor_1(global::System.IntPtr instance, global::System.IntPtr _0);
 
                     [SuppressUnmanagedCodeSecurity]
                     [DllImport("CppSharp.CppParser", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
                         EntryPoint="_ZN8CppSharp9CppParser3AST14BinaryOperatorD2Ev")]
                     internal static extern void dtor_0(global::System.IntPtr instance);
-
-                    [SuppressUnmanagedCodeSecurity]
-                    [DllImport("CppSharp.CppParser", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
-                        EntryPoint="_ZN8CppSharp9CppParser3AST14BinaryOperator12getOpcodeStrEv")]
-                    internal static extern global::System.IntPtr GetOpcodeStr(global::System.IntPtr instance);
-
-                    [SuppressUnmanagedCodeSecurity]
-                    [DllImport("CppSharp.CppParser", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
-                        EntryPoint="_ZN8CppSharp9CppParser3AST14BinaryOperator12setOpcodeStrEPKc")]
-                    internal static extern void SetOpcodeStr(global::System.IntPtr instance, [MarshalAs(UnmanagedType.LPStr)] string s);
                 }
 
                 internal static new global::CppSharp.Parser.AST.BinaryOperator __CreateInstance(global::System.IntPtr native, bool skipVTables = false)
@@ -6348,7 +6328,7 @@ namespace CppSharp
                 private static void* __CopyValue(global::CppSharp.Parser.AST.BinaryOperator.__Internal native)
                 {
                     var ret = Marshal.AllocHGlobal(sizeof(global::CppSharp.Parser.AST.BinaryOperator.__Internal));
-                    global::CppSharp.Parser.AST.BinaryOperator.__Internal.cctor_0(ret, new global::System.IntPtr(&native));
+                    global::CppSharp.Parser.AST.BinaryOperator.__Internal.cctor_1(ret, new global::System.IntPtr(&native));
                     return ret.ToPointer();
                 }
 
@@ -6368,6 +6348,27 @@ namespace CppSharp
                     __Instance = new global::System.IntPtr(native);
                 }
 
+                public BinaryOperator(string str, global::CppSharp.Parser.AST.Expression lhs, global::CppSharp.Parser.AST.Expression rhs, string opcodeStr)
+                    : this((void*) null)
+                {
+                    __Instance = Marshal.AllocHGlobal(sizeof(global::CppSharp.Parser.AST.BinaryOperator.__Internal));
+                    __ownsNativeInstance = true;
+                    NativeToManagedMap[__Instance] = this;
+                    var __allocator0 = new global::Std.__1.Allocator();
+                    var __basicString0 = new global::Std.__1.BasicString(str, __allocator0);
+                    var __arg0 = __basicString0.__Instance;
+                    var __arg1 = ReferenceEquals(lhs, null) ? global::System.IntPtr.Zero : lhs.__Instance;
+                    var __arg2 = ReferenceEquals(rhs, null) ? global::System.IntPtr.Zero : rhs.__Instance;
+                    var __allocator3 = new global::Std.__1.Allocator();
+                    var __basicString3 = new global::Std.__1.BasicString(opcodeStr, __allocator3);
+                    var __arg3 = __basicString3.__Instance;
+                    __Internal.ctor_0((__Instance + __PointerAdjustment), __arg0, __arg1, __arg2, __arg3);
+                    __basicString0.Dispose(false);
+                    __allocator0.Dispose();
+                    __basicString3.Dispose(false);
+                    __allocator3.Dispose();
+                }
+
                 public BinaryOperator(global::CppSharp.Parser.AST.BinaryOperator _0)
                     : this((void*) null)
                 {
@@ -6377,7 +6378,7 @@ namespace CppSharp
                     if (ReferenceEquals(_0, null))
                         throw new global::System.ArgumentNullException("_0", "Cannot be null because it is a C++ reference (&).");
                     var __arg0 = _0.__Instance;
-                    __Internal.cctor_0((__Instance + __PointerAdjustment), __arg0);
+                    __Internal.cctor_1((__Instance + __PointerAdjustment), __arg0);
                 }
 
                 public override void Dispose(bool disposing)
@@ -6433,13 +6434,14 @@ namespace CppSharp
                 {
                     get
                     {
-                        var __ret = __Internal.GetOpcodeStr((__Instance + __PointerAdjustment));
-                        return Marshal.PtrToStringAnsi(__ret);
+                        return global::Std.__1.BasicString.__CreateInstance(((global::CppSharp.Parser.AST.BinaryOperator.__Internal*) __Instance)->opcodeStr).CStr();
                     }
 
                     set
                     {
-                        __Internal.SetOpcodeStr((__Instance + __PointerAdjustment), value);
+                        var __allocator0 = new global::Std.__1.Allocator();
+                        var __basicString0 = new global::Std.__1.BasicString(value, __allocator0);
+                        ((global::CppSharp.Parser.AST.BinaryOperator.__Internal*) __Instance)->opcodeStr = *(global::Std.__1.BasicString.__Internal*) __basicString0.__Instance;
                     }
                 }
             }
@@ -6456,15 +6458,20 @@ namespace CppSharp
                     internal global::System.IntPtr decl;
 
                     [FieldOffset(8)]
-                    internal global::Std.__1.BasicString.__Internal String;
+                    internal global::Std.__1.BasicString.__Internal @string;
 
                     [FieldOffset(20)]
                     internal global::Std.__1.Vector.__Internal Arguments;
 
                     [SuppressUnmanagedCodeSecurity]
                     [DllImport("CppSharp.CppParser", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
+                        EntryPoint="_ZN8CppSharp9CppParser3AST8CallExprC2ERKNSt3__112basic_stringIcNS3_11char_traitsIcEENS3_9allocatorIcEEEEPNS1_11DeclarationE")]
+                    internal static extern void ctor_0(global::System.IntPtr instance, global::System.IntPtr str, global::System.IntPtr decl);
+
+                    [SuppressUnmanagedCodeSecurity]
+                    [DllImport("CppSharp.CppParser", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
                         EntryPoint="_ZN8CppSharp9CppParser3AST8CallExprC2ERKS2_")]
-                    internal static extern void cctor_0(global::System.IntPtr instance, global::System.IntPtr _0);
+                    internal static extern void cctor_1(global::System.IntPtr instance, global::System.IntPtr _0);
 
                     [SuppressUnmanagedCodeSecurity]
                     [DllImport("CppSharp.CppParser", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
@@ -6505,7 +6512,7 @@ namespace CppSharp
                 private static void* __CopyValue(global::CppSharp.Parser.AST.CallExpr.__Internal native)
                 {
                     var ret = Marshal.AllocHGlobal(sizeof(global::CppSharp.Parser.AST.CallExpr.__Internal));
-                    global::CppSharp.Parser.AST.CallExpr.__Internal.cctor_0(ret, new global::System.IntPtr(&native));
+                    global::CppSharp.Parser.AST.CallExpr.__Internal.cctor_1(ret, new global::System.IntPtr(&native));
                     return ret.ToPointer();
                 }
 
@@ -6525,6 +6532,21 @@ namespace CppSharp
                     __Instance = new global::System.IntPtr(native);
                 }
 
+                public CallExpr(string str, global::CppSharp.Parser.AST.Declaration decl)
+                    : this((void*) null)
+                {
+                    __Instance = Marshal.AllocHGlobal(sizeof(global::CppSharp.Parser.AST.CallExpr.__Internal));
+                    __ownsNativeInstance = true;
+                    NativeToManagedMap[__Instance] = this;
+                    var __allocator0 = new global::Std.__1.Allocator();
+                    var __basicString0 = new global::Std.__1.BasicString(str, __allocator0);
+                    var __arg0 = __basicString0.__Instance;
+                    var __arg1 = ReferenceEquals(decl, null) ? global::System.IntPtr.Zero : decl.__Instance;
+                    __Internal.ctor_0((__Instance + __PointerAdjustment), __arg0, __arg1);
+                    __basicString0.Dispose(false);
+                    __allocator0.Dispose();
+                }
+
                 public CallExpr(global::CppSharp.Parser.AST.CallExpr _0)
                     : this((void*) null)
                 {
@@ -6534,7 +6556,7 @@ namespace CppSharp
                     if (ReferenceEquals(_0, null))
                         throw new global::System.ArgumentNullException("_0", "Cannot be null because it is a C++ reference (&).");
                     var __arg0 = _0.__Instance;
-                    __Internal.cctor_0((__Instance + __PointerAdjustment), __arg0);
+                    __Internal.cctor_1((__Instance + __PointerAdjustment), __arg0);
                 }
 
                 public override void Dispose(bool disposing)
@@ -6596,15 +6618,20 @@ namespace CppSharp
                     internal global::System.IntPtr decl;
 
                     [FieldOffset(8)]
-                    internal global::Std.__1.BasicString.__Internal String;
+                    internal global::Std.__1.BasicString.__Internal @string;
 
                     [FieldOffset(20)]
                     internal global::Std.__1.Vector.__Internal Arguments;
 
                     [SuppressUnmanagedCodeSecurity]
                     [DllImport("CppSharp.CppParser", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
+                        EntryPoint="_ZN8CppSharp9CppParser3AST16CXXConstructExprC2ERKNSt3__112basic_stringIcNS3_11char_traitsIcEENS3_9allocatorIcEEEEPNS1_11DeclarationE")]
+                    internal static extern void ctor_0(global::System.IntPtr instance, global::System.IntPtr str, global::System.IntPtr decl);
+
+                    [SuppressUnmanagedCodeSecurity]
+                    [DllImport("CppSharp.CppParser", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
                         EntryPoint="_ZN8CppSharp9CppParser3AST16CXXConstructExprC2ERKS2_")]
-                    internal static extern void cctor_0(global::System.IntPtr instance, global::System.IntPtr _0);
+                    internal static extern void cctor_1(global::System.IntPtr instance, global::System.IntPtr _0);
 
                     [SuppressUnmanagedCodeSecurity]
                     [DllImport("CppSharp.CppParser", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
@@ -6645,7 +6672,7 @@ namespace CppSharp
                 private static void* __CopyValue(global::CppSharp.Parser.AST.CXXConstructExpr.__Internal native)
                 {
                     var ret = Marshal.AllocHGlobal(sizeof(global::CppSharp.Parser.AST.CXXConstructExpr.__Internal));
-                    global::CppSharp.Parser.AST.CXXConstructExpr.__Internal.cctor_0(ret, new global::System.IntPtr(&native));
+                    global::CppSharp.Parser.AST.CXXConstructExpr.__Internal.cctor_1(ret, new global::System.IntPtr(&native));
                     return ret.ToPointer();
                 }
 
@@ -6665,6 +6692,21 @@ namespace CppSharp
                     __Instance = new global::System.IntPtr(native);
                 }
 
+                public CXXConstructExpr(string str, global::CppSharp.Parser.AST.Declaration decl)
+                    : this((void*) null)
+                {
+                    __Instance = Marshal.AllocHGlobal(sizeof(global::CppSharp.Parser.AST.CXXConstructExpr.__Internal));
+                    __ownsNativeInstance = true;
+                    NativeToManagedMap[__Instance] = this;
+                    var __allocator0 = new global::Std.__1.Allocator();
+                    var __basicString0 = new global::Std.__1.BasicString(str, __allocator0);
+                    var __arg0 = __basicString0.__Instance;
+                    var __arg1 = ReferenceEquals(decl, null) ? global::System.IntPtr.Zero : decl.__Instance;
+                    __Internal.ctor_0((__Instance + __PointerAdjustment), __arg0, __arg1);
+                    __basicString0.Dispose(false);
+                    __allocator0.Dispose();
+                }
+
                 public CXXConstructExpr(global::CppSharp.Parser.AST.CXXConstructExpr _0)
                     : this((void*) null)
                 {
@@ -6674,7 +6716,7 @@ namespace CppSharp
                     if (ReferenceEquals(_0, null))
                         throw new global::System.ArgumentNullException("_0", "Cannot be null because it is a C++ reference (&).");
                     var __arg0 = _0.__Instance;
-                    __Internal.cctor_0((__Instance + __PointerAdjustment), __arg0);
+                    __Internal.cctor_1((__Instance + __PointerAdjustment), __arg0);
                 }
 
                 public override void Dispose(bool disposing)
@@ -6748,13 +6790,13 @@ namespace CppSharp
                     internal int lineNumberEnd;
 
                     [FieldOffset(24)]
-                    internal global::Std.__1.BasicString.__Internal Name;
+                    internal global::Std.__1.BasicString.__Internal name;
 
                     [FieldOffset(36)]
                     internal global::Std.__1.BasicString.__Internal USR;
 
                     [FieldOffset(48)]
-                    internal global::Std.__1.BasicString.__Internal DebugText;
+                    internal global::Std.__1.BasicString.__Internal debugText;
 
                     [FieldOffset(60)]
                     internal byte isIncomplete;
@@ -6976,13 +7018,13 @@ namespace CppSharp
                     internal int lineNumberEnd;
 
                     [FieldOffset(24)]
-                    internal global::Std.__1.BasicString.__Internal Name;
+                    internal global::Std.__1.BasicString.__Internal name;
 
                     [FieldOffset(36)]
                     internal global::Std.__1.BasicString.__Internal USR;
 
                     [FieldOffset(48)]
-                    internal global::Std.__1.BasicString.__Internal DebugText;
+                    internal global::Std.__1.BasicString.__Internal debugText;
 
                     [FieldOffset(60)]
                     internal byte isIncomplete;
@@ -7042,13 +7084,13 @@ namespace CppSharp
                     internal global::CppSharp.Parser.AST.CXXOperatorKind operatorKind;
 
                     [FieldOffset(128)]
-                    internal global::Std.__1.BasicString.__Internal Mangled;
+                    internal global::Std.__1.BasicString.__Internal mangled;
 
                     [FieldOffset(140)]
-                    internal global::Std.__1.BasicString.__Internal Signature;
+                    internal global::Std.__1.BasicString.__Internal signature;
 
                     [FieldOffset(152)]
-                    internal global::Std.__1.BasicString.__Internal Body;
+                    internal global::Std.__1.BasicString.__Internal body;
 
                     [FieldOffset(164)]
                     internal global::CppSharp.Parser.AST.CallingConvention callingConvention;
@@ -7094,36 +7136,6 @@ namespace CppSharp
                     [DllImport("CppSharp.CppParser", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
                         EntryPoint="_ZN8CppSharp9CppParser3AST8Function15clearParametersEv")]
                     internal static extern void ClearParameters_0(global::System.IntPtr instance);
-
-                    [SuppressUnmanagedCodeSecurity]
-                    [DllImport("CppSharp.CppParser", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
-                        EntryPoint="_ZN8CppSharp9CppParser3AST8Function10getMangledEv")]
-                    internal static extern global::System.IntPtr GetMangled(global::System.IntPtr instance);
-
-                    [SuppressUnmanagedCodeSecurity]
-                    [DllImport("CppSharp.CppParser", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
-                        EntryPoint="_ZN8CppSharp9CppParser3AST8Function10setMangledEPKc")]
-                    internal static extern void SetMangled(global::System.IntPtr instance, [MarshalAs(UnmanagedType.LPStr)] string s);
-
-                    [SuppressUnmanagedCodeSecurity]
-                    [DllImport("CppSharp.CppParser", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
-                        EntryPoint="_ZN8CppSharp9CppParser3AST8Function12getSignatureEv")]
-                    internal static extern global::System.IntPtr GetSignature(global::System.IntPtr instance);
-
-                    [SuppressUnmanagedCodeSecurity]
-                    [DllImport("CppSharp.CppParser", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
-                        EntryPoint="_ZN8CppSharp9CppParser3AST8Function12setSignatureEPKc")]
-                    internal static extern void SetSignature(global::System.IntPtr instance, [MarshalAs(UnmanagedType.LPStr)] string s);
-
-                    [SuppressUnmanagedCodeSecurity]
-                    [DllImport("CppSharp.CppParser", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
-                        EntryPoint="_ZN8CppSharp9CppParser3AST8Function7getBodyEv")]
-                    internal static extern global::System.IntPtr GetBody(global::System.IntPtr instance);
-
-                    [SuppressUnmanagedCodeSecurity]
-                    [DllImport("CppSharp.CppParser", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
-                        EntryPoint="_ZN8CppSharp9CppParser3AST8Function7setBodyEPKc")]
-                    internal static extern void SetBody(global::System.IntPtr instance, [MarshalAs(UnmanagedType.LPStr)] string s);
 
                     [SuppressUnmanagedCodeSecurity]
                     [DllImport("CppSharp.CppParser", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
@@ -7352,6 +7364,51 @@ namespace CppSharp
                     }
                 }
 
+                public string Mangled
+                {
+                    get
+                    {
+                        return global::Std.__1.BasicString.__CreateInstance(((global::CppSharp.Parser.AST.Function.__Internal*) __Instance)->mangled).CStr();
+                    }
+
+                    set
+                    {
+                        var __allocator0 = new global::Std.__1.Allocator();
+                        var __basicString0 = new global::Std.__1.BasicString(value, __allocator0);
+                        ((global::CppSharp.Parser.AST.Function.__Internal*) __Instance)->mangled = *(global::Std.__1.BasicString.__Internal*) __basicString0.__Instance;
+                    }
+                }
+
+                public string Signature
+                {
+                    get
+                    {
+                        return global::Std.__1.BasicString.__CreateInstance(((global::CppSharp.Parser.AST.Function.__Internal*) __Instance)->signature).CStr();
+                    }
+
+                    set
+                    {
+                        var __allocator0 = new global::Std.__1.Allocator();
+                        var __basicString0 = new global::Std.__1.BasicString(value, __allocator0);
+                        ((global::CppSharp.Parser.AST.Function.__Internal*) __Instance)->signature = *(global::Std.__1.BasicString.__Internal*) __basicString0.__Instance;
+                    }
+                }
+
+                public string Body
+                {
+                    get
+                    {
+                        return global::Std.__1.BasicString.__CreateInstance(((global::CppSharp.Parser.AST.Function.__Internal*) __Instance)->body).CStr();
+                    }
+
+                    set
+                    {
+                        var __allocator0 = new global::Std.__1.Allocator();
+                        var __basicString0 = new global::Std.__1.BasicString(value, __allocator0);
+                        ((global::CppSharp.Parser.AST.Function.__Internal*) __Instance)->body = *(global::Std.__1.BasicString.__Internal*) __basicString0.__Instance;
+                    }
+                }
+
                 public global::CppSharp.Parser.AST.CallingConvention CallingConvention
                 {
                     get
@@ -7414,48 +7471,6 @@ namespace CppSharp
                     }
                 }
 
-                public string Mangled
-                {
-                    get
-                    {
-                        var __ret = __Internal.GetMangled((__Instance + __PointerAdjustment));
-                        return Marshal.PtrToStringAnsi(__ret);
-                    }
-
-                    set
-                    {
-                        __Internal.SetMangled((__Instance + __PointerAdjustment), value);
-                    }
-                }
-
-                public string Signature
-                {
-                    get
-                    {
-                        var __ret = __Internal.GetSignature((__Instance + __PointerAdjustment));
-                        return Marshal.PtrToStringAnsi(__ret);
-                    }
-
-                    set
-                    {
-                        __Internal.SetSignature((__Instance + __PointerAdjustment), value);
-                    }
-                }
-
-                public string Body
-                {
-                    get
-                    {
-                        var __ret = __Internal.GetBody((__Instance + __PointerAdjustment));
-                        return Marshal.PtrToStringAnsi(__ret);
-                    }
-
-                    set
-                    {
-                        __Internal.SetBody((__Instance + __PointerAdjustment), value);
-                    }
-                }
-
                 public uint ParametersCount
                 {
                     get
@@ -7490,13 +7505,13 @@ namespace CppSharp
                     internal int lineNumberEnd;
 
                     [FieldOffset(24)]
-                    internal global::Std.__1.BasicString.__Internal Name;
+                    internal global::Std.__1.BasicString.__Internal name;
 
                     [FieldOffset(36)]
                     internal global::Std.__1.BasicString.__Internal USR;
 
                     [FieldOffset(48)]
-                    internal global::Std.__1.BasicString.__Internal DebugText;
+                    internal global::Std.__1.BasicString.__Internal debugText;
 
                     [FieldOffset(60)]
                     internal byte isIncomplete;
@@ -7556,13 +7571,13 @@ namespace CppSharp
                     internal global::CppSharp.Parser.AST.CXXOperatorKind operatorKind;
 
                     [FieldOffset(128)]
-                    internal global::Std.__1.BasicString.__Internal Mangled;
+                    internal global::Std.__1.BasicString.__Internal mangled;
 
                     [FieldOffset(140)]
-                    internal global::Std.__1.BasicString.__Internal Signature;
+                    internal global::Std.__1.BasicString.__Internal signature;
 
                     [FieldOffset(152)]
-                    internal global::Std.__1.BasicString.__Internal Body;
+                    internal global::Std.__1.BasicString.__Internal body;
 
                     [FieldOffset(164)]
                     internal global::CppSharp.Parser.AST.CallingConvention callingConvention;
@@ -7863,13 +7878,13 @@ namespace CppSharp
                     internal int lineNumberEnd;
 
                     [FieldOffset(24)]
-                    internal global::Std.__1.BasicString.__Internal Name;
+                    internal global::Std.__1.BasicString.__Internal name;
 
                     [FieldOffset(36)]
                     internal global::Std.__1.BasicString.__Internal USR;
 
                     [FieldOffset(48)]
-                    internal global::Std.__1.BasicString.__Internal DebugText;
+                    internal global::Std.__1.BasicString.__Internal debugText;
 
                     [FieldOffset(60)]
                     internal byte isIncomplete;
@@ -7975,6 +7990,11 @@ namespace CppSharp
 
                     [SuppressUnmanagedCodeSecurity]
                     [DllImport("CppSharp.CppParser", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
+                        EntryPoint="_ZN8CppSharp9CppParser3AST11Enumeration14FindItemByNameERKNSt3__112basic_stringIcNS3_11char_traitsIcEENS3_9allocatorIcEEEE")]
+                    internal static extern global::System.IntPtr FindItemByName_0(global::System.IntPtr instance, global::System.IntPtr Name);
+
+                    [SuppressUnmanagedCodeSecurity]
+                    [DllImport("CppSharp.CppParser", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
                         EntryPoint="_ZN8CppSharp9CppParser3AST11Enumeration13getItemsCountEv")]
                     internal static extern uint GetItemsCount(global::System.IntPtr instance);
                 }
@@ -8011,13 +8031,13 @@ namespace CppSharp
                         internal int lineNumberEnd;
 
                         [FieldOffset(24)]
-                        internal global::Std.__1.BasicString.__Internal Name;
+                        internal global::Std.__1.BasicString.__Internal name;
 
                         [FieldOffset(36)]
                         internal global::Std.__1.BasicString.__Internal USR;
 
                         [FieldOffset(48)]
-                        internal global::Std.__1.BasicString.__Internal DebugText;
+                        internal global::Std.__1.BasicString.__Internal debugText;
 
                         [FieldOffset(60)]
                         internal byte isIncomplete;
@@ -8047,7 +8067,7 @@ namespace CppSharp
                         internal global::System.IntPtr comment;
 
                         [FieldOffset(104)]
-                        internal global::Std.__1.BasicString.__Internal Expression;
+                        internal global::Std.__1.BasicString.__Internal expression;
 
                         [FieldOffset(116)]
                         internal ulong value;
@@ -8066,16 +8086,6 @@ namespace CppSharp
                         [DllImport("CppSharp.CppParser", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
                             EntryPoint="_ZN8CppSharp9CppParser3AST11Enumeration4ItemD2Ev")]
                         internal static extern void dtor_0(global::System.IntPtr instance);
-
-                        [SuppressUnmanagedCodeSecurity]
-                        [DllImport("CppSharp.CppParser", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
-                            EntryPoint="_ZN8CppSharp9CppParser3AST11Enumeration4Item13getExpressionEv")]
-                        internal static extern global::System.IntPtr GetExpression(global::System.IntPtr instance);
-
-                        [SuppressUnmanagedCodeSecurity]
-                        [DllImport("CppSharp.CppParser", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
-                            EntryPoint="_ZN8CppSharp9CppParser3AST11Enumeration4Item13setExpressionEPKc")]
-                        internal static extern void SetExpression(global::System.IntPtr instance, [MarshalAs(UnmanagedType.LPStr)] string s);
                     }
 
                     internal static new global::CppSharp.Parser.AST.Enumeration.Item __CreateInstance(global::System.IntPtr native, bool skipVTables = false)
@@ -8145,6 +8155,21 @@ namespace CppSharp
                         __Instance = IntPtr.Zero;
                     }
 
+                    public string Expression
+                    {
+                        get
+                        {
+                            return global::Std.__1.BasicString.__CreateInstance(((global::CppSharp.Parser.AST.Enumeration.Item.__Internal*) __Instance)->expression).CStr();
+                        }
+
+                        set
+                        {
+                            var __allocator0 = new global::Std.__1.Allocator();
+                            var __basicString0 = new global::Std.__1.BasicString(value, __allocator0);
+                            ((global::CppSharp.Parser.AST.Enumeration.Item.__Internal*) __Instance)->expression = *(global::Std.__1.BasicString.__Internal*) __basicString0.__Instance;
+                        }
+                    }
+
                     public ulong Value
                     {
                         get
@@ -8155,20 +8180,6 @@ namespace CppSharp
                         set
                         {
                             ((global::CppSharp.Parser.AST.Enumeration.Item.__Internal*) __Instance)->value = value;
-                        }
-                    }
-
-                    public string Expression
-                    {
-                        get
-                        {
-                            var __ret = __Internal.GetExpression((__Instance + __PointerAdjustment));
-                            return Marshal.PtrToStringAnsi(__ret);
-                        }
-
-                        set
-                        {
-                            __Internal.SetExpression((__Instance + __PointerAdjustment), value);
                         }
                     }
                 }
@@ -8264,6 +8275,22 @@ namespace CppSharp
                     __Internal.ClearItems_0((__Instance + __PointerAdjustment));
                 }
 
+                public global::CppSharp.Parser.AST.Enumeration.Item FindItemByName(string Name)
+                {
+                    var __allocator0 = new global::Std.__1.Allocator();
+                    var __basicString0 = new global::Std.__1.BasicString(Name, __allocator0);
+                    var __arg0 = __basicString0.__Instance;
+                    var __ret = __Internal.FindItemByName_0((__Instance + __PointerAdjustment), __arg0);
+                    __basicString0.Dispose(false);
+                    __allocator0.Dispose();
+                    global::CppSharp.Parser.AST.Enumeration.Item __result0;
+                    if (__ret == IntPtr.Zero) __result0 = null;
+                    else if (global::CppSharp.Parser.AST.Enumeration.Item.NativeToManagedMap.ContainsKey(__ret))
+                        __result0 = (global::CppSharp.Parser.AST.Enumeration.Item) global::CppSharp.Parser.AST.Enumeration.Item.NativeToManagedMap[__ret];
+                    else __result0 = global::CppSharp.Parser.AST.Enumeration.Item.__CreateInstance(__ret);
+                    return __result0;
+                }
+
                 public global::CppSharp.Parser.AST.Enumeration.EnumModifiers Modifiers
                 {
                     get
@@ -8347,13 +8374,13 @@ namespace CppSharp
                     internal int lineNumberEnd;
 
                     [FieldOffset(24)]
-                    internal global::Std.__1.BasicString.__Internal Name;
+                    internal global::Std.__1.BasicString.__Internal name;
 
                     [FieldOffset(36)]
                     internal global::Std.__1.BasicString.__Internal USR;
 
                     [FieldOffset(48)]
-                    internal global::Std.__1.BasicString.__Internal DebugText;
+                    internal global::Std.__1.BasicString.__Internal debugText;
 
                     [FieldOffset(60)]
                     internal byte isIncomplete;
@@ -8383,7 +8410,7 @@ namespace CppSharp
                     internal global::System.IntPtr comment;
 
                     [FieldOffset(104)]
-                    internal global::Std.__1.BasicString.__Internal Mangled;
+                    internal global::Std.__1.BasicString.__Internal mangled;
 
                     [FieldOffset(116)]
                     internal global::CppSharp.Parser.AST.QualifiedType.__Internal qualifiedType;
@@ -8402,16 +8429,6 @@ namespace CppSharp
                     [DllImport("CppSharp.CppParser", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
                         EntryPoint="_ZN8CppSharp9CppParser3AST8VariableD2Ev")]
                     internal static extern void dtor_0(global::System.IntPtr instance);
-
-                    [SuppressUnmanagedCodeSecurity]
-                    [DllImport("CppSharp.CppParser", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
-                        EntryPoint="_ZN8CppSharp9CppParser3AST8Variable10getMangledEv")]
-                    internal static extern global::System.IntPtr GetMangled(global::System.IntPtr instance);
-
-                    [SuppressUnmanagedCodeSecurity]
-                    [DllImport("CppSharp.CppParser", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
-                        EntryPoint="_ZN8CppSharp9CppParser3AST8Variable10setMangledEPKc")]
-                    internal static extern void SetMangled(global::System.IntPtr instance, [MarshalAs(UnmanagedType.LPStr)] string s);
                 }
 
                 internal static new global::CppSharp.Parser.AST.Variable __CreateInstance(global::System.IntPtr native, bool skipVTables = false)
@@ -8481,6 +8498,21 @@ namespace CppSharp
                     __Instance = IntPtr.Zero;
                 }
 
+                public string Mangled
+                {
+                    get
+                    {
+                        return global::Std.__1.BasicString.__CreateInstance(((global::CppSharp.Parser.AST.Variable.__Internal*) __Instance)->mangled).CStr();
+                    }
+
+                    set
+                    {
+                        var __allocator0 = new global::Std.__1.Allocator();
+                        var __basicString0 = new global::Std.__1.BasicString(value, __allocator0);
+                        ((global::CppSharp.Parser.AST.Variable.__Internal*) __Instance)->mangled = *(global::Std.__1.BasicString.__Internal*) __basicString0.__Instance;
+                    }
+                }
+
                 public global::CppSharp.Parser.AST.QualifiedType QualifiedType
                 {
                     get
@@ -8491,20 +8523,6 @@ namespace CppSharp
                     set
                     {
                         ((global::CppSharp.Parser.AST.Variable.__Internal*) __Instance)->qualifiedType = ReferenceEquals(value, null) ? new global::CppSharp.Parser.AST.QualifiedType.__Internal() : *(global::CppSharp.Parser.AST.QualifiedType.__Internal*) value.__Instance;
-                    }
-                }
-
-                public string Mangled
-                {
-                    get
-                    {
-                        var __ret = __Internal.GetMangled((__Instance + __PointerAdjustment));
-                        return Marshal.PtrToStringAnsi(__ret);
-                    }
-
-                    set
-                    {
-                        __Internal.SetMangled((__Instance + __PointerAdjustment), value);
                     }
                 }
             }
@@ -8690,13 +8708,13 @@ namespace CppSharp
                     internal int lineNumberEnd;
 
                     [FieldOffset(24)]
-                    internal global::Std.__1.BasicString.__Internal Name;
+                    internal global::Std.__1.BasicString.__Internal name;
 
                     [FieldOffset(36)]
                     internal global::Std.__1.BasicString.__Internal USR;
 
                     [FieldOffset(48)]
-                    internal global::Std.__1.BasicString.__Internal DebugText;
+                    internal global::Std.__1.BasicString.__Internal debugText;
 
                     [FieldOffset(60)]
                     internal byte isIncomplete;
@@ -8902,13 +8920,13 @@ namespace CppSharp
                     internal int lineNumberEnd;
 
                     [FieldOffset(24)]
-                    internal global::Std.__1.BasicString.__Internal Name;
+                    internal global::Std.__1.BasicString.__Internal name;
 
                     [FieldOffset(36)]
                     internal global::Std.__1.BasicString.__Internal USR;
 
                     [FieldOffset(48)]
-                    internal global::Std.__1.BasicString.__Internal DebugText;
+                    internal global::Std.__1.BasicString.__Internal debugText;
 
                     [FieldOffset(60)]
                     internal byte isIncomplete;
@@ -9045,13 +9063,13 @@ namespace CppSharp
                     internal int lineNumberEnd;
 
                     [FieldOffset(24)]
-                    internal global::Std.__1.BasicString.__Internal Name;
+                    internal global::Std.__1.BasicString.__Internal name;
 
                     [FieldOffset(36)]
                     internal global::Std.__1.BasicString.__Internal USR;
 
                     [FieldOffset(48)]
-                    internal global::Std.__1.BasicString.__Internal DebugText;
+                    internal global::Std.__1.BasicString.__Internal debugText;
 
                     [FieldOffset(60)]
                     internal byte isIncomplete;
@@ -9626,13 +9644,13 @@ namespace CppSharp
                     internal int lineNumberEnd;
 
                     [FieldOffset(24)]
-                    internal global::Std.__1.BasicString.__Internal Name;
+                    internal global::Std.__1.BasicString.__Internal name;
 
                     [FieldOffset(36)]
                     internal global::Std.__1.BasicString.__Internal USR;
 
                     [FieldOffset(48)]
-                    internal global::Std.__1.BasicString.__Internal DebugText;
+                    internal global::Std.__1.BasicString.__Internal debugText;
 
                     [FieldOffset(60)]
                     internal byte isIncomplete;
@@ -9865,13 +9883,13 @@ namespace CppSharp
                     internal int lineNumberEnd;
 
                     [FieldOffset(24)]
-                    internal global::Std.__1.BasicString.__Internal Name;
+                    internal global::Std.__1.BasicString.__Internal name;
 
                     [FieldOffset(36)]
                     internal global::Std.__1.BasicString.__Internal USR;
 
                     [FieldOffset(48)]
-                    internal global::Std.__1.BasicString.__Internal DebugText;
+                    internal global::Std.__1.BasicString.__Internal debugText;
 
                     [FieldOffset(60)]
                     internal byte isIncomplete;
@@ -10014,13 +10032,13 @@ namespace CppSharp
                     internal int lineNumberEnd;
 
                     [FieldOffset(24)]
-                    internal global::Std.__1.BasicString.__Internal Name;
+                    internal global::Std.__1.BasicString.__Internal name;
 
                     [FieldOffset(36)]
                     internal global::Std.__1.BasicString.__Internal USR;
 
                     [FieldOffset(48)]
-                    internal global::Std.__1.BasicString.__Internal DebugText;
+                    internal global::Std.__1.BasicString.__Internal debugText;
 
                     [FieldOffset(60)]
                     internal byte isIncomplete;
@@ -10210,13 +10228,13 @@ namespace CppSharp
                     internal int lineNumberEnd;
 
                     [FieldOffset(24)]
-                    internal global::Std.__1.BasicString.__Internal Name;
+                    internal global::Std.__1.BasicString.__Internal name;
 
                     [FieldOffset(36)]
                     internal global::Std.__1.BasicString.__Internal USR;
 
                     [FieldOffset(48)]
-                    internal global::Std.__1.BasicString.__Internal DebugText;
+                    internal global::Std.__1.BasicString.__Internal debugText;
 
                     [FieldOffset(60)]
                     internal byte isIncomplete;
@@ -10407,13 +10425,13 @@ namespace CppSharp
                     internal int lineNumberEnd;
 
                     [FieldOffset(24)]
-                    internal global::Std.__1.BasicString.__Internal Name;
+                    internal global::Std.__1.BasicString.__Internal name;
 
                     [FieldOffset(36)]
                     internal global::Std.__1.BasicString.__Internal USR;
 
                     [FieldOffset(48)]
-                    internal global::Std.__1.BasicString.__Internal DebugText;
+                    internal global::Std.__1.BasicString.__Internal debugText;
 
                     [FieldOffset(60)]
                     internal byte isIncomplete;
@@ -10575,13 +10593,13 @@ namespace CppSharp
                     internal int lineNumberEnd;
 
                     [FieldOffset(24)]
-                    internal global::Std.__1.BasicString.__Internal Name;
+                    internal global::Std.__1.BasicString.__Internal name;
 
                     [FieldOffset(36)]
                     internal global::Std.__1.BasicString.__Internal USR;
 
                     [FieldOffset(48)]
-                    internal global::Std.__1.BasicString.__Internal DebugText;
+                    internal global::Std.__1.BasicString.__Internal debugText;
 
                     [FieldOffset(60)]
                     internal byte isIncomplete;
@@ -10796,13 +10814,13 @@ namespace CppSharp
                     internal int lineNumberEnd;
 
                     [FieldOffset(24)]
-                    internal global::Std.__1.BasicString.__Internal Name;
+                    internal global::Std.__1.BasicString.__Internal name;
 
                     [FieldOffset(36)]
                     internal global::Std.__1.BasicString.__Internal USR;
 
                     [FieldOffset(48)]
-                    internal global::Std.__1.BasicString.__Internal DebugText;
+                    internal global::Std.__1.BasicString.__Internal debugText;
 
                     [FieldOffset(60)]
                     internal byte isIncomplete;
@@ -10869,6 +10887,16 @@ namespace CppSharp
                     [DllImport("CppSharp.CppParser", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
                         EntryPoint="_ZN8CppSharp9CppParser3AST13ClassTemplate20clearSpecializationsEv")]
                     internal static extern void ClearSpecializations_0(global::System.IntPtr instance);
+
+                    [SuppressUnmanagedCodeSecurity]
+                    [DllImport("CppSharp.CppParser", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
+                        EntryPoint="_ZN8CppSharp9CppParser3AST13ClassTemplate18FindSpecializationERKNSt3__112basic_stringIcNS3_11char_traitsIcEENS3_9allocatorIcEEEE")]
+                    internal static extern global::System.IntPtr FindSpecialization_0(global::System.IntPtr instance, global::System.IntPtr usr);
+
+                    [SuppressUnmanagedCodeSecurity]
+                    [DllImport("CppSharp.CppParser", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
+                        EntryPoint="_ZN8CppSharp9CppParser3AST13ClassTemplate25FindPartialSpecializationERKNSt3__112basic_stringIcNS3_11char_traitsIcEENS3_9allocatorIcEEEE")]
+                    internal static extern global::System.IntPtr FindPartialSpecialization_0(global::System.IntPtr instance, global::System.IntPtr usr);
 
                     [SuppressUnmanagedCodeSecurity]
                     [DllImport("CppSharp.CppParser", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
@@ -10967,6 +10995,38 @@ namespace CppSharp
                     __Internal.ClearSpecializations_0((__Instance + __PointerAdjustment));
                 }
 
+                public global::CppSharp.Parser.AST.ClassTemplateSpecialization FindSpecialization(string usr)
+                {
+                    var __allocator0 = new global::Std.__1.Allocator();
+                    var __basicString0 = new global::Std.__1.BasicString(usr, __allocator0);
+                    var __arg0 = __basicString0.__Instance;
+                    var __ret = __Internal.FindSpecialization_0((__Instance + __PointerAdjustment), __arg0);
+                    __basicString0.Dispose(false);
+                    __allocator0.Dispose();
+                    global::CppSharp.Parser.AST.ClassTemplateSpecialization __result0;
+                    if (__ret == IntPtr.Zero) __result0 = null;
+                    else if (global::CppSharp.Parser.AST.ClassTemplateSpecialization.NativeToManagedMap.ContainsKey(__ret))
+                        __result0 = (global::CppSharp.Parser.AST.ClassTemplateSpecialization) global::CppSharp.Parser.AST.ClassTemplateSpecialization.NativeToManagedMap[__ret];
+                    else __result0 = global::CppSharp.Parser.AST.ClassTemplateSpecialization.__CreateInstance(__ret);
+                    return __result0;
+                }
+
+                public global::CppSharp.Parser.AST.ClassTemplatePartialSpecialization FindPartialSpecialization(string usr)
+                {
+                    var __allocator0 = new global::Std.__1.Allocator();
+                    var __basicString0 = new global::Std.__1.BasicString(usr, __allocator0);
+                    var __arg0 = __basicString0.__Instance;
+                    var __ret = __Internal.FindPartialSpecialization_0((__Instance + __PointerAdjustment), __arg0);
+                    __basicString0.Dispose(false);
+                    __allocator0.Dispose();
+                    global::CppSharp.Parser.AST.ClassTemplatePartialSpecialization __result0;
+                    if (__ret == IntPtr.Zero) __result0 = null;
+                    else if (global::CppSharp.Parser.AST.ClassTemplatePartialSpecialization.NativeToManagedMap.ContainsKey(__ret))
+                        __result0 = (global::CppSharp.Parser.AST.ClassTemplatePartialSpecialization) global::CppSharp.Parser.AST.ClassTemplatePartialSpecialization.NativeToManagedMap[__ret];
+                    else __result0 = global::CppSharp.Parser.AST.ClassTemplatePartialSpecialization.__CreateInstance(__ret);
+                    return __result0;
+                }
+
                 public uint SpecializationsCount
                 {
                     get
@@ -11001,13 +11061,13 @@ namespace CppSharp
                     internal int lineNumberEnd;
 
                     [FieldOffset(24)]
-                    internal global::Std.__1.BasicString.__Internal Name;
+                    internal global::Std.__1.BasicString.__Internal name;
 
                     [FieldOffset(36)]
                     internal global::Std.__1.BasicString.__Internal USR;
 
                     [FieldOffset(48)]
-                    internal global::Std.__1.BasicString.__Internal DebugText;
+                    internal global::Std.__1.BasicString.__Internal debugText;
 
                     [FieldOffset(60)]
                     internal byte isIncomplete;
@@ -11311,13 +11371,13 @@ namespace CppSharp
                     internal int lineNumberEnd;
 
                     [FieldOffset(24)]
-                    internal global::Std.__1.BasicString.__Internal Name;
+                    internal global::Std.__1.BasicString.__Internal name;
 
                     [FieldOffset(36)]
                     internal global::Std.__1.BasicString.__Internal USR;
 
                     [FieldOffset(48)]
-                    internal global::Std.__1.BasicString.__Internal DebugText;
+                    internal global::Std.__1.BasicString.__Internal debugText;
 
                     [FieldOffset(60)]
                     internal byte isIncomplete;
@@ -11541,13 +11601,13 @@ namespace CppSharp
                     internal int lineNumberEnd;
 
                     [FieldOffset(24)]
-                    internal global::Std.__1.BasicString.__Internal Name;
+                    internal global::Std.__1.BasicString.__Internal name;
 
                     [FieldOffset(36)]
                     internal global::Std.__1.BasicString.__Internal USR;
 
                     [FieldOffset(48)]
-                    internal global::Std.__1.BasicString.__Internal DebugText;
+                    internal global::Std.__1.BasicString.__Internal debugText;
 
                     [FieldOffset(60)]
                     internal byte isIncomplete;
@@ -11614,6 +11674,11 @@ namespace CppSharp
                     [DllImport("CppSharp.CppParser", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
                         EntryPoint="_ZN8CppSharp9CppParser3AST16FunctionTemplate20clearSpecializationsEv")]
                     internal static extern void ClearSpecializations_0(global::System.IntPtr instance);
+
+                    [SuppressUnmanagedCodeSecurity]
+                    [DllImport("CppSharp.CppParser", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
+                        EntryPoint="_ZN8CppSharp9CppParser3AST16FunctionTemplate18FindSpecializationERKNSt3__112basic_stringIcNS3_11char_traitsIcEENS3_9allocatorIcEEEE")]
+                    internal static extern global::System.IntPtr FindSpecialization_0(global::System.IntPtr instance, global::System.IntPtr usr);
 
                     [SuppressUnmanagedCodeSecurity]
                     [DllImport("CppSharp.CppParser", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
@@ -11710,6 +11775,22 @@ namespace CppSharp
                 public void ClearSpecializations()
                 {
                     __Internal.ClearSpecializations_0((__Instance + __PointerAdjustment));
+                }
+
+                public global::CppSharp.Parser.AST.FunctionTemplateSpecialization FindSpecialization(string usr)
+                {
+                    var __allocator0 = new global::Std.__1.Allocator();
+                    var __basicString0 = new global::Std.__1.BasicString(usr, __allocator0);
+                    var __arg0 = __basicString0.__Instance;
+                    var __ret = __Internal.FindSpecialization_0((__Instance + __PointerAdjustment), __arg0);
+                    __basicString0.Dispose(false);
+                    __allocator0.Dispose();
+                    global::CppSharp.Parser.AST.FunctionTemplateSpecialization __result0;
+                    if (__ret == IntPtr.Zero) __result0 = null;
+                    else if (global::CppSharp.Parser.AST.FunctionTemplateSpecialization.NativeToManagedMap.ContainsKey(__ret))
+                        __result0 = (global::CppSharp.Parser.AST.FunctionTemplateSpecialization) global::CppSharp.Parser.AST.FunctionTemplateSpecialization.NativeToManagedMap[__ret];
+                    else __result0 = global::CppSharp.Parser.AST.FunctionTemplateSpecialization.__CreateInstance(__ret);
+                    return __result0;
                 }
 
                 public uint SpecializationsCount
@@ -11954,13 +12035,13 @@ namespace CppSharp
                     internal int lineNumberEnd;
 
                     [FieldOffset(24)]
-                    internal global::Std.__1.BasicString.__Internal Name;
+                    internal global::Std.__1.BasicString.__Internal name;
 
                     [FieldOffset(36)]
                     internal global::Std.__1.BasicString.__Internal USR;
 
                     [FieldOffset(48)]
-                    internal global::Std.__1.BasicString.__Internal DebugText;
+                    internal global::Std.__1.BasicString.__Internal debugText;
 
                     [FieldOffset(60)]
                     internal byte isIncomplete;
@@ -12027,6 +12108,16 @@ namespace CppSharp
                     [DllImport("CppSharp.CppParser", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
                         EntryPoint="_ZN8CppSharp9CppParser3AST11VarTemplate20clearSpecializationsEv")]
                     internal static extern void ClearSpecializations_0(global::System.IntPtr instance);
+
+                    [SuppressUnmanagedCodeSecurity]
+                    [DllImport("CppSharp.CppParser", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
+                        EntryPoint="_ZN8CppSharp9CppParser3AST11VarTemplate18FindSpecializationERKNSt3__112basic_stringIcNS3_11char_traitsIcEENS3_9allocatorIcEEEE")]
+                    internal static extern global::System.IntPtr FindSpecialization_0(global::System.IntPtr instance, global::System.IntPtr usr);
+
+                    [SuppressUnmanagedCodeSecurity]
+                    [DllImport("CppSharp.CppParser", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
+                        EntryPoint="_ZN8CppSharp9CppParser3AST11VarTemplate25FindPartialSpecializationERKNSt3__112basic_stringIcNS3_11char_traitsIcEENS3_9allocatorIcEEEE")]
+                    internal static extern global::System.IntPtr FindPartialSpecialization_0(global::System.IntPtr instance, global::System.IntPtr usr);
 
                     [SuppressUnmanagedCodeSecurity]
                     [DllImport("CppSharp.CppParser", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
@@ -12125,6 +12216,38 @@ namespace CppSharp
                     __Internal.ClearSpecializations_0((__Instance + __PointerAdjustment));
                 }
 
+                public global::CppSharp.Parser.AST.VarTemplateSpecialization FindSpecialization(string usr)
+                {
+                    var __allocator0 = new global::Std.__1.Allocator();
+                    var __basicString0 = new global::Std.__1.BasicString(usr, __allocator0);
+                    var __arg0 = __basicString0.__Instance;
+                    var __ret = __Internal.FindSpecialization_0((__Instance + __PointerAdjustment), __arg0);
+                    __basicString0.Dispose(false);
+                    __allocator0.Dispose();
+                    global::CppSharp.Parser.AST.VarTemplateSpecialization __result0;
+                    if (__ret == IntPtr.Zero) __result0 = null;
+                    else if (global::CppSharp.Parser.AST.VarTemplateSpecialization.NativeToManagedMap.ContainsKey(__ret))
+                        __result0 = (global::CppSharp.Parser.AST.VarTemplateSpecialization) global::CppSharp.Parser.AST.VarTemplateSpecialization.NativeToManagedMap[__ret];
+                    else __result0 = global::CppSharp.Parser.AST.VarTemplateSpecialization.__CreateInstance(__ret);
+                    return __result0;
+                }
+
+                public global::CppSharp.Parser.AST.VarTemplatePartialSpecialization FindPartialSpecialization(string usr)
+                {
+                    var __allocator0 = new global::Std.__1.Allocator();
+                    var __basicString0 = new global::Std.__1.BasicString(usr, __allocator0);
+                    var __arg0 = __basicString0.__Instance;
+                    var __ret = __Internal.FindPartialSpecialization_0((__Instance + __PointerAdjustment), __arg0);
+                    __basicString0.Dispose(false);
+                    __allocator0.Dispose();
+                    global::CppSharp.Parser.AST.VarTemplatePartialSpecialization __result0;
+                    if (__ret == IntPtr.Zero) __result0 = null;
+                    else if (global::CppSharp.Parser.AST.VarTemplatePartialSpecialization.NativeToManagedMap.ContainsKey(__ret))
+                        __result0 = (global::CppSharp.Parser.AST.VarTemplatePartialSpecialization) global::CppSharp.Parser.AST.VarTemplatePartialSpecialization.NativeToManagedMap[__ret];
+                    else __result0 = global::CppSharp.Parser.AST.VarTemplatePartialSpecialization.__CreateInstance(__ret);
+                    return __result0;
+                }
+
                 public uint SpecializationsCount
                 {
                     get
@@ -12159,13 +12282,13 @@ namespace CppSharp
                     internal int lineNumberEnd;
 
                     [FieldOffset(24)]
-                    internal global::Std.__1.BasicString.__Internal Name;
+                    internal global::Std.__1.BasicString.__Internal name;
 
                     [FieldOffset(36)]
                     internal global::Std.__1.BasicString.__Internal USR;
 
                     [FieldOffset(48)]
-                    internal global::Std.__1.BasicString.__Internal DebugText;
+                    internal global::Std.__1.BasicString.__Internal debugText;
 
                     [FieldOffset(60)]
                     internal byte isIncomplete;
@@ -12195,7 +12318,7 @@ namespace CppSharp
                     internal global::System.IntPtr comment;
 
                     [FieldOffset(104)]
-                    internal global::Std.__1.BasicString.__Internal Mangled;
+                    internal global::Std.__1.BasicString.__Internal mangled;
 
                     [FieldOffset(116)]
                     internal global::CppSharp.Parser.AST.QualifiedType.__Internal qualifiedType;
@@ -12397,13 +12520,13 @@ namespace CppSharp
                     internal int lineNumberEnd;
 
                     [FieldOffset(24)]
-                    internal global::Std.__1.BasicString.__Internal Name;
+                    internal global::Std.__1.BasicString.__Internal name;
 
                     [FieldOffset(36)]
                     internal global::Std.__1.BasicString.__Internal USR;
 
                     [FieldOffset(48)]
-                    internal global::Std.__1.BasicString.__Internal DebugText;
+                    internal global::Std.__1.BasicString.__Internal debugText;
 
                     [FieldOffset(60)]
                     internal byte isIncomplete;
@@ -12433,7 +12556,7 @@ namespace CppSharp
                     internal global::System.IntPtr comment;
 
                     [FieldOffset(104)]
-                    internal global::Std.__1.BasicString.__Internal Mangled;
+                    internal global::Std.__1.BasicString.__Internal mangled;
 
                     [FieldOffset(116)]
                     internal global::CppSharp.Parser.AST.QualifiedType.__Internal qualifiedType;
@@ -12555,13 +12678,13 @@ namespace CppSharp
                     internal int lineNumberEnd;
 
                     [FieldOffset(24)]
-                    internal global::Std.__1.BasicString.__Internal Name;
+                    internal global::Std.__1.BasicString.__Internal name;
 
                     [FieldOffset(36)]
                     internal global::Std.__1.BasicString.__Internal USR;
 
                     [FieldOffset(48)]
-                    internal global::Std.__1.BasicString.__Internal DebugText;
+                    internal global::Std.__1.BasicString.__Internal debugText;
 
                     [FieldOffset(60)]
                     internal byte isIncomplete;
@@ -12874,10 +12997,10 @@ namespace CppSharp
                     internal global::CppSharp.Parser.AST.DeclarationKind kind;
 
                     [FieldOffset(12)]
-                    internal global::Std.__1.BasicString.__Internal Name;
+                    internal global::Std.__1.BasicString.__Internal name;
 
                     [FieldOffset(24)]
-                    internal global::Std.__1.BasicString.__Internal Expression;
+                    internal global::Std.__1.BasicString.__Internal expression;
 
                     [FieldOffset(36)]
                     internal int lineNumberStart;
@@ -12899,26 +13022,6 @@ namespace CppSharp
                     [DllImport("CppSharp.CppParser", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
                         EntryPoint="_ZN8CppSharp9CppParser3AST15MacroDefinitionD2Ev")]
                     internal static extern void dtor_0(global::System.IntPtr instance);
-
-                    [SuppressUnmanagedCodeSecurity]
-                    [DllImport("CppSharp.CppParser", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
-                        EntryPoint="_ZN8CppSharp9CppParser3AST15MacroDefinition7getNameEv")]
-                    internal static extern global::System.IntPtr GetName(global::System.IntPtr instance);
-
-                    [SuppressUnmanagedCodeSecurity]
-                    [DllImport("CppSharp.CppParser", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
-                        EntryPoint="_ZN8CppSharp9CppParser3AST15MacroDefinition7setNameEPKc")]
-                    internal static extern void SetName(global::System.IntPtr instance, [MarshalAs(UnmanagedType.LPStr)] string s);
-
-                    [SuppressUnmanagedCodeSecurity]
-                    [DllImport("CppSharp.CppParser", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
-                        EntryPoint="_ZN8CppSharp9CppParser3AST15MacroDefinition13getExpressionEv")]
-                    internal static extern global::System.IntPtr GetExpression(global::System.IntPtr instance);
-
-                    [SuppressUnmanagedCodeSecurity]
-                    [DllImport("CppSharp.CppParser", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
-                        EntryPoint="_ZN8CppSharp9CppParser3AST15MacroDefinition13setExpressionEPKc")]
-                    internal static extern void SetExpression(global::System.IntPtr instance, [MarshalAs(UnmanagedType.LPStr)] string s);
                 }
 
                 internal static new global::CppSharp.Parser.AST.MacroDefinition __CreateInstance(global::System.IntPtr native, bool skipVTables = false)
@@ -12988,6 +13091,36 @@ namespace CppSharp
                     __Instance = IntPtr.Zero;
                 }
 
+                public string Name
+                {
+                    get
+                    {
+                        return global::Std.__1.BasicString.__CreateInstance(((global::CppSharp.Parser.AST.MacroDefinition.__Internal*) __Instance)->name).CStr();
+                    }
+
+                    set
+                    {
+                        var __allocator0 = new global::Std.__1.Allocator();
+                        var __basicString0 = new global::Std.__1.BasicString(value, __allocator0);
+                        ((global::CppSharp.Parser.AST.MacroDefinition.__Internal*) __Instance)->name = *(global::Std.__1.BasicString.__Internal*) __basicString0.__Instance;
+                    }
+                }
+
+                public string Expression
+                {
+                    get
+                    {
+                        return global::Std.__1.BasicString.__CreateInstance(((global::CppSharp.Parser.AST.MacroDefinition.__Internal*) __Instance)->expression).CStr();
+                    }
+
+                    set
+                    {
+                        var __allocator0 = new global::Std.__1.Allocator();
+                        var __basicString0 = new global::Std.__1.BasicString(value, __allocator0);
+                        ((global::CppSharp.Parser.AST.MacroDefinition.__Internal*) __Instance)->expression = *(global::Std.__1.BasicString.__Internal*) __basicString0.__Instance;
+                    }
+                }
+
                 public int LineNumberStart
                 {
                     get
@@ -13013,34 +13146,6 @@ namespace CppSharp
                         ((global::CppSharp.Parser.AST.MacroDefinition.__Internal*) __Instance)->lineNumberEnd = value;
                     }
                 }
-
-                public string Name
-                {
-                    get
-                    {
-                        var __ret = __Internal.GetName((__Instance + __PointerAdjustment));
-                        return Marshal.PtrToStringAnsi(__ret);
-                    }
-
-                    set
-                    {
-                        __Internal.SetName((__Instance + __PointerAdjustment), value);
-                    }
-                }
-
-                public string Expression
-                {
-                    get
-                    {
-                        var __ret = __Internal.GetExpression((__Instance + __PointerAdjustment));
-                        return Marshal.PtrToStringAnsi(__ret);
-                    }
-
-                    set
-                    {
-                        __Internal.SetExpression((__Instance + __PointerAdjustment), value);
-                    }
-                }
             }
 
             public unsafe partial class MacroExpansion : global::CppSharp.Parser.AST.PreprocessedEntity, IDisposable
@@ -13058,10 +13163,10 @@ namespace CppSharp
                     internal global::CppSharp.Parser.AST.DeclarationKind kind;
 
                     [FieldOffset(12)]
-                    internal global::Std.__1.BasicString.__Internal Name;
+                    internal global::Std.__1.BasicString.__Internal name;
 
                     [FieldOffset(24)]
-                    internal global::Std.__1.BasicString.__Internal Text;
+                    internal global::Std.__1.BasicString.__Internal text;
 
                     [FieldOffset(36)]
                     internal global::System.IntPtr definition;
@@ -13080,26 +13185,6 @@ namespace CppSharp
                     [DllImport("CppSharp.CppParser", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
                         EntryPoint="_ZN8CppSharp9CppParser3AST14MacroExpansionD2Ev")]
                     internal static extern void dtor_0(global::System.IntPtr instance);
-
-                    [SuppressUnmanagedCodeSecurity]
-                    [DllImport("CppSharp.CppParser", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
-                        EntryPoint="_ZN8CppSharp9CppParser3AST14MacroExpansion7getNameEv")]
-                    internal static extern global::System.IntPtr GetName(global::System.IntPtr instance);
-
-                    [SuppressUnmanagedCodeSecurity]
-                    [DllImport("CppSharp.CppParser", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
-                        EntryPoint="_ZN8CppSharp9CppParser3AST14MacroExpansion7setNameEPKc")]
-                    internal static extern void SetName(global::System.IntPtr instance, [MarshalAs(UnmanagedType.LPStr)] string s);
-
-                    [SuppressUnmanagedCodeSecurity]
-                    [DllImport("CppSharp.CppParser", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
-                        EntryPoint="_ZN8CppSharp9CppParser3AST14MacroExpansion7getTextEv")]
-                    internal static extern global::System.IntPtr GetText(global::System.IntPtr instance);
-
-                    [SuppressUnmanagedCodeSecurity]
-                    [DllImport("CppSharp.CppParser", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
-                        EntryPoint="_ZN8CppSharp9CppParser3AST14MacroExpansion7setTextEPKc")]
-                    internal static extern void SetText(global::System.IntPtr instance, [MarshalAs(UnmanagedType.LPStr)] string s);
                 }
 
                 internal static new global::CppSharp.Parser.AST.MacroExpansion __CreateInstance(global::System.IntPtr native, bool skipVTables = false)
@@ -13169,6 +13254,36 @@ namespace CppSharp
                     __Instance = IntPtr.Zero;
                 }
 
+                public string Name
+                {
+                    get
+                    {
+                        return global::Std.__1.BasicString.__CreateInstance(((global::CppSharp.Parser.AST.MacroExpansion.__Internal*) __Instance)->name).CStr();
+                    }
+
+                    set
+                    {
+                        var __allocator0 = new global::Std.__1.Allocator();
+                        var __basicString0 = new global::Std.__1.BasicString(value, __allocator0);
+                        ((global::CppSharp.Parser.AST.MacroExpansion.__Internal*) __Instance)->name = *(global::Std.__1.BasicString.__Internal*) __basicString0.__Instance;
+                    }
+                }
+
+                public string Text
+                {
+                    get
+                    {
+                        return global::Std.__1.BasicString.__CreateInstance(((global::CppSharp.Parser.AST.MacroExpansion.__Internal*) __Instance)->text).CStr();
+                    }
+
+                    set
+                    {
+                        var __allocator0 = new global::Std.__1.Allocator();
+                        var __basicString0 = new global::Std.__1.BasicString(value, __allocator0);
+                        ((global::CppSharp.Parser.AST.MacroExpansion.__Internal*) __Instance)->text = *(global::Std.__1.BasicString.__Internal*) __basicString0.__Instance;
+                    }
+                }
+
                 public global::CppSharp.Parser.AST.MacroDefinition Definition
                 {
                     get
@@ -13184,34 +13299,6 @@ namespace CppSharp
                     set
                     {
                         ((global::CppSharp.Parser.AST.MacroExpansion.__Internal*) __Instance)->definition = ReferenceEquals(value, null) ? global::System.IntPtr.Zero : value.__Instance;
-                    }
-                }
-
-                public string Name
-                {
-                    get
-                    {
-                        var __ret = __Internal.GetName((__Instance + __PointerAdjustment));
-                        return Marshal.PtrToStringAnsi(__ret);
-                    }
-
-                    set
-                    {
-                        __Internal.SetName((__Instance + __PointerAdjustment), value);
-                    }
-                }
-
-                public string Text
-                {
-                    get
-                    {
-                        var __ret = __Internal.GetText((__Instance + __PointerAdjustment));
-                        return Marshal.PtrToStringAnsi(__ret);
-                    }
-
-                    set
-                    {
-                        __Internal.SetText((__Instance + __PointerAdjustment), value);
                     }
                 }
             }
@@ -13240,13 +13327,13 @@ namespace CppSharp
                     internal int lineNumberEnd;
 
                     [FieldOffset(24)]
-                    internal global::Std.__1.BasicString.__Internal Name;
+                    internal global::Std.__1.BasicString.__Internal name;
 
                     [FieldOffset(36)]
                     internal global::Std.__1.BasicString.__Internal USR;
 
                     [FieldOffset(48)]
-                    internal global::Std.__1.BasicString.__Internal DebugText;
+                    internal global::Std.__1.BasicString.__Internal debugText;
 
                     [FieldOffset(60)]
                     internal byte isIncomplete;
@@ -13312,7 +13399,7 @@ namespace CppSharp
                     internal byte isInline;
 
                     [FieldOffset(228)]
-                    internal global::Std.__1.BasicString.__Internal FileName;
+                    internal global::Std.__1.BasicString.__Internal fileName;
 
                     [FieldOffset(240)]
                     internal byte isSystemHeader;
@@ -13349,16 +13436,6 @@ namespace CppSharp
                     [DllImport("CppSharp.CppParser", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
                         EntryPoint="_ZN8CppSharp9CppParser3AST15TranslationUnit11clearMacrosEv")]
                     internal static extern void ClearMacros_0(global::System.IntPtr instance);
-
-                    [SuppressUnmanagedCodeSecurity]
-                    [DllImport("CppSharp.CppParser", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
-                        EntryPoint="_ZN8CppSharp9CppParser3AST15TranslationUnit11getFileNameEv")]
-                    internal static extern global::System.IntPtr GetFileName(global::System.IntPtr instance);
-
-                    [SuppressUnmanagedCodeSecurity]
-                    [DllImport("CppSharp.CppParser", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
-                        EntryPoint="_ZN8CppSharp9CppParser3AST15TranslationUnit11setFileNameEPKc")]
-                    internal static extern void SetFileName(global::System.IntPtr instance, [MarshalAs(UnmanagedType.LPStr)] string s);
 
                     [SuppressUnmanagedCodeSecurity]
                     [DllImport("CppSharp.CppParser", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
@@ -13457,6 +13534,21 @@ namespace CppSharp
                     __Internal.ClearMacros_0((__Instance + __PointerAdjustment));
                 }
 
+                public string FileName
+                {
+                    get
+                    {
+                        return global::Std.__1.BasicString.__CreateInstance(((global::CppSharp.Parser.AST.TranslationUnit.__Internal*) __Instance)->fileName).CStr();
+                    }
+
+                    set
+                    {
+                        var __allocator0 = new global::Std.__1.Allocator();
+                        var __basicString0 = new global::Std.__1.BasicString(value, __allocator0);
+                        ((global::CppSharp.Parser.AST.TranslationUnit.__Internal*) __Instance)->fileName = *(global::Std.__1.BasicString.__Internal*) __basicString0.__Instance;
+                    }
+                }
+
                 public bool IsSystemHeader
                 {
                     get
@@ -13467,20 +13559,6 @@ namespace CppSharp
                     set
                     {
                         ((global::CppSharp.Parser.AST.TranslationUnit.__Internal*) __Instance)->isSystemHeader = (byte) (value ? 1 : 0);
-                    }
-                }
-
-                public string FileName
-                {
-                    get
-                    {
-                        var __ret = __Internal.GetFileName((__Instance + __PointerAdjustment));
-                        return Marshal.PtrToStringAnsi(__ret);
-                    }
-
-                    set
-                    {
-                        __Internal.SetFileName((__Instance + __PointerAdjustment), value);
                     }
                 }
 
@@ -13500,7 +13578,7 @@ namespace CppSharp
                 public partial struct __Internal
                 {
                     [FieldOffset(0)]
-                    internal global::Std.__1.BasicString.__Internal FileName;
+                    internal global::Std.__1.BasicString.__Internal fileName;
 
                     [FieldOffset(12)]
                     internal global::CppSharp.Parser.AST.ArchType archType;
@@ -13555,16 +13633,6 @@ namespace CppSharp
                     [DllImport("CppSharp.CppParser", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
                         EntryPoint="_ZN8CppSharp9CppParser3AST13NativeLibrary17clearDependenciesEv")]
                     internal static extern void ClearDependencies_0(global::System.IntPtr instance);
-
-                    [SuppressUnmanagedCodeSecurity]
-                    [DllImport("CppSharp.CppParser", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
-                        EntryPoint="_ZN8CppSharp9CppParser3AST13NativeLibrary11getFileNameEv")]
-                    internal static extern global::System.IntPtr GetFileName(global::System.IntPtr instance);
-
-                    [SuppressUnmanagedCodeSecurity]
-                    [DllImport("CppSharp.CppParser", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
-                        EntryPoint="_ZN8CppSharp9CppParser3AST13NativeLibrary11setFileNameEPKc")]
-                    internal static extern void SetFileName(global::System.IntPtr instance, [MarshalAs(UnmanagedType.LPStr)] string s);
 
                     [SuppressUnmanagedCodeSecurity]
                     [DllImport("CppSharp.CppParser", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
@@ -13685,6 +13753,21 @@ namespace CppSharp
                     __Internal.ClearDependencies_0((__Instance + __PointerAdjustment));
                 }
 
+                public string FileName
+                {
+                    get
+                    {
+                        return global::Std.__1.BasicString.__CreateInstance(((global::CppSharp.Parser.AST.NativeLibrary.__Internal*) __Instance)->fileName).CStr();
+                    }
+
+                    set
+                    {
+                        var __allocator0 = new global::Std.__1.Allocator();
+                        var __basicString0 = new global::Std.__1.BasicString(value, __allocator0);
+                        ((global::CppSharp.Parser.AST.NativeLibrary.__Internal*) __Instance)->fileName = *(global::Std.__1.BasicString.__Internal*) __basicString0.__Instance;
+                    }
+                }
+
                 public global::CppSharp.Parser.AST.ArchType ArchType
                 {
                     get
@@ -13695,20 +13778,6 @@ namespace CppSharp
                     set
                     {
                         ((global::CppSharp.Parser.AST.NativeLibrary.__Internal*) __Instance)->archType = value;
-                    }
-                }
-
-                public string FileName
-                {
-                    get
-                    {
-                        var __ret = __Internal.GetFileName((__Instance + __PointerAdjustment));
-                        return Marshal.PtrToStringAnsi(__ret);
-                    }
-
-                    set
-                    {
-                        __Internal.SetFileName((__Instance + __PointerAdjustment), value);
                     }
                 }
 
@@ -13753,6 +13822,11 @@ namespace CppSharp
                     [DllImport("CppSharp.CppParser", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
                         EntryPoint="_ZN8CppSharp9CppParser3AST10ASTContextD2Ev")]
                     internal static extern void dtor_0(global::System.IntPtr instance);
+
+                    [SuppressUnmanagedCodeSecurity]
+                    [DllImport("CppSharp.CppParser", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
+                        EntryPoint="_ZN8CppSharp9CppParser3AST10ASTContext18FindOrCreateModuleENSt3__112basic_stringIcNS3_11char_traitsIcEENS3_9allocatorIcEEEE")]
+                    internal static extern global::System.IntPtr FindOrCreateModule_0(global::System.IntPtr instance, global::Std.__1.BasicString.__Internal File);
 
                     [SuppressUnmanagedCodeSecurity]
                     [DllImport("CppSharp.CppParser", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
@@ -13849,6 +13923,22 @@ namespace CppSharp
                     if (__ownsNativeInstance)
                         Marshal.FreeHGlobal(__Instance);
                     __Instance = IntPtr.Zero;
+                }
+
+                public global::CppSharp.Parser.AST.TranslationUnit FindOrCreateModule(string File)
+                {
+                    var __allocator0 = new global::Std.__1.Allocator();
+                    var __basicString0 = new global::Std.__1.BasicString(File, __allocator0);
+                    var __arg0 = *(global::Std.__1.BasicString.__Internal*) __basicString0.__Instance;
+                    var __ret = __Internal.FindOrCreateModule_0((__Instance + __PointerAdjustment), __arg0);
+                    __basicString0.Dispose(false);
+                    __allocator0.Dispose();
+                    global::CppSharp.Parser.AST.TranslationUnit __result0;
+                    if (__ret == IntPtr.Zero) __result0 = null;
+                    else if (global::CppSharp.Parser.AST.TranslationUnit.NativeToManagedMap.ContainsKey(__ret))
+                        __result0 = (global::CppSharp.Parser.AST.TranslationUnit) global::CppSharp.Parser.AST.TranslationUnit.NativeToManagedMap[__ret];
+                    else __result0 = global::CppSharp.Parser.AST.TranslationUnit.__CreateInstance(__ret);
+                    return __result0;
                 }
 
                 public global::CppSharp.Parser.AST.TranslationUnit GetTranslationUnits(uint i)
@@ -14566,7 +14656,7 @@ namespace CppSharp
                     public partial struct __Internal
                     {
                         [FieldOffset(0)]
-                        internal global::Std.__1.BasicString.__Internal Text;
+                        internal global::Std.__1.BasicString.__Internal text;
 
                         [SuppressUnmanagedCodeSecurity]
                         [DllImport("CppSharp.CppParser", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
@@ -14582,16 +14672,6 @@ namespace CppSharp
                         [DllImport("CppSharp.CppParser", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
                             EntryPoint="_ZN8CppSharp9CppParser3AST19BlockCommandComment8ArgumentD2Ev")]
                         internal static extern void dtor_0(global::System.IntPtr instance);
-
-                        [SuppressUnmanagedCodeSecurity]
-                        [DllImport("CppSharp.CppParser", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
-                            EntryPoint="_ZN8CppSharp9CppParser3AST19BlockCommandComment8Argument7getTextEv")]
-                        internal static extern global::System.IntPtr GetText(global::System.IntPtr instance);
-
-                        [SuppressUnmanagedCodeSecurity]
-                        [DllImport("CppSharp.CppParser", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
-                            EntryPoint="_ZN8CppSharp9CppParser3AST19BlockCommandComment8Argument7setTextEPKc")]
-                        internal static extern void SetText(global::System.IntPtr instance, [MarshalAs(UnmanagedType.LPStr)] string s);
                     }
 
                     public global::System.IntPtr __Instance { get; protected set; }
@@ -14674,13 +14754,14 @@ namespace CppSharp
                     {
                         get
                         {
-                            var __ret = __Internal.GetText((__Instance + __PointerAdjustment));
-                            return Marshal.PtrToStringAnsi(__ret);
+                            return global::Std.__1.BasicString.__CreateInstance(((global::CppSharp.Parser.AST.BlockCommandComment.Argument.__Internal*) __Instance)->text).CStr();
                         }
 
                         set
                         {
-                            __Internal.SetText((__Instance + __PointerAdjustment), value);
+                            var __allocator0 = new global::Std.__1.Allocator();
+                            var __basicString0 = new global::Std.__1.BasicString(value, __allocator0);
+                            ((global::CppSharp.Parser.AST.BlockCommandComment.Argument.__Internal*) __Instance)->text = *(global::Std.__1.BasicString.__Internal*) __basicString0.__Instance;
                         }
                     }
                 }
@@ -15129,7 +15210,7 @@ namespace CppSharp
                     internal global::CppSharp.Parser.AST.CommentKind kind;
 
                     [FieldOffset(4)]
-                    internal global::Std.__1.BasicString.__Internal Text;
+                    internal global::Std.__1.BasicString.__Internal text;
 
                     [SuppressUnmanagedCodeSecurity]
                     [DllImport("CppSharp.CppParser", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
@@ -15145,16 +15226,6 @@ namespace CppSharp
                     [DllImport("CppSharp.CppParser", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
                         EntryPoint="_ZN8CppSharp9CppParser3AST24VerbatimBlockLineCommentD2Ev")]
                     internal static extern void dtor_0(global::System.IntPtr instance);
-
-                    [SuppressUnmanagedCodeSecurity]
-                    [DllImport("CppSharp.CppParser", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
-                        EntryPoint="_ZN8CppSharp9CppParser3AST24VerbatimBlockLineComment7getTextEv")]
-                    internal static extern global::System.IntPtr GetText(global::System.IntPtr instance);
-
-                    [SuppressUnmanagedCodeSecurity]
-                    [DllImport("CppSharp.CppParser", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
-                        EntryPoint="_ZN8CppSharp9CppParser3AST24VerbatimBlockLineComment7setTextEPKc")]
-                    internal static extern void SetText(global::System.IntPtr instance, [MarshalAs(UnmanagedType.LPStr)] string s);
                 }
 
                 internal static new global::CppSharp.Parser.AST.VerbatimBlockLineComment __CreateInstance(global::System.IntPtr native, bool skipVTables = false)
@@ -15228,13 +15299,14 @@ namespace CppSharp
                 {
                     get
                     {
-                        var __ret = __Internal.GetText((__Instance + __PointerAdjustment));
-                        return Marshal.PtrToStringAnsi(__ret);
+                        return global::Std.__1.BasicString.__CreateInstance(((global::CppSharp.Parser.AST.VerbatimBlockLineComment.__Internal*) __Instance)->text).CStr();
                     }
 
                     set
                     {
-                        __Internal.SetText((__Instance + __PointerAdjustment), value);
+                        var __allocator0 = new global::Std.__1.Allocator();
+                        var __basicString0 = new global::Std.__1.BasicString(value, __allocator0);
+                        ((global::CppSharp.Parser.AST.VerbatimBlockLineComment.__Internal*) __Instance)->text = *(global::Std.__1.BasicString.__Internal*) __basicString0.__Instance;
                     }
                 }
             }
@@ -15414,7 +15486,7 @@ namespace CppSharp
                     internal global::Std.__1.Vector.__Internal Arguments;
 
                     [FieldOffset(24)]
-                    internal global::Std.__1.BasicString.__Internal Text;
+                    internal global::Std.__1.BasicString.__Internal text;
 
                     [SuppressUnmanagedCodeSecurity]
                     [DllImport("CppSharp.CppParser", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
@@ -15430,16 +15502,6 @@ namespace CppSharp
                     [DllImport("CppSharp.CppParser", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
                         EntryPoint="_ZN8CppSharp9CppParser3AST19VerbatimLineCommentD2Ev")]
                     internal static extern void dtor_0(global::System.IntPtr instance);
-
-                    [SuppressUnmanagedCodeSecurity]
-                    [DllImport("CppSharp.CppParser", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
-                        EntryPoint="_ZN8CppSharp9CppParser3AST19VerbatimLineComment7getTextEv")]
-                    internal static extern global::System.IntPtr GetText(global::System.IntPtr instance);
-
-                    [SuppressUnmanagedCodeSecurity]
-                    [DllImport("CppSharp.CppParser", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
-                        EntryPoint="_ZN8CppSharp9CppParser3AST19VerbatimLineComment7setTextEPKc")]
-                    internal static extern void SetText(global::System.IntPtr instance, [MarshalAs(UnmanagedType.LPStr)] string s);
                 }
 
                 internal static new global::CppSharp.Parser.AST.VerbatimLineComment __CreateInstance(global::System.IntPtr native, bool skipVTables = false)
@@ -15513,13 +15575,14 @@ namespace CppSharp
                 {
                     get
                     {
-                        var __ret = __Internal.GetText((__Instance + __PointerAdjustment));
-                        return Marshal.PtrToStringAnsi(__ret);
+                        return global::Std.__1.BasicString.__CreateInstance(((global::CppSharp.Parser.AST.VerbatimLineComment.__Internal*) __Instance)->text).CStr();
                     }
 
                     set
                     {
-                        __Internal.SetText((__Instance + __PointerAdjustment), value);
+                        var __allocator0 = new global::Std.__1.Allocator();
+                        var __basicString0 = new global::Std.__1.BasicString(value, __allocator0);
+                        ((global::CppSharp.Parser.AST.VerbatimLineComment.__Internal*) __Instance)->text = *(global::Std.__1.BasicString.__Internal*) __basicString0.__Instance;
                     }
                 }
             }
@@ -15594,7 +15657,7 @@ namespace CppSharp
                     public partial struct __Internal
                     {
                         [FieldOffset(0)]
-                        internal global::Std.__1.BasicString.__Internal Text;
+                        internal global::Std.__1.BasicString.__Internal text;
 
                         [SuppressUnmanagedCodeSecurity]
                         [DllImport("CppSharp.CppParser", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
@@ -15610,16 +15673,6 @@ namespace CppSharp
                         [DllImport("CppSharp.CppParser", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
                             EntryPoint="_ZN8CppSharp9CppParser3AST20InlineCommandComment8ArgumentD2Ev")]
                         internal static extern void dtor_0(global::System.IntPtr instance);
-
-                        [SuppressUnmanagedCodeSecurity]
-                        [DllImport("CppSharp.CppParser", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
-                            EntryPoint="_ZN8CppSharp9CppParser3AST20InlineCommandComment8Argument7getTextEv")]
-                        internal static extern global::System.IntPtr GetText(global::System.IntPtr instance);
-
-                        [SuppressUnmanagedCodeSecurity]
-                        [DllImport("CppSharp.CppParser", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
-                            EntryPoint="_ZN8CppSharp9CppParser3AST20InlineCommandComment8Argument7setTextEPKc")]
-                        internal static extern void SetText(global::System.IntPtr instance, [MarshalAs(UnmanagedType.LPStr)] string s);
                     }
 
                     public global::System.IntPtr __Instance { get; protected set; }
@@ -15702,13 +15755,14 @@ namespace CppSharp
                     {
                         get
                         {
-                            var __ret = __Internal.GetText((__Instance + __PointerAdjustment));
-                            return Marshal.PtrToStringAnsi(__ret);
+                            return global::Std.__1.BasicString.__CreateInstance(((global::CppSharp.Parser.AST.InlineCommandComment.Argument.__Internal*) __Instance)->text).CStr();
                         }
 
                         set
                         {
-                            __Internal.SetText((__Instance + __PointerAdjustment), value);
+                            var __allocator0 = new global::Std.__1.Allocator();
+                            var __basicString0 = new global::Std.__1.BasicString(value, __allocator0);
+                            ((global::CppSharp.Parser.AST.InlineCommandComment.Argument.__Internal*) __Instance)->text = *(global::Std.__1.BasicString.__Internal*) __basicString0.__Instance;
                         }
                     }
                 }
@@ -15941,7 +15995,7 @@ namespace CppSharp
                     internal byte hasTrailingNewline;
 
                     [FieldOffset(8)]
-                    internal global::Std.__1.BasicString.__Internal TagName;
+                    internal global::Std.__1.BasicString.__Internal tagName;
 
                     [FieldOffset(20)]
                     internal global::Std.__1.Vector.__Internal Attributes;
@@ -15978,16 +16032,6 @@ namespace CppSharp
 
                     [SuppressUnmanagedCodeSecurity]
                     [DllImport("CppSharp.CppParser", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
-                        EntryPoint="_ZN8CppSharp9CppParser3AST19HTMLStartTagComment10getTagNameEv")]
-                    internal static extern global::System.IntPtr GetTagName(global::System.IntPtr instance);
-
-                    [SuppressUnmanagedCodeSecurity]
-                    [DllImport("CppSharp.CppParser", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
-                        EntryPoint="_ZN8CppSharp9CppParser3AST19HTMLStartTagComment10setTagNameEPKc")]
-                    internal static extern void SetTagName(global::System.IntPtr instance, [MarshalAs(UnmanagedType.LPStr)] string s);
-
-                    [SuppressUnmanagedCodeSecurity]
-                    [DllImport("CppSharp.CppParser", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
                         EntryPoint="_ZN8CppSharp9CppParser3AST19HTMLStartTagComment18getAttributesCountEv")]
                     internal static extern uint GetAttributesCount(global::System.IntPtr instance);
                 }
@@ -15998,10 +16042,10 @@ namespace CppSharp
                     public partial struct __Internal
                     {
                         [FieldOffset(0)]
-                        internal global::Std.__1.BasicString.__Internal Name;
+                        internal global::Std.__1.BasicString.__Internal name;
 
                         [FieldOffset(12)]
-                        internal global::Std.__1.BasicString.__Internal Value;
+                        internal global::Std.__1.BasicString.__Internal value;
 
                         [SuppressUnmanagedCodeSecurity]
                         [DllImport("CppSharp.CppParser", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
@@ -16017,26 +16061,6 @@ namespace CppSharp
                         [DllImport("CppSharp.CppParser", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
                             EntryPoint="_ZN8CppSharp9CppParser3AST19HTMLStartTagComment9AttributeD2Ev")]
                         internal static extern void dtor_0(global::System.IntPtr instance);
-
-                        [SuppressUnmanagedCodeSecurity]
-                        [DllImport("CppSharp.CppParser", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
-                            EntryPoint="_ZN8CppSharp9CppParser3AST19HTMLStartTagComment9Attribute7getNameEv")]
-                        internal static extern global::System.IntPtr GetName(global::System.IntPtr instance);
-
-                        [SuppressUnmanagedCodeSecurity]
-                        [DllImport("CppSharp.CppParser", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
-                            EntryPoint="_ZN8CppSharp9CppParser3AST19HTMLStartTagComment9Attribute7setNameEPKc")]
-                        internal static extern void SetName(global::System.IntPtr instance, [MarshalAs(UnmanagedType.LPStr)] string s);
-
-                        [SuppressUnmanagedCodeSecurity]
-                        [DllImport("CppSharp.CppParser", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
-                            EntryPoint="_ZN8CppSharp9CppParser3AST19HTMLStartTagComment9Attribute8getValueEv")]
-                        internal static extern global::System.IntPtr GetValue(global::System.IntPtr instance);
-
-                        [SuppressUnmanagedCodeSecurity]
-                        [DllImport("CppSharp.CppParser", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
-                            EntryPoint="_ZN8CppSharp9CppParser3AST19HTMLStartTagComment9Attribute8setValueEPKc")]
-                        internal static extern void SetValue(global::System.IntPtr instance, [MarshalAs(UnmanagedType.LPStr)] string s);
                     }
 
                     public global::System.IntPtr __Instance { get; protected set; }
@@ -16119,13 +16143,14 @@ namespace CppSharp
                     {
                         get
                         {
-                            var __ret = __Internal.GetName((__Instance + __PointerAdjustment));
-                            return Marshal.PtrToStringAnsi(__ret);
+                            return global::Std.__1.BasicString.__CreateInstance(((global::CppSharp.Parser.AST.HTMLStartTagComment.Attribute.__Internal*) __Instance)->name).CStr();
                         }
 
                         set
                         {
-                            __Internal.SetName((__Instance + __PointerAdjustment), value);
+                            var __allocator0 = new global::Std.__1.Allocator();
+                            var __basicString0 = new global::Std.__1.BasicString(value, __allocator0);
+                            ((global::CppSharp.Parser.AST.HTMLStartTagComment.Attribute.__Internal*) __Instance)->name = *(global::Std.__1.BasicString.__Internal*) __basicString0.__Instance;
                         }
                     }
 
@@ -16133,13 +16158,14 @@ namespace CppSharp
                     {
                         get
                         {
-                            var __ret = __Internal.GetValue((__Instance + __PointerAdjustment));
-                            return Marshal.PtrToStringAnsi(__ret);
+                            return global::Std.__1.BasicString.__CreateInstance(((global::CppSharp.Parser.AST.HTMLStartTagComment.Attribute.__Internal*) __Instance)->value).CStr();
                         }
 
                         set
                         {
-                            __Internal.SetValue((__Instance + __PointerAdjustment), value);
+                            var __allocator0 = new global::Std.__1.Allocator();
+                            var __basicString0 = new global::Std.__1.BasicString(value, __allocator0);
+                            ((global::CppSharp.Parser.AST.HTMLStartTagComment.Attribute.__Internal*) __Instance)->value = *(global::Std.__1.BasicString.__Internal*) __basicString0.__Instance;
                         }
                     }
                 }
@@ -16235,13 +16261,14 @@ namespace CppSharp
                 {
                     get
                     {
-                        var __ret = __Internal.GetTagName((__Instance + __PointerAdjustment));
-                        return Marshal.PtrToStringAnsi(__ret);
+                        return global::Std.__1.BasicString.__CreateInstance(((global::CppSharp.Parser.AST.HTMLStartTagComment.__Internal*) __Instance)->tagName).CStr();
                     }
 
                     set
                     {
-                        __Internal.SetTagName((__Instance + __PointerAdjustment), value);
+                        var __allocator0 = new global::Std.__1.Allocator();
+                        var __basicString0 = new global::Std.__1.BasicString(value, __allocator0);
+                        ((global::CppSharp.Parser.AST.HTMLStartTagComment.__Internal*) __Instance)->tagName = *(global::Std.__1.BasicString.__Internal*) __basicString0.__Instance;
                     }
                 }
 
@@ -16267,7 +16294,7 @@ namespace CppSharp
                     internal byte hasTrailingNewline;
 
                     [FieldOffset(8)]
-                    internal global::Std.__1.BasicString.__Internal TagName;
+                    internal global::Std.__1.BasicString.__Internal tagName;
 
                     [SuppressUnmanagedCodeSecurity]
                     [DllImport("CppSharp.CppParser", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
@@ -16283,16 +16310,6 @@ namespace CppSharp
                     [DllImport("CppSharp.CppParser", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
                         EntryPoint="_ZN8CppSharp9CppParser3AST17HTMLEndTagCommentD2Ev")]
                     internal static extern void dtor_0(global::System.IntPtr instance);
-
-                    [SuppressUnmanagedCodeSecurity]
-                    [DllImport("CppSharp.CppParser", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
-                        EntryPoint="_ZN8CppSharp9CppParser3AST17HTMLEndTagComment10getTagNameEv")]
-                    internal static extern global::System.IntPtr GetTagName(global::System.IntPtr instance);
-
-                    [SuppressUnmanagedCodeSecurity]
-                    [DllImport("CppSharp.CppParser", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
-                        EntryPoint="_ZN8CppSharp9CppParser3AST17HTMLEndTagComment10setTagNameEPKc")]
-                    internal static extern void SetTagName(global::System.IntPtr instance, [MarshalAs(UnmanagedType.LPStr)] string s);
                 }
 
                 internal static new global::CppSharp.Parser.AST.HTMLEndTagComment __CreateInstance(global::System.IntPtr native, bool skipVTables = false)
@@ -16366,13 +16383,14 @@ namespace CppSharp
                 {
                     get
                     {
-                        var __ret = __Internal.GetTagName((__Instance + __PointerAdjustment));
-                        return Marshal.PtrToStringAnsi(__ret);
+                        return global::Std.__1.BasicString.__CreateInstance(((global::CppSharp.Parser.AST.HTMLEndTagComment.__Internal*) __Instance)->tagName).CStr();
                     }
 
                     set
                     {
-                        __Internal.SetTagName((__Instance + __PointerAdjustment), value);
+                        var __allocator0 = new global::Std.__1.Allocator();
+                        var __basicString0 = new global::Std.__1.BasicString(value, __allocator0);
+                        ((global::CppSharp.Parser.AST.HTMLEndTagComment.__Internal*) __Instance)->tagName = *(global::Std.__1.BasicString.__Internal*) __basicString0.__Instance;
                     }
                 }
             }
@@ -16389,7 +16407,7 @@ namespace CppSharp
                     internal byte hasTrailingNewline;
 
                     [FieldOffset(8)]
-                    internal global::Std.__1.BasicString.__Internal Text;
+                    internal global::Std.__1.BasicString.__Internal text;
 
                     [SuppressUnmanagedCodeSecurity]
                     [DllImport("CppSharp.CppParser", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
@@ -16405,16 +16423,6 @@ namespace CppSharp
                     [DllImport("CppSharp.CppParser", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
                         EntryPoint="_ZN8CppSharp9CppParser3AST11TextCommentD2Ev")]
                     internal static extern void dtor_0(global::System.IntPtr instance);
-
-                    [SuppressUnmanagedCodeSecurity]
-                    [DllImport("CppSharp.CppParser", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
-                        EntryPoint="_ZN8CppSharp9CppParser3AST11TextComment7getTextEv")]
-                    internal static extern global::System.IntPtr GetText(global::System.IntPtr instance);
-
-                    [SuppressUnmanagedCodeSecurity]
-                    [DllImport("CppSharp.CppParser", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
-                        EntryPoint="_ZN8CppSharp9CppParser3AST11TextComment7setTextEPKc")]
-                    internal static extern void SetText(global::System.IntPtr instance, [MarshalAs(UnmanagedType.LPStr)] string s);
                 }
 
                 internal static new global::CppSharp.Parser.AST.TextComment __CreateInstance(global::System.IntPtr native, bool skipVTables = false)
@@ -16488,13 +16496,14 @@ namespace CppSharp
                 {
                     get
                     {
-                        var __ret = __Internal.GetText((__Instance + __PointerAdjustment));
-                        return Marshal.PtrToStringAnsi(__ret);
+                        return global::Std.__1.BasicString.__CreateInstance(((global::CppSharp.Parser.AST.TextComment.__Internal*) __Instance)->text).CStr();
                     }
 
                     set
                     {
-                        __Internal.SetText((__Instance + __PointerAdjustment), value);
+                        var __allocator0 = new global::Std.__1.Allocator();
+                        var __basicString0 = new global::Std.__1.BasicString(value, __allocator0);
+                        ((global::CppSharp.Parser.AST.TextComment.__Internal*) __Instance)->text = *(global::Std.__1.BasicString.__Internal*) __basicString0.__Instance;
                     }
                 }
             }
@@ -16508,10 +16517,10 @@ namespace CppSharp
                     internal global::CppSharp.Parser.AST.RawCommentKind kind;
 
                     [FieldOffset(4)]
-                    internal global::Std.__1.BasicString.__Internal Text;
+                    internal global::Std.__1.BasicString.__Internal text;
 
                     [FieldOffset(16)]
-                    internal global::Std.__1.BasicString.__Internal BriefText;
+                    internal global::Std.__1.BasicString.__Internal briefText;
 
                     [FieldOffset(28)]
                     internal global::System.IntPtr fullCommentBlock;
@@ -16530,26 +16539,6 @@ namespace CppSharp
                     [DllImport("CppSharp.CppParser", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
                         EntryPoint="_ZN8CppSharp9CppParser3AST10RawCommentD2Ev")]
                     internal static extern void dtor_0(global::System.IntPtr instance);
-
-                    [SuppressUnmanagedCodeSecurity]
-                    [DllImport("CppSharp.CppParser", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
-                        EntryPoint="_ZN8CppSharp9CppParser3AST10RawComment7getTextEv")]
-                    internal static extern global::System.IntPtr GetText(global::System.IntPtr instance);
-
-                    [SuppressUnmanagedCodeSecurity]
-                    [DllImport("CppSharp.CppParser", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
-                        EntryPoint="_ZN8CppSharp9CppParser3AST10RawComment7setTextEPKc")]
-                    internal static extern void SetText(global::System.IntPtr instance, [MarshalAs(UnmanagedType.LPStr)] string s);
-
-                    [SuppressUnmanagedCodeSecurity]
-                    [DllImport("CppSharp.CppParser", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
-                        EntryPoint="_ZN8CppSharp9CppParser3AST10RawComment12getBriefTextEv")]
-                    internal static extern global::System.IntPtr GetBriefText(global::System.IntPtr instance);
-
-                    [SuppressUnmanagedCodeSecurity]
-                    [DllImport("CppSharp.CppParser", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
-                        EntryPoint="_ZN8CppSharp9CppParser3AST10RawComment12setBriefTextEPKc")]
-                    internal static extern void SetBriefText(global::System.IntPtr instance, [MarshalAs(UnmanagedType.LPStr)] string s);
                 }
 
                 public global::System.IntPtr __Instance { get; protected set; }
@@ -16641,6 +16630,36 @@ namespace CppSharp
                     }
                 }
 
+                public string Text
+                {
+                    get
+                    {
+                        return global::Std.__1.BasicString.__CreateInstance(((global::CppSharp.Parser.AST.RawComment.__Internal*) __Instance)->text).CStr();
+                    }
+
+                    set
+                    {
+                        var __allocator0 = new global::Std.__1.Allocator();
+                        var __basicString0 = new global::Std.__1.BasicString(value, __allocator0);
+                        ((global::CppSharp.Parser.AST.RawComment.__Internal*) __Instance)->text = *(global::Std.__1.BasicString.__Internal*) __basicString0.__Instance;
+                    }
+                }
+
+                public string BriefText
+                {
+                    get
+                    {
+                        return global::Std.__1.BasicString.__CreateInstance(((global::CppSharp.Parser.AST.RawComment.__Internal*) __Instance)->briefText).CStr();
+                    }
+
+                    set
+                    {
+                        var __allocator0 = new global::Std.__1.Allocator();
+                        var __basicString0 = new global::Std.__1.BasicString(value, __allocator0);
+                        ((global::CppSharp.Parser.AST.RawComment.__Internal*) __Instance)->briefText = *(global::Std.__1.BasicString.__Internal*) __basicString0.__Instance;
+                    }
+                }
+
                 public global::CppSharp.Parser.AST.FullComment FullCommentBlock
                 {
                     get
@@ -16656,34 +16675,6 @@ namespace CppSharp
                     set
                     {
                         ((global::CppSharp.Parser.AST.RawComment.__Internal*) __Instance)->fullCommentBlock = ReferenceEquals(value, null) ? global::System.IntPtr.Zero : value.__Instance;
-                    }
-                }
-
-                public string Text
-                {
-                    get
-                    {
-                        var __ret = __Internal.GetText((__Instance + __PointerAdjustment));
-                        return Marshal.PtrToStringAnsi(__ret);
-                    }
-
-                    set
-                    {
-                        __Internal.SetText((__Instance + __PointerAdjustment), value);
-                    }
-                }
-
-                public string BriefText
-                {
-                    get
-                    {
-                        var __ret = __Internal.GetBriefText((__Instance + __PointerAdjustment));
-                        return Marshal.PtrToStringAnsi(__ret);
-                    }
-
-                    set
-                    {
-                        __Internal.SetBriefText((__Instance + __PointerAdjustment), value);
                     }
                 }
             }
@@ -16945,16 +16936,6 @@ namespace CppSharp
                 [DllImport("CppSharp.CppParser", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
                     EntryPoint="_ZN8CppSharp9CppParser16ParserTargetInfoD2Ev")]
                 internal static extern void dtor_0(global::System.IntPtr instance);
-
-                [SuppressUnmanagedCodeSecurity]
-                [DllImport("CppSharp.CppParser", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
-                    EntryPoint="_ZN8CppSharp9CppParser16ParserTargetInfo6getABIEv")]
-                internal static extern global::System.IntPtr GetABI(global::System.IntPtr instance);
-
-                [SuppressUnmanagedCodeSecurity]
-                [DllImport("CppSharp.CppParser", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
-                    EntryPoint="_ZN8CppSharp9CppParser16ParserTargetInfo6setABIEPKc")]
-                internal static extern void SetABI(global::System.IntPtr instance, [MarshalAs(UnmanagedType.LPStr)] string s);
             }
 
             public global::System.IntPtr __Instance { get; protected set; }
@@ -17031,6 +17012,21 @@ namespace CppSharp
                 if (__ownsNativeInstance)
                     Marshal.FreeHGlobal(__Instance);
                 __Instance = IntPtr.Zero;
+            }
+
+            public string ABI
+            {
+                get
+                {
+                    return global::Std.__1.BasicString.__CreateInstance(((global::CppSharp.Parser.ParserTargetInfo.__Internal*) __Instance)->ABI).CStr();
+                }
+
+                set
+                {
+                    var __allocator0 = new global::Std.__1.Allocator();
+                    var __basicString0 = new global::Std.__1.BasicString(value, __allocator0);
+                    ((global::CppSharp.Parser.ParserTargetInfo.__Internal*) __Instance)->ABI = *(global::Std.__1.BasicString.__Internal*) __basicString0.__Instance;
+                }
             }
 
             public global::CppSharp.Parser.ParserIntType Char16Type
@@ -17552,20 +17548,6 @@ namespace CppSharp
                     ((global::CppSharp.Parser.ParserTargetInfo.__Internal*) __Instance)->float128Width = value;
                 }
             }
-
-            public string ABI
-            {
-                get
-                {
-                    var __ret = __Internal.GetABI((__Instance + __PointerAdjustment));
-                    return Marshal.PtrToStringAnsi(__ret);
-                }
-
-                set
-                {
-                    __Internal.SetABI((__Instance + __PointerAdjustment), value);
-                }
-            }
         }
     }
 }
@@ -17671,7 +17653,7 @@ namespace CppSharp
                 internal global::Std.__1.Vector.__Internal Arguments;
 
                 [FieldOffset(12)]
-                internal global::Std.__1.BasicString.__Internal LibraryFile;
+                internal global::Std.__1.BasicString.__Internal libraryFile;
 
                 [FieldOffset(24)]
                 internal global::Std.__1.Vector.__Internal SourceFiles;
@@ -17698,7 +17680,7 @@ namespace CppSharp
                 internal int toolSetToUse;
 
                 [FieldOffset(104)]
-                internal global::Std.__1.BasicString.__Internal TargetTriple;
+                internal global::Std.__1.BasicString.__Internal targetTriple;
 
                 [FieldOffset(116)]
                 internal global::CppSharp.Parser.AST.CppAbi abi;
@@ -17840,26 +17822,6 @@ namespace CppSharp
                 [DllImport("CppSharp.CppParser", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
                     EntryPoint="_ZN8CppSharp9CppParser16CppParserOptions16clearLibraryDirsEv")]
                 internal static extern void ClearLibraryDirs_0(global::System.IntPtr instance);
-
-                [SuppressUnmanagedCodeSecurity]
-                [DllImport("CppSharp.CppParser", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
-                    EntryPoint="_ZN8CppSharp9CppParser16CppParserOptions14getLibraryFileEv")]
-                internal static extern global::System.IntPtr GetLibraryFile(global::System.IntPtr instance);
-
-                [SuppressUnmanagedCodeSecurity]
-                [DllImport("CppSharp.CppParser", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
-                    EntryPoint="_ZN8CppSharp9CppParser16CppParserOptions14setLibraryFileEPKc")]
-                internal static extern void SetLibraryFile(global::System.IntPtr instance, [MarshalAs(UnmanagedType.LPStr)] string s);
-
-                [SuppressUnmanagedCodeSecurity]
-                [DllImport("CppSharp.CppParser", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
-                    EntryPoint="_ZN8CppSharp9CppParser16CppParserOptions15getTargetTripleEv")]
-                internal static extern global::System.IntPtr GetTargetTriple(global::System.IntPtr instance);
-
-                [SuppressUnmanagedCodeSecurity]
-                [DllImport("CppSharp.CppParser", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
-                    EntryPoint="_ZN8CppSharp9CppParser16CppParserOptions15setTargetTripleEPKc")]
-                internal static extern void SetTargetTriple(global::System.IntPtr instance, [MarshalAs(UnmanagedType.LPStr)] string s);
 
                 [SuppressUnmanagedCodeSecurity]
                 [DllImport("CppSharp.CppParser", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
@@ -18085,6 +18047,21 @@ namespace CppSharp
                 __Internal.ClearLibraryDirs_0((__Instance + __PointerAdjustment));
             }
 
+            public string LibraryFile
+            {
+                get
+                {
+                    return global::Std.__1.BasicString.__CreateInstance(((global::CppSharp.Parser.CppParserOptions.__Internal*) __Instance)->libraryFile).CStr();
+                }
+
+                set
+                {
+                    var __allocator0 = new global::Std.__1.Allocator();
+                    var __basicString0 = new global::Std.__1.BasicString(value, __allocator0);
+                    ((global::CppSharp.Parser.CppParserOptions.__Internal*) __Instance)->libraryFile = *(global::Std.__1.BasicString.__Internal*) __basicString0.__Instance;
+                }
+            }
+
             public global::CppSharp.Parser.AST.ASTContext ASTContext
             {
                 get
@@ -18113,6 +18090,21 @@ namespace CppSharp
                 set
                 {
                     ((global::CppSharp.Parser.CppParserOptions.__Internal*) __Instance)->toolSetToUse = value;
+                }
+            }
+
+            public string TargetTriple
+            {
+                get
+                {
+                    return global::Std.__1.BasicString.__CreateInstance(((global::CppSharp.Parser.CppParserOptions.__Internal*) __Instance)->targetTriple).CStr();
+                }
+
+                set
+                {
+                    var __allocator0 = new global::Std.__1.Allocator();
+                    var __basicString0 = new global::Std.__1.BasicString(value, __allocator0);
+                    ((global::CppSharp.Parser.CppParserOptions.__Internal*) __Instance)->targetTriple = *(global::Std.__1.BasicString.__Internal*) __basicString0.__Instance;
                 }
             }
 
@@ -18212,34 +18204,6 @@ namespace CppSharp
                 }
             }
 
-            public string LibraryFile
-            {
-                get
-                {
-                    var __ret = __Internal.GetLibraryFile((__Instance + __PointerAdjustment));
-                    return Marshal.PtrToStringAnsi(__ret);
-                }
-
-                set
-                {
-                    __Internal.SetLibraryFile((__Instance + __PointerAdjustment), value);
-                }
-            }
-
-            public string TargetTriple
-            {
-                get
-                {
-                    var __ret = __Internal.GetTargetTriple((__Instance + __PointerAdjustment));
-                    return Marshal.PtrToStringAnsi(__ret);
-                }
-
-                set
-                {
-                    __Internal.SetTargetTriple((__Instance + __PointerAdjustment), value);
-                }
-            }
-
             public uint ArgumentsCount
             {
                 get
@@ -18310,10 +18274,10 @@ namespace CppSharp
             public partial struct __Internal
             {
                 [FieldOffset(0)]
-                internal global::Std.__1.BasicString.__Internal FileName;
+                internal global::Std.__1.BasicString.__Internal fileName;
 
                 [FieldOffset(12)]
-                internal global::Std.__1.BasicString.__Internal Message;
+                internal global::Std.__1.BasicString.__Internal message;
 
                 [FieldOffset(24)]
                 internal global::CppSharp.Parser.ParserDiagnosticLevel level;
@@ -18338,26 +18302,6 @@ namespace CppSharp
                 [DllImport("CppSharp.CppParser", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
                     EntryPoint="_ZN8CppSharp9CppParser16ParserDiagnosticD2Ev")]
                 internal static extern void dtor_0(global::System.IntPtr instance);
-
-                [SuppressUnmanagedCodeSecurity]
-                [DllImport("CppSharp.CppParser", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
-                    EntryPoint="_ZN8CppSharp9CppParser16ParserDiagnostic11getFileNameEv")]
-                internal static extern global::System.IntPtr GetFileName(global::System.IntPtr instance);
-
-                [SuppressUnmanagedCodeSecurity]
-                [DllImport("CppSharp.CppParser", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
-                    EntryPoint="_ZN8CppSharp9CppParser16ParserDiagnostic11setFileNameEPKc")]
-                internal static extern void SetFileName(global::System.IntPtr instance, [MarshalAs(UnmanagedType.LPStr)] string s);
-
-                [SuppressUnmanagedCodeSecurity]
-                [DllImport("CppSharp.CppParser", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
-                    EntryPoint="_ZN8CppSharp9CppParser16ParserDiagnostic10getMessageEv")]
-                internal static extern global::System.IntPtr GetMessage(global::System.IntPtr instance);
-
-                [SuppressUnmanagedCodeSecurity]
-                [DllImport("CppSharp.CppParser", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
-                    EntryPoint="_ZN8CppSharp9CppParser16ParserDiagnostic10setMessageEPKc")]
-                internal static extern void SetMessage(global::System.IntPtr instance, [MarshalAs(UnmanagedType.LPStr)] string s);
             }
 
             public global::System.IntPtr __Instance { get; protected set; }
@@ -18436,6 +18380,36 @@ namespace CppSharp
                 __Instance = IntPtr.Zero;
             }
 
+            public string FileName
+            {
+                get
+                {
+                    return global::Std.__1.BasicString.__CreateInstance(((global::CppSharp.Parser.ParserDiagnostic.__Internal*) __Instance)->fileName).CStr();
+                }
+
+                set
+                {
+                    var __allocator0 = new global::Std.__1.Allocator();
+                    var __basicString0 = new global::Std.__1.BasicString(value, __allocator0);
+                    ((global::CppSharp.Parser.ParserDiagnostic.__Internal*) __Instance)->fileName = *(global::Std.__1.BasicString.__Internal*) __basicString0.__Instance;
+                }
+            }
+
+            public string Message
+            {
+                get
+                {
+                    return global::Std.__1.BasicString.__CreateInstance(((global::CppSharp.Parser.ParserDiagnostic.__Internal*) __Instance)->message).CStr();
+                }
+
+                set
+                {
+                    var __allocator0 = new global::Std.__1.Allocator();
+                    var __basicString0 = new global::Std.__1.BasicString(value, __allocator0);
+                    ((global::CppSharp.Parser.ParserDiagnostic.__Internal*) __Instance)->message = *(global::Std.__1.BasicString.__Internal*) __basicString0.__Instance;
+                }
+            }
+
             public global::CppSharp.Parser.ParserDiagnosticLevel Level
             {
                 get
@@ -18472,34 +18446,6 @@ namespace CppSharp
                 set
                 {
                     ((global::CppSharp.Parser.ParserDiagnostic.__Internal*) __Instance)->columnNumber = value;
-                }
-            }
-
-            public string FileName
-            {
-                get
-                {
-                    var __ret = __Internal.GetFileName((__Instance + __PointerAdjustment));
-                    return Marshal.PtrToStringAnsi(__ret);
-                }
-
-                set
-                {
-                    __Internal.SetFileName((__Instance + __PointerAdjustment), value);
-                }
-            }
-
-            public string Message
-            {
-                get
-                {
-                    var __ret = __Internal.GetMessage((__Instance + __PointerAdjustment));
-                    return Marshal.PtrToStringAnsi(__ret);
-                }
-
-                set
-                {
-                    __Internal.SetMessage((__Instance + __PointerAdjustment), value);
                 }
             }
         }

--- a/src/CppParser/Bindings/CSharp/i686-apple-darwin12.4.0/Std.cs
+++ b/src/CppParser/Bindings/CSharp/i686-apple-darwin12.4.0/Std.cs
@@ -1256,69 +1256,6 @@ namespace Std
 {
     namespace __1
     {
-        public unsafe partial class CharTraits : IDisposable
-        {
-            [StructLayout(LayoutKind.Explicit, Size = 0)]
-            public unsafe partial struct __Internal
-            {
-            }
-
-            public global::System.IntPtr __Instance { get; protected set; }
-
-            protected int __PointerAdjustment;
-            internal static readonly global::System.Collections.Concurrent.ConcurrentDictionary<IntPtr, global::Std.__1.CharTraits> NativeToManagedMap = new global::System.Collections.Concurrent.ConcurrentDictionary<IntPtr, global::Std.__1.CharTraits>();
-            protected void*[] __OriginalVTables;
-
-            protected bool __ownsNativeInstance;
-
-            internal static global::Std.__1.CharTraits __CreateInstance(global::System.IntPtr native, bool skipVTables = false)
-            {
-                return new global::Std.__1.CharTraits(native.ToPointer(), skipVTables);
-            }
-
-            internal static global::Std.__1.CharTraits __CreateInstance(global::Std.__1.CharTraits.__Internal native, bool skipVTables = false)
-            {
-                return new global::Std.__1.CharTraits(native, skipVTables);
-            }
-
-            private static void* __CopyValue(global::Std.__1.CharTraits.__Internal native)
-            {
-                var ret = Marshal.AllocHGlobal(sizeof(global::Std.__1.CharTraits.__Internal));
-                *(global::Std.__1.CharTraits.__Internal*) ret = native;
-                return ret.ToPointer();
-            }
-
-            private CharTraits(global::Std.__1.CharTraits.__Internal native, bool skipVTables = false)
-                : this(__CopyValue(native), skipVTables)
-            {
-                __ownsNativeInstance = true;
-                NativeToManagedMap[__Instance] = this;
-            }
-
-            protected CharTraits(void* native, bool skipVTables = false)
-            {
-                if (native == null)
-                    return;
-                __Instance = new global::System.IntPtr(native);
-            }
-
-            public void Dispose()
-            {
-                Dispose(disposing: true);
-            }
-
-            public virtual void Dispose(bool disposing)
-            {
-                if (__Instance == IntPtr.Zero)
-                    return;
-                global::Std.__1.CharTraits __dummy;
-                NativeToManagedMap.TryRemove(__Instance, out __dummy);
-                if (__ownsNativeInstance)
-                    Marshal.FreeHGlobal(__Instance);
-                __Instance = IntPtr.Zero;
-            }
-        }
-
         public unsafe partial class BasicString : IDisposable
         {
             [StructLayout(LayoutKind.Explicit, Size = 12)]
@@ -1326,6 +1263,11 @@ namespace Std
             {
                 [FieldOffset(0)]
                 internal global::Std.__1.CompressedPair.__Internal __r_;
+
+                [SuppressUnmanagedCodeSecurity]
+                [DllImport("Std-symbols", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
+                    EntryPoint="_ZNSt3__112basic_stringIcNS_11char_traitsIcEENS_9allocatorIcEEEC2EPKcRKS4_")]
+                internal static extern void ctorc__N_std_N___1_S_basic_string__C___N_std_N___1_S_char_traits__C___N_std_N___1_S_allocator__C_0(global::System.IntPtr instance, [MarshalAs(UnmanagedType.LPStr)] string __s, global::System.IntPtr __a);
 
                 [SuppressUnmanagedCodeSecurity]
                 [DllImport("Std-symbols", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
@@ -1492,6 +1434,17 @@ namespace Std
                 if (native == null)
                     return;
                 __Instance = new global::System.IntPtr(native);
+            }
+
+            public BasicString(string __s, global::Std.__1.Allocator __a)
+            {
+                __Instance = Marshal.AllocHGlobal(sizeof(global::Std.__1.BasicString.__Internal));
+                __ownsNativeInstance = true;
+                NativeToManagedMap[__Instance] = this;
+                if (ReferenceEquals(__a, null))
+                    throw new global::System.ArgumentNullException("__a", "Cannot be null because it is a C++ reference (&).");
+                var __arg1 = __a.__Instance;
+                global::Std.__1.BasicString.__Internal.ctorc__N_std_N___1_S_basic_string__C___N_std_N___1_S_char_traits__C___N_std_N___1_S_allocator__C_0((__Instance + __PointerAdjustment), __s, __arg1);
             }
 
             public void Dispose()

--- a/src/CppParser/Bindings/CSharp/i686-pc-win32-msvc/CppSharp.CppParser.cs
+++ b/src/CppParser/Bindings/CSharp/i686-pc-win32-msvc/CppSharp.CppParser.cs
@@ -2589,7 +2589,7 @@ namespace CppSharp
                     internal global::CppSharp.Parser.AST.QualifiedType.__Internal qualifier;
 
                     [FieldOffset(16)]
-                    internal global::Std.BasicString.__Internal Identifier;
+                    internal global::Std.BasicString.__Internal identifier;
 
                     [SuppressUnmanagedCodeSecurity]
                     [DllImport("CppSharp.CppParser.dll", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.ThisCall,
@@ -2605,16 +2605,6 @@ namespace CppSharp
                     [DllImport("CppSharp.CppParser.dll", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.ThisCall,
                         EntryPoint="??1DependentNameType@AST@CppParser@CppSharp@@QAE@XZ")]
                     internal static extern void dtor_0(global::System.IntPtr instance, int delete);
-
-                    [SuppressUnmanagedCodeSecurity]
-                    [DllImport("CppSharp.CppParser.dll", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.ThisCall,
-                        EntryPoint="?getIdentifier@DependentNameType@AST@CppParser@CppSharp@@QAEPBDXZ")]
-                    internal static extern global::System.IntPtr GetIdentifier(global::System.IntPtr instance);
-
-                    [SuppressUnmanagedCodeSecurity]
-                    [DllImport("CppSharp.CppParser.dll", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.ThisCall,
-                        EntryPoint="?setIdentifier@DependentNameType@AST@CppParser@CppSharp@@QAEXPBD@Z")]
-                    internal static extern void SetIdentifier(global::System.IntPtr instance, [MarshalAs(UnmanagedType.LPStr)] string s);
                 }
 
                 internal static new global::CppSharp.Parser.AST.DependentNameType __CreateInstance(global::System.IntPtr native, bool skipVTables = false)
@@ -2701,13 +2691,14 @@ namespace CppSharp
                 {
                     get
                     {
-                        var __ret = __Internal.GetIdentifier((__Instance + __PointerAdjustment));
-                        return Marshal.PtrToStringAnsi(__ret);
+                        return global::Std.BasicString.__CreateInstance(((global::CppSharp.Parser.AST.DependentNameType.__Internal*) __Instance)->identifier).CStr();
                     }
 
                     set
                     {
-                        __Internal.SetIdentifier((__Instance + __PointerAdjustment), value);
+                        var __allocator0 = new global::Std.Allocator();
+                        var __basicString0 = new global::Std.BasicString(value, __allocator0);
+                        ((global::CppSharp.Parser.AST.DependentNameType.__Internal*) __Instance)->identifier = *(global::Std.BasicString.__Internal*) __basicString0.__Instance;
                     }
                 }
             }
@@ -3562,7 +3553,7 @@ namespace CppSharp
                     internal uint offset;
 
                     [FieldOffset(4)]
-                    internal global::Std.BasicString.__Internal Name;
+                    internal global::Std.BasicString.__Internal name;
 
                     [FieldOffset(28)]
                     internal global::CppSharp.Parser.AST.QualifiedType.__Internal qualifiedType;
@@ -3584,16 +3575,6 @@ namespace CppSharp
                     [DllImport("CppSharp.CppParser.dll", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.ThisCall,
                         EntryPoint="??1LayoutField@AST@CppParser@CppSharp@@QAE@XZ")]
                     internal static extern void dtor_0(global::System.IntPtr instance, int delete);
-
-                    [SuppressUnmanagedCodeSecurity]
-                    [DllImport("CppSharp.CppParser.dll", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.ThisCall,
-                        EntryPoint="?getName@LayoutField@AST@CppParser@CppSharp@@QAEPBDXZ")]
-                    internal static extern global::System.IntPtr GetName(global::System.IntPtr instance);
-
-                    [SuppressUnmanagedCodeSecurity]
-                    [DllImport("CppSharp.CppParser.dll", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.ThisCall,
-                        EntryPoint="?setName@LayoutField@AST@CppParser@CppSharp@@QAEXPBD@Z")]
-                    internal static extern void SetName(global::System.IntPtr instance, [MarshalAs(UnmanagedType.LPStr)] string s);
                 }
 
                 public global::System.IntPtr __Instance { get; protected set; }
@@ -3685,6 +3666,21 @@ namespace CppSharp
                     }
                 }
 
+                public string Name
+                {
+                    get
+                    {
+                        return global::Std.BasicString.__CreateInstance(((global::CppSharp.Parser.AST.LayoutField.__Internal*) __Instance)->name).CStr();
+                    }
+
+                    set
+                    {
+                        var __allocator0 = new global::Std.Allocator();
+                        var __basicString0 = new global::Std.BasicString(value, __allocator0);
+                        ((global::CppSharp.Parser.AST.LayoutField.__Internal*) __Instance)->name = *(global::Std.BasicString.__Internal*) __basicString0.__Instance;
+                    }
+                }
+
                 public global::CppSharp.Parser.AST.QualifiedType QualifiedType
                 {
                     get
@@ -3708,20 +3704,6 @@ namespace CppSharp
                     set
                     {
                         ((global::CppSharp.Parser.AST.LayoutField.__Internal*) __Instance)->fieldPtr = (global::System.IntPtr) value;
-                    }
-                }
-
-                public string Name
-                {
-                    get
-                    {
-                        var __ret = __Internal.GetName((__Instance + __PointerAdjustment));
-                        return Marshal.PtrToStringAnsi(__ret);
-                    }
-
-                    set
-                    {
-                        __Internal.SetName((__Instance + __PointerAdjustment), value);
                     }
                 }
             }
@@ -4251,13 +4233,13 @@ namespace CppSharp
                     internal int lineNumberEnd;
 
                     [FieldOffset(24)]
-                    internal global::Std.BasicString.__Internal Name;
+                    internal global::Std.BasicString.__Internal name;
 
                     [FieldOffset(48)]
                     internal global::Std.BasicString.__Internal USR;
 
                     [FieldOffset(72)]
-                    internal global::Std.BasicString.__Internal DebugText;
+                    internal global::Std.BasicString.__Internal debugText;
 
                     [FieldOffset(96)]
                     internal byte isIncomplete;
@@ -4330,36 +4312,6 @@ namespace CppSharp
                     [DllImport("CppSharp.CppParser.dll", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.ThisCall,
                         EntryPoint="?clearRedeclarations@Declaration@AST@CppParser@CppSharp@@QAEXXZ")]
                     internal static extern void ClearRedeclarations_0(global::System.IntPtr instance);
-
-                    [SuppressUnmanagedCodeSecurity]
-                    [DllImport("CppSharp.CppParser.dll", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.ThisCall,
-                        EntryPoint="?getName@Declaration@AST@CppParser@CppSharp@@QAEPBDXZ")]
-                    internal static extern global::System.IntPtr GetName(global::System.IntPtr instance);
-
-                    [SuppressUnmanagedCodeSecurity]
-                    [DllImport("CppSharp.CppParser.dll", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.ThisCall,
-                        EntryPoint="?setName@Declaration@AST@CppParser@CppSharp@@QAEXPBD@Z")]
-                    internal static extern void SetName(global::System.IntPtr instance, [MarshalAs(UnmanagedType.LPStr)] string s);
-
-                    [SuppressUnmanagedCodeSecurity]
-                    [DllImport("CppSharp.CppParser.dll", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.ThisCall,
-                        EntryPoint="?getUSR@Declaration@AST@CppParser@CppSharp@@QAEPBDXZ")]
-                    internal static extern global::System.IntPtr GetUSR(global::System.IntPtr instance);
-
-                    [SuppressUnmanagedCodeSecurity]
-                    [DllImport("CppSharp.CppParser.dll", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.ThisCall,
-                        EntryPoint="?setUSR@Declaration@AST@CppParser@CppSharp@@QAEXPBD@Z")]
-                    internal static extern void SetUSR(global::System.IntPtr instance, [MarshalAs(UnmanagedType.LPStr)] string s);
-
-                    [SuppressUnmanagedCodeSecurity]
-                    [DllImport("CppSharp.CppParser.dll", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.ThisCall,
-                        EntryPoint="?getDebugText@Declaration@AST@CppParser@CppSharp@@QAEPBDXZ")]
-                    internal static extern global::System.IntPtr GetDebugText(global::System.IntPtr instance);
-
-                    [SuppressUnmanagedCodeSecurity]
-                    [DllImport("CppSharp.CppParser.dll", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.ThisCall,
-                        EntryPoint="?setDebugText@Declaration@AST@CppParser@CppSharp@@QAEXPBD@Z")]
-                    internal static extern void SetDebugText(global::System.IntPtr instance, [MarshalAs(UnmanagedType.LPStr)] string s);
 
                     [SuppressUnmanagedCodeSecurity]
                     [DllImport("CppSharp.CppParser.dll", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.ThisCall,
@@ -4584,6 +4536,51 @@ namespace CppSharp
                     }
                 }
 
+                public string Name
+                {
+                    get
+                    {
+                        return global::Std.BasicString.__CreateInstance(((global::CppSharp.Parser.AST.Declaration.__Internal*) __Instance)->name).CStr();
+                    }
+
+                    set
+                    {
+                        var __allocator0 = new global::Std.Allocator();
+                        var __basicString0 = new global::Std.BasicString(value, __allocator0);
+                        ((global::CppSharp.Parser.AST.Declaration.__Internal*) __Instance)->name = *(global::Std.BasicString.__Internal*) __basicString0.__Instance;
+                    }
+                }
+
+                public string USR
+                {
+                    get
+                    {
+                        return global::Std.BasicString.__CreateInstance(((global::CppSharp.Parser.AST.Declaration.__Internal*) __Instance)->USR).CStr();
+                    }
+
+                    set
+                    {
+                        var __allocator0 = new global::Std.Allocator();
+                        var __basicString0 = new global::Std.BasicString(value, __allocator0);
+                        ((global::CppSharp.Parser.AST.Declaration.__Internal*) __Instance)->USR = *(global::Std.BasicString.__Internal*) __basicString0.__Instance;
+                    }
+                }
+
+                public string DebugText
+                {
+                    get
+                    {
+                        return global::Std.BasicString.__CreateInstance(((global::CppSharp.Parser.AST.Declaration.__Internal*) __Instance)->debugText).CStr();
+                    }
+
+                    set
+                    {
+                        var __allocator0 = new global::Std.Allocator();
+                        var __basicString0 = new global::Std.BasicString(value, __allocator0);
+                        ((global::CppSharp.Parser.AST.Declaration.__Internal*) __Instance)->debugText = *(global::Std.BasicString.__Internal*) __basicString0.__Instance;
+                    }
+                }
+
                 public bool IsIncomplete
                 {
                     get
@@ -4685,48 +4682,6 @@ namespace CppSharp
                     }
                 }
 
-                public string Name
-                {
-                    get
-                    {
-                        var __ret = __Internal.GetName((__Instance + __PointerAdjustment));
-                        return Marshal.PtrToStringAnsi(__ret);
-                    }
-
-                    set
-                    {
-                        __Internal.SetName((__Instance + __PointerAdjustment), value);
-                    }
-                }
-
-                public string USR
-                {
-                    get
-                    {
-                        var __ret = __Internal.GetUSR((__Instance + __PointerAdjustment));
-                        return Marshal.PtrToStringAnsi(__ret);
-                    }
-
-                    set
-                    {
-                        __Internal.SetUSR((__Instance + __PointerAdjustment), value);
-                    }
-                }
-
-                public string DebugText
-                {
-                    get
-                    {
-                        var __ret = __Internal.GetDebugText((__Instance + __PointerAdjustment));
-                        return Marshal.PtrToStringAnsi(__ret);
-                    }
-
-                    set
-                    {
-                        __Internal.SetDebugText((__Instance + __PointerAdjustment), value);
-                    }
-                }
-
                 public uint PreprocessedEntitiesCount
                 {
                     get
@@ -4770,13 +4725,13 @@ namespace CppSharp
                     internal int lineNumberEnd;
 
                     [FieldOffset(24)]
-                    internal global::Std.BasicString.__Internal Name;
+                    internal global::Std.BasicString.__Internal name;
 
                     [FieldOffset(48)]
                     internal global::Std.BasicString.__Internal USR;
 
                     [FieldOffset(72)]
-                    internal global::Std.BasicString.__Internal DebugText;
+                    internal global::Std.BasicString.__Internal debugText;
 
                     [FieldOffset(96)]
                     internal byte isIncomplete;
@@ -5441,13 +5396,13 @@ namespace CppSharp
                     internal int lineNumberEnd;
 
                     [FieldOffset(24)]
-                    internal global::Std.BasicString.__Internal Name;
+                    internal global::Std.BasicString.__Internal name;
 
                     [FieldOffset(48)]
                     internal global::Std.BasicString.__Internal USR;
 
                     [FieldOffset(72)]
-                    internal global::Std.BasicString.__Internal DebugText;
+                    internal global::Std.BasicString.__Internal debugText;
 
                     [FieldOffset(96)]
                     internal byte isIncomplete;
@@ -5605,13 +5560,13 @@ namespace CppSharp
                     internal int lineNumberEnd;
 
                     [FieldOffset(24)]
-                    internal global::Std.BasicString.__Internal Name;
+                    internal global::Std.BasicString.__Internal name;
 
                     [FieldOffset(48)]
                     internal global::Std.BasicString.__Internal USR;
 
                     [FieldOffset(72)]
-                    internal global::Std.BasicString.__Internal DebugText;
+                    internal global::Std.BasicString.__Internal debugText;
 
                     [FieldOffset(96)]
                     internal byte isIncomplete;
@@ -5751,13 +5706,13 @@ namespace CppSharp
                     internal int lineNumberEnd;
 
                     [FieldOffset(24)]
-                    internal global::Std.BasicString.__Internal Name;
+                    internal global::Std.BasicString.__Internal name;
 
                     [FieldOffset(48)]
                     internal global::Std.BasicString.__Internal USR;
 
                     [FieldOffset(72)]
-                    internal global::Std.BasicString.__Internal DebugText;
+                    internal global::Std.BasicString.__Internal debugText;
 
                     [FieldOffset(96)]
                     internal byte isIncomplete;
@@ -5918,13 +5873,13 @@ namespace CppSharp
                     internal int lineNumberEnd;
 
                     [FieldOffset(24)]
-                    internal global::Std.BasicString.__Internal Name;
+                    internal global::Std.BasicString.__Internal name;
 
                     [FieldOffset(48)]
                     internal global::Std.BasicString.__Internal USR;
 
                     [FieldOffset(72)]
-                    internal global::Std.BasicString.__Internal DebugText;
+                    internal global::Std.BasicString.__Internal debugText;
 
                     [FieldOffset(96)]
                     internal byte isIncomplete;
@@ -6070,27 +6025,22 @@ namespace CppSharp
                     internal global::System.IntPtr decl;
 
                     [FieldOffset(8)]
-                    internal global::Std.BasicString.__Internal String;
+                    internal global::Std.BasicString.__Internal @string;
+
+                    [SuppressUnmanagedCodeSecurity]
+                    [DllImport("CppSharp.CppParser.dll", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.ThisCall,
+                        EntryPoint="??0Statement@AST@CppParser@CppSharp@@QAE@ABV?$basic_string@DU?$char_traits@D@std@@V?$allocator@D@2@@std@@W4StatementClass@123@PAVDeclaration@123@@Z")]
+                    internal static extern global::System.IntPtr ctor_0(global::System.IntPtr instance, global::System.IntPtr str, global::CppSharp.Parser.AST.StatementClass Class, global::System.IntPtr decl);
 
                     [SuppressUnmanagedCodeSecurity]
                     [DllImport("CppSharp.CppParser.dll", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.ThisCall,
                         EntryPoint="??0Statement@AST@CppParser@CppSharp@@QAE@ABV0123@@Z")]
-                    internal static extern global::System.IntPtr cctor_0(global::System.IntPtr instance, global::System.IntPtr _0);
+                    internal static extern global::System.IntPtr cctor_1(global::System.IntPtr instance, global::System.IntPtr _0);
 
                     [SuppressUnmanagedCodeSecurity]
                     [DllImport("CppSharp.CppParser.dll", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.ThisCall,
                         EntryPoint="??1Statement@AST@CppParser@CppSharp@@QAE@XZ")]
                     internal static extern void dtor_0(global::System.IntPtr instance, int delete);
-
-                    [SuppressUnmanagedCodeSecurity]
-                    [DllImport("CppSharp.CppParser.dll", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.ThisCall,
-                        EntryPoint="?getString@Statement@AST@CppParser@CppSharp@@QAEPBDXZ")]
-                    internal static extern global::System.IntPtr GetString(global::System.IntPtr instance);
-
-                    [SuppressUnmanagedCodeSecurity]
-                    [DllImport("CppSharp.CppParser.dll", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.ThisCall,
-                        EntryPoint="?setString@Statement@AST@CppParser@CppSharp@@QAEXPBD@Z")]
-                    internal static extern void SetString(global::System.IntPtr instance, [MarshalAs(UnmanagedType.LPStr)] string s);
                 }
 
                 public global::System.IntPtr __Instance { get; protected set; }
@@ -6114,7 +6064,7 @@ namespace CppSharp
                 private static void* __CopyValue(global::CppSharp.Parser.AST.Statement.__Internal native)
                 {
                     var ret = Marshal.AllocHGlobal(sizeof(global::CppSharp.Parser.AST.Statement.__Internal));
-                    global::CppSharp.Parser.AST.Statement.__Internal.cctor_0(ret, new global::System.IntPtr(&native));
+                    global::CppSharp.Parser.AST.Statement.__Internal.cctor_1(ret, new global::System.IntPtr(&native));
                     return ret.ToPointer();
                 }
 
@@ -6132,6 +6082,20 @@ namespace CppSharp
                     __Instance = new global::System.IntPtr(native);
                 }
 
+                public Statement(string str, global::CppSharp.Parser.AST.StatementClass Class, global::CppSharp.Parser.AST.Declaration decl)
+                {
+                    __Instance = Marshal.AllocHGlobal(sizeof(global::CppSharp.Parser.AST.Statement.__Internal));
+                    __ownsNativeInstance = true;
+                    NativeToManagedMap[__Instance] = this;
+                    var __allocator0 = new global::Std.Allocator();
+                    var __basicString0 = new global::Std.BasicString(str, __allocator0);
+                    var __arg0 = __basicString0.__Instance;
+                    var __arg2 = ReferenceEquals(decl, null) ? global::System.IntPtr.Zero : decl.__Instance;
+                    __Internal.ctor_0((__Instance + __PointerAdjustment), __arg0, Class, __arg2);
+                    __basicString0.Dispose(false);
+                    __allocator0.Dispose();
+                }
+
                 public Statement(global::CppSharp.Parser.AST.Statement _0)
                 {
                     __Instance = Marshal.AllocHGlobal(sizeof(global::CppSharp.Parser.AST.Statement.__Internal));
@@ -6140,7 +6104,7 @@ namespace CppSharp
                     if (ReferenceEquals(_0, null))
                         throw new global::System.ArgumentNullException("_0", "Cannot be null because it is a C++ reference (&).");
                     var __arg0 = _0.__Instance;
-                    __Internal.cctor_0((__Instance + __PointerAdjustment), __arg0);
+                    __Internal.cctor_1((__Instance + __PointerAdjustment), __arg0);
                 }
 
                 public void Dispose()
@@ -6196,13 +6160,14 @@ namespace CppSharp
                 {
                     get
                     {
-                        var __ret = __Internal.GetString((__Instance + __PointerAdjustment));
-                        return Marshal.PtrToStringAnsi(__ret);
+                        return global::Std.BasicString.__CreateInstance(((global::CppSharp.Parser.AST.Statement.__Internal*) __Instance)->@string).CStr();
                     }
 
                     set
                     {
-                        __Internal.SetString((__Instance + __PointerAdjustment), value);
+                        var __allocator0 = new global::Std.Allocator();
+                        var __basicString0 = new global::Std.BasicString(value, __allocator0);
+                        ((global::CppSharp.Parser.AST.Statement.__Internal*) __Instance)->@string = *(global::Std.BasicString.__Internal*) __basicString0.__Instance;
                     }
                 }
             }
@@ -6219,12 +6184,17 @@ namespace CppSharp
                     internal global::System.IntPtr decl;
 
                     [FieldOffset(8)]
-                    internal global::Std.BasicString.__Internal String;
+                    internal global::Std.BasicString.__Internal @string;
+
+                    [SuppressUnmanagedCodeSecurity]
+                    [DllImport("CppSharp.CppParser.dll", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.ThisCall,
+                        EntryPoint="??0Expression@AST@CppParser@CppSharp@@QAE@ABV?$basic_string@DU?$char_traits@D@std@@V?$allocator@D@2@@std@@W4StatementClass@123@PAVDeclaration@123@@Z")]
+                    internal static extern global::System.IntPtr ctor_0(global::System.IntPtr instance, global::System.IntPtr str, global::CppSharp.Parser.AST.StatementClass Class, global::System.IntPtr decl);
 
                     [SuppressUnmanagedCodeSecurity]
                     [DllImport("CppSharp.CppParser.dll", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.ThisCall,
                         EntryPoint="??0Expression@AST@CppParser@CppSharp@@QAE@ABV0123@@Z")]
-                    internal static extern global::System.IntPtr cctor_0(global::System.IntPtr instance, global::System.IntPtr _0);
+                    internal static extern global::System.IntPtr cctor_1(global::System.IntPtr instance, global::System.IntPtr _0);
 
                     [SuppressUnmanagedCodeSecurity]
                     [DllImport("CppSharp.CppParser.dll", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.ThisCall,
@@ -6245,7 +6215,7 @@ namespace CppSharp
                 private static void* __CopyValue(global::CppSharp.Parser.AST.Expression.__Internal native)
                 {
                     var ret = Marshal.AllocHGlobal(sizeof(global::CppSharp.Parser.AST.Expression.__Internal));
-                    global::CppSharp.Parser.AST.Expression.__Internal.cctor_0(ret, new global::System.IntPtr(&native));
+                    global::CppSharp.Parser.AST.Expression.__Internal.cctor_1(ret, new global::System.IntPtr(&native));
                     return ret.ToPointer();
                 }
 
@@ -6265,6 +6235,21 @@ namespace CppSharp
                     __Instance = new global::System.IntPtr(native);
                 }
 
+                public Expression(string str, global::CppSharp.Parser.AST.StatementClass Class, global::CppSharp.Parser.AST.Declaration decl)
+                    : this((void*) null)
+                {
+                    __Instance = Marshal.AllocHGlobal(sizeof(global::CppSharp.Parser.AST.Expression.__Internal));
+                    __ownsNativeInstance = true;
+                    NativeToManagedMap[__Instance] = this;
+                    var __allocator0 = new global::Std.Allocator();
+                    var __basicString0 = new global::Std.BasicString(str, __allocator0);
+                    var __arg0 = __basicString0.__Instance;
+                    var __arg2 = ReferenceEquals(decl, null) ? global::System.IntPtr.Zero : decl.__Instance;
+                    __Internal.ctor_0((__Instance + __PointerAdjustment), __arg0, Class, __arg2);
+                    __basicString0.Dispose(false);
+                    __allocator0.Dispose();
+                }
+
                 public Expression(global::CppSharp.Parser.AST.Expression _0)
                     : this((void*) null)
                 {
@@ -6274,7 +6259,7 @@ namespace CppSharp
                     if (ReferenceEquals(_0, null))
                         throw new global::System.ArgumentNullException("_0", "Cannot be null because it is a C++ reference (&).");
                     var __arg0 = _0.__Instance;
-                    __Internal.cctor_0((__Instance + __PointerAdjustment), __arg0);
+                    __Internal.cctor_1((__Instance + __PointerAdjustment), __arg0);
                 }
 
                 public override void Dispose(bool disposing)
@@ -6303,7 +6288,7 @@ namespace CppSharp
                     internal global::System.IntPtr decl;
 
                     [FieldOffset(8)]
-                    internal global::Std.BasicString.__Internal String;
+                    internal global::Std.BasicString.__Internal @string;
 
                     [FieldOffset(32)]
                     internal global::System.IntPtr LHS;
@@ -6312,27 +6297,22 @@ namespace CppSharp
                     internal global::System.IntPtr RHS;
 
                     [FieldOffset(40)]
-                    internal global::Std.BasicString.__Internal OpcodeStr;
+                    internal global::Std.BasicString.__Internal opcodeStr;
+
+                    [SuppressUnmanagedCodeSecurity]
+                    [DllImport("CppSharp.CppParser.dll", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.ThisCall,
+                        EntryPoint="??0BinaryOperator@AST@CppParser@CppSharp@@QAE@ABV?$basic_string@DU?$char_traits@D@std@@V?$allocator@D@2@@std@@PAVExpression@123@10@Z")]
+                    internal static extern global::System.IntPtr ctor_0(global::System.IntPtr instance, global::System.IntPtr str, global::System.IntPtr lhs, global::System.IntPtr rhs, global::System.IntPtr opcodeStr);
 
                     [SuppressUnmanagedCodeSecurity]
                     [DllImport("CppSharp.CppParser.dll", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.ThisCall,
                         EntryPoint="??0BinaryOperator@AST@CppParser@CppSharp@@QAE@ABV0123@@Z")]
-                    internal static extern global::System.IntPtr cctor_0(global::System.IntPtr instance, global::System.IntPtr _0);
+                    internal static extern global::System.IntPtr cctor_1(global::System.IntPtr instance, global::System.IntPtr _0);
 
                     [SuppressUnmanagedCodeSecurity]
                     [DllImport("CppSharp.CppParser.dll", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.ThisCall,
                         EntryPoint="??1BinaryOperator@AST@CppParser@CppSharp@@QAE@XZ")]
                     internal static extern void dtor_0(global::System.IntPtr instance, int delete);
-
-                    [SuppressUnmanagedCodeSecurity]
-                    [DllImport("CppSharp.CppParser.dll", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.ThisCall,
-                        EntryPoint="?getOpcodeStr@BinaryOperator@AST@CppParser@CppSharp@@QAEPBDXZ")]
-                    internal static extern global::System.IntPtr GetOpcodeStr(global::System.IntPtr instance);
-
-                    [SuppressUnmanagedCodeSecurity]
-                    [DllImport("CppSharp.CppParser.dll", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.ThisCall,
-                        EntryPoint="?setOpcodeStr@BinaryOperator@AST@CppParser@CppSharp@@QAEXPBD@Z")]
-                    internal static extern void SetOpcodeStr(global::System.IntPtr instance, [MarshalAs(UnmanagedType.LPStr)] string s);
                 }
 
                 internal static new global::CppSharp.Parser.AST.BinaryOperator __CreateInstance(global::System.IntPtr native, bool skipVTables = false)
@@ -6348,7 +6328,7 @@ namespace CppSharp
                 private static void* __CopyValue(global::CppSharp.Parser.AST.BinaryOperator.__Internal native)
                 {
                     var ret = Marshal.AllocHGlobal(sizeof(global::CppSharp.Parser.AST.BinaryOperator.__Internal));
-                    global::CppSharp.Parser.AST.BinaryOperator.__Internal.cctor_0(ret, new global::System.IntPtr(&native));
+                    global::CppSharp.Parser.AST.BinaryOperator.__Internal.cctor_1(ret, new global::System.IntPtr(&native));
                     return ret.ToPointer();
                 }
 
@@ -6368,6 +6348,27 @@ namespace CppSharp
                     __Instance = new global::System.IntPtr(native);
                 }
 
+                public BinaryOperator(string str, global::CppSharp.Parser.AST.Expression lhs, global::CppSharp.Parser.AST.Expression rhs, string opcodeStr)
+                    : this((void*) null)
+                {
+                    __Instance = Marshal.AllocHGlobal(sizeof(global::CppSharp.Parser.AST.BinaryOperator.__Internal));
+                    __ownsNativeInstance = true;
+                    NativeToManagedMap[__Instance] = this;
+                    var __allocator0 = new global::Std.Allocator();
+                    var __basicString0 = new global::Std.BasicString(str, __allocator0);
+                    var __arg0 = __basicString0.__Instance;
+                    var __arg1 = ReferenceEquals(lhs, null) ? global::System.IntPtr.Zero : lhs.__Instance;
+                    var __arg2 = ReferenceEquals(rhs, null) ? global::System.IntPtr.Zero : rhs.__Instance;
+                    var __allocator3 = new global::Std.Allocator();
+                    var __basicString3 = new global::Std.BasicString(opcodeStr, __allocator3);
+                    var __arg3 = __basicString3.__Instance;
+                    __Internal.ctor_0((__Instance + __PointerAdjustment), __arg0, __arg1, __arg2, __arg3);
+                    __basicString0.Dispose(false);
+                    __allocator0.Dispose();
+                    __basicString3.Dispose(false);
+                    __allocator3.Dispose();
+                }
+
                 public BinaryOperator(global::CppSharp.Parser.AST.BinaryOperator _0)
                     : this((void*) null)
                 {
@@ -6377,7 +6378,7 @@ namespace CppSharp
                     if (ReferenceEquals(_0, null))
                         throw new global::System.ArgumentNullException("_0", "Cannot be null because it is a C++ reference (&).");
                     var __arg0 = _0.__Instance;
-                    __Internal.cctor_0((__Instance + __PointerAdjustment), __arg0);
+                    __Internal.cctor_1((__Instance + __PointerAdjustment), __arg0);
                 }
 
                 public override void Dispose(bool disposing)
@@ -6433,13 +6434,14 @@ namespace CppSharp
                 {
                     get
                     {
-                        var __ret = __Internal.GetOpcodeStr((__Instance + __PointerAdjustment));
-                        return Marshal.PtrToStringAnsi(__ret);
+                        return global::Std.BasicString.__CreateInstance(((global::CppSharp.Parser.AST.BinaryOperator.__Internal*) __Instance)->opcodeStr).CStr();
                     }
 
                     set
                     {
-                        __Internal.SetOpcodeStr((__Instance + __PointerAdjustment), value);
+                        var __allocator0 = new global::Std.Allocator();
+                        var __basicString0 = new global::Std.BasicString(value, __allocator0);
+                        ((global::CppSharp.Parser.AST.BinaryOperator.__Internal*) __Instance)->opcodeStr = *(global::Std.BasicString.__Internal*) __basicString0.__Instance;
                     }
                 }
             }
@@ -6456,15 +6458,20 @@ namespace CppSharp
                     internal global::System.IntPtr decl;
 
                     [FieldOffset(8)]
-                    internal global::Std.BasicString.__Internal String;
+                    internal global::Std.BasicString.__Internal @string;
 
                     [FieldOffset(32)]
                     internal global::Std.Vector.__Internal Arguments;
 
                     [SuppressUnmanagedCodeSecurity]
                     [DllImport("CppSharp.CppParser.dll", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.ThisCall,
+                        EntryPoint="??0CallExpr@AST@CppParser@CppSharp@@QAE@ABV?$basic_string@DU?$char_traits@D@std@@V?$allocator@D@2@@std@@PAVDeclaration@123@@Z")]
+                    internal static extern global::System.IntPtr ctor_0(global::System.IntPtr instance, global::System.IntPtr str, global::System.IntPtr decl);
+
+                    [SuppressUnmanagedCodeSecurity]
+                    [DllImport("CppSharp.CppParser.dll", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.ThisCall,
                         EntryPoint="??0CallExpr@AST@CppParser@CppSharp@@QAE@ABV0123@@Z")]
-                    internal static extern global::System.IntPtr cctor_0(global::System.IntPtr instance, global::System.IntPtr _0);
+                    internal static extern global::System.IntPtr cctor_1(global::System.IntPtr instance, global::System.IntPtr _0);
 
                     [SuppressUnmanagedCodeSecurity]
                     [DllImport("CppSharp.CppParser.dll", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.ThisCall,
@@ -6505,7 +6512,7 @@ namespace CppSharp
                 private static void* __CopyValue(global::CppSharp.Parser.AST.CallExpr.__Internal native)
                 {
                     var ret = Marshal.AllocHGlobal(sizeof(global::CppSharp.Parser.AST.CallExpr.__Internal));
-                    global::CppSharp.Parser.AST.CallExpr.__Internal.cctor_0(ret, new global::System.IntPtr(&native));
+                    global::CppSharp.Parser.AST.CallExpr.__Internal.cctor_1(ret, new global::System.IntPtr(&native));
                     return ret.ToPointer();
                 }
 
@@ -6525,6 +6532,21 @@ namespace CppSharp
                     __Instance = new global::System.IntPtr(native);
                 }
 
+                public CallExpr(string str, global::CppSharp.Parser.AST.Declaration decl)
+                    : this((void*) null)
+                {
+                    __Instance = Marshal.AllocHGlobal(sizeof(global::CppSharp.Parser.AST.CallExpr.__Internal));
+                    __ownsNativeInstance = true;
+                    NativeToManagedMap[__Instance] = this;
+                    var __allocator0 = new global::Std.Allocator();
+                    var __basicString0 = new global::Std.BasicString(str, __allocator0);
+                    var __arg0 = __basicString0.__Instance;
+                    var __arg1 = ReferenceEquals(decl, null) ? global::System.IntPtr.Zero : decl.__Instance;
+                    __Internal.ctor_0((__Instance + __PointerAdjustment), __arg0, __arg1);
+                    __basicString0.Dispose(false);
+                    __allocator0.Dispose();
+                }
+
                 public CallExpr(global::CppSharp.Parser.AST.CallExpr _0)
                     : this((void*) null)
                 {
@@ -6534,7 +6556,7 @@ namespace CppSharp
                     if (ReferenceEquals(_0, null))
                         throw new global::System.ArgumentNullException("_0", "Cannot be null because it is a C++ reference (&).");
                     var __arg0 = _0.__Instance;
-                    __Internal.cctor_0((__Instance + __PointerAdjustment), __arg0);
+                    __Internal.cctor_1((__Instance + __PointerAdjustment), __arg0);
                 }
 
                 public override void Dispose(bool disposing)
@@ -6596,15 +6618,20 @@ namespace CppSharp
                     internal global::System.IntPtr decl;
 
                     [FieldOffset(8)]
-                    internal global::Std.BasicString.__Internal String;
+                    internal global::Std.BasicString.__Internal @string;
 
                     [FieldOffset(32)]
                     internal global::Std.Vector.__Internal Arguments;
 
                     [SuppressUnmanagedCodeSecurity]
                     [DllImport("CppSharp.CppParser.dll", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.ThisCall,
+                        EntryPoint="??0CXXConstructExpr@AST@CppParser@CppSharp@@QAE@ABV?$basic_string@DU?$char_traits@D@std@@V?$allocator@D@2@@std@@PAVDeclaration@123@@Z")]
+                    internal static extern global::System.IntPtr ctor_0(global::System.IntPtr instance, global::System.IntPtr str, global::System.IntPtr decl);
+
+                    [SuppressUnmanagedCodeSecurity]
+                    [DllImport("CppSharp.CppParser.dll", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.ThisCall,
                         EntryPoint="??0CXXConstructExpr@AST@CppParser@CppSharp@@QAE@ABV0123@@Z")]
-                    internal static extern global::System.IntPtr cctor_0(global::System.IntPtr instance, global::System.IntPtr _0);
+                    internal static extern global::System.IntPtr cctor_1(global::System.IntPtr instance, global::System.IntPtr _0);
 
                     [SuppressUnmanagedCodeSecurity]
                     [DllImport("CppSharp.CppParser.dll", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.ThisCall,
@@ -6645,7 +6672,7 @@ namespace CppSharp
                 private static void* __CopyValue(global::CppSharp.Parser.AST.CXXConstructExpr.__Internal native)
                 {
                     var ret = Marshal.AllocHGlobal(sizeof(global::CppSharp.Parser.AST.CXXConstructExpr.__Internal));
-                    global::CppSharp.Parser.AST.CXXConstructExpr.__Internal.cctor_0(ret, new global::System.IntPtr(&native));
+                    global::CppSharp.Parser.AST.CXXConstructExpr.__Internal.cctor_1(ret, new global::System.IntPtr(&native));
                     return ret.ToPointer();
                 }
 
@@ -6665,6 +6692,21 @@ namespace CppSharp
                     __Instance = new global::System.IntPtr(native);
                 }
 
+                public CXXConstructExpr(string str, global::CppSharp.Parser.AST.Declaration decl)
+                    : this((void*) null)
+                {
+                    __Instance = Marshal.AllocHGlobal(sizeof(global::CppSharp.Parser.AST.CXXConstructExpr.__Internal));
+                    __ownsNativeInstance = true;
+                    NativeToManagedMap[__Instance] = this;
+                    var __allocator0 = new global::Std.Allocator();
+                    var __basicString0 = new global::Std.BasicString(str, __allocator0);
+                    var __arg0 = __basicString0.__Instance;
+                    var __arg1 = ReferenceEquals(decl, null) ? global::System.IntPtr.Zero : decl.__Instance;
+                    __Internal.ctor_0((__Instance + __PointerAdjustment), __arg0, __arg1);
+                    __basicString0.Dispose(false);
+                    __allocator0.Dispose();
+                }
+
                 public CXXConstructExpr(global::CppSharp.Parser.AST.CXXConstructExpr _0)
                     : this((void*) null)
                 {
@@ -6674,7 +6716,7 @@ namespace CppSharp
                     if (ReferenceEquals(_0, null))
                         throw new global::System.ArgumentNullException("_0", "Cannot be null because it is a C++ reference (&).");
                     var __arg0 = _0.__Instance;
-                    __Internal.cctor_0((__Instance + __PointerAdjustment), __arg0);
+                    __Internal.cctor_1((__Instance + __PointerAdjustment), __arg0);
                 }
 
                 public override void Dispose(bool disposing)
@@ -6748,13 +6790,13 @@ namespace CppSharp
                     internal int lineNumberEnd;
 
                     [FieldOffset(24)]
-                    internal global::Std.BasicString.__Internal Name;
+                    internal global::Std.BasicString.__Internal name;
 
                     [FieldOffset(48)]
                     internal global::Std.BasicString.__Internal USR;
 
                     [FieldOffset(72)]
-                    internal global::Std.BasicString.__Internal DebugText;
+                    internal global::Std.BasicString.__Internal debugText;
 
                     [FieldOffset(96)]
                     internal byte isIncomplete;
@@ -6976,13 +7018,13 @@ namespace CppSharp
                     internal int lineNumberEnd;
 
                     [FieldOffset(24)]
-                    internal global::Std.BasicString.__Internal Name;
+                    internal global::Std.BasicString.__Internal name;
 
                     [FieldOffset(48)]
                     internal global::Std.BasicString.__Internal USR;
 
                     [FieldOffset(72)]
-                    internal global::Std.BasicString.__Internal DebugText;
+                    internal global::Std.BasicString.__Internal debugText;
 
                     [FieldOffset(96)]
                     internal byte isIncomplete;
@@ -7042,13 +7084,13 @@ namespace CppSharp
                     internal global::CppSharp.Parser.AST.CXXOperatorKind operatorKind;
 
                     [FieldOffset(164)]
-                    internal global::Std.BasicString.__Internal Mangled;
+                    internal global::Std.BasicString.__Internal mangled;
 
                     [FieldOffset(188)]
-                    internal global::Std.BasicString.__Internal Signature;
+                    internal global::Std.BasicString.__Internal signature;
 
                     [FieldOffset(212)]
-                    internal global::Std.BasicString.__Internal Body;
+                    internal global::Std.BasicString.__Internal body;
 
                     [FieldOffset(236)]
                     internal global::CppSharp.Parser.AST.CallingConvention callingConvention;
@@ -7094,36 +7136,6 @@ namespace CppSharp
                     [DllImport("CppSharp.CppParser.dll", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.ThisCall,
                         EntryPoint="?clearParameters@Function@AST@CppParser@CppSharp@@QAEXXZ")]
                     internal static extern void ClearParameters_0(global::System.IntPtr instance);
-
-                    [SuppressUnmanagedCodeSecurity]
-                    [DllImport("CppSharp.CppParser.dll", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.ThisCall,
-                        EntryPoint="?getMangled@Function@AST@CppParser@CppSharp@@QAEPBDXZ")]
-                    internal static extern global::System.IntPtr GetMangled(global::System.IntPtr instance);
-
-                    [SuppressUnmanagedCodeSecurity]
-                    [DllImport("CppSharp.CppParser.dll", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.ThisCall,
-                        EntryPoint="?setMangled@Function@AST@CppParser@CppSharp@@QAEXPBD@Z")]
-                    internal static extern void SetMangled(global::System.IntPtr instance, [MarshalAs(UnmanagedType.LPStr)] string s);
-
-                    [SuppressUnmanagedCodeSecurity]
-                    [DllImport("CppSharp.CppParser.dll", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.ThisCall,
-                        EntryPoint="?getSignature@Function@AST@CppParser@CppSharp@@QAEPBDXZ")]
-                    internal static extern global::System.IntPtr GetSignature(global::System.IntPtr instance);
-
-                    [SuppressUnmanagedCodeSecurity]
-                    [DllImport("CppSharp.CppParser.dll", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.ThisCall,
-                        EntryPoint="?setSignature@Function@AST@CppParser@CppSharp@@QAEXPBD@Z")]
-                    internal static extern void SetSignature(global::System.IntPtr instance, [MarshalAs(UnmanagedType.LPStr)] string s);
-
-                    [SuppressUnmanagedCodeSecurity]
-                    [DllImport("CppSharp.CppParser.dll", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.ThisCall,
-                        EntryPoint="?getBody@Function@AST@CppParser@CppSharp@@QAEPBDXZ")]
-                    internal static extern global::System.IntPtr GetBody(global::System.IntPtr instance);
-
-                    [SuppressUnmanagedCodeSecurity]
-                    [DllImport("CppSharp.CppParser.dll", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.ThisCall,
-                        EntryPoint="?setBody@Function@AST@CppParser@CppSharp@@QAEXPBD@Z")]
-                    internal static extern void SetBody(global::System.IntPtr instance, [MarshalAs(UnmanagedType.LPStr)] string s);
 
                     [SuppressUnmanagedCodeSecurity]
                     [DllImport("CppSharp.CppParser.dll", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.ThisCall,
@@ -7352,6 +7364,51 @@ namespace CppSharp
                     }
                 }
 
+                public string Mangled
+                {
+                    get
+                    {
+                        return global::Std.BasicString.__CreateInstance(((global::CppSharp.Parser.AST.Function.__Internal*) __Instance)->mangled).CStr();
+                    }
+
+                    set
+                    {
+                        var __allocator0 = new global::Std.Allocator();
+                        var __basicString0 = new global::Std.BasicString(value, __allocator0);
+                        ((global::CppSharp.Parser.AST.Function.__Internal*) __Instance)->mangled = *(global::Std.BasicString.__Internal*) __basicString0.__Instance;
+                    }
+                }
+
+                public string Signature
+                {
+                    get
+                    {
+                        return global::Std.BasicString.__CreateInstance(((global::CppSharp.Parser.AST.Function.__Internal*) __Instance)->signature).CStr();
+                    }
+
+                    set
+                    {
+                        var __allocator0 = new global::Std.Allocator();
+                        var __basicString0 = new global::Std.BasicString(value, __allocator0);
+                        ((global::CppSharp.Parser.AST.Function.__Internal*) __Instance)->signature = *(global::Std.BasicString.__Internal*) __basicString0.__Instance;
+                    }
+                }
+
+                public string Body
+                {
+                    get
+                    {
+                        return global::Std.BasicString.__CreateInstance(((global::CppSharp.Parser.AST.Function.__Internal*) __Instance)->body).CStr();
+                    }
+
+                    set
+                    {
+                        var __allocator0 = new global::Std.Allocator();
+                        var __basicString0 = new global::Std.BasicString(value, __allocator0);
+                        ((global::CppSharp.Parser.AST.Function.__Internal*) __Instance)->body = *(global::Std.BasicString.__Internal*) __basicString0.__Instance;
+                    }
+                }
+
                 public global::CppSharp.Parser.AST.CallingConvention CallingConvention
                 {
                     get
@@ -7414,48 +7471,6 @@ namespace CppSharp
                     }
                 }
 
-                public string Mangled
-                {
-                    get
-                    {
-                        var __ret = __Internal.GetMangled((__Instance + __PointerAdjustment));
-                        return Marshal.PtrToStringAnsi(__ret);
-                    }
-
-                    set
-                    {
-                        __Internal.SetMangled((__Instance + __PointerAdjustment), value);
-                    }
-                }
-
-                public string Signature
-                {
-                    get
-                    {
-                        var __ret = __Internal.GetSignature((__Instance + __PointerAdjustment));
-                        return Marshal.PtrToStringAnsi(__ret);
-                    }
-
-                    set
-                    {
-                        __Internal.SetSignature((__Instance + __PointerAdjustment), value);
-                    }
-                }
-
-                public string Body
-                {
-                    get
-                    {
-                        var __ret = __Internal.GetBody((__Instance + __PointerAdjustment));
-                        return Marshal.PtrToStringAnsi(__ret);
-                    }
-
-                    set
-                    {
-                        __Internal.SetBody((__Instance + __PointerAdjustment), value);
-                    }
-                }
-
                 public uint ParametersCount
                 {
                     get
@@ -7490,13 +7505,13 @@ namespace CppSharp
                     internal int lineNumberEnd;
 
                     [FieldOffset(24)]
-                    internal global::Std.BasicString.__Internal Name;
+                    internal global::Std.BasicString.__Internal name;
 
                     [FieldOffset(48)]
                     internal global::Std.BasicString.__Internal USR;
 
                     [FieldOffset(72)]
-                    internal global::Std.BasicString.__Internal DebugText;
+                    internal global::Std.BasicString.__Internal debugText;
 
                     [FieldOffset(96)]
                     internal byte isIncomplete;
@@ -7556,13 +7571,13 @@ namespace CppSharp
                     internal global::CppSharp.Parser.AST.CXXOperatorKind operatorKind;
 
                     [FieldOffset(164)]
-                    internal global::Std.BasicString.__Internal Mangled;
+                    internal global::Std.BasicString.__Internal mangled;
 
                     [FieldOffset(188)]
-                    internal global::Std.BasicString.__Internal Signature;
+                    internal global::Std.BasicString.__Internal signature;
 
                     [FieldOffset(212)]
-                    internal global::Std.BasicString.__Internal Body;
+                    internal global::Std.BasicString.__Internal body;
 
                     [FieldOffset(236)]
                     internal global::CppSharp.Parser.AST.CallingConvention callingConvention;
@@ -7863,13 +7878,13 @@ namespace CppSharp
                     internal int lineNumberEnd;
 
                     [FieldOffset(24)]
-                    internal global::Std.BasicString.__Internal Name;
+                    internal global::Std.BasicString.__Internal name;
 
                     [FieldOffset(48)]
                     internal global::Std.BasicString.__Internal USR;
 
                     [FieldOffset(72)]
-                    internal global::Std.BasicString.__Internal DebugText;
+                    internal global::Std.BasicString.__Internal debugText;
 
                     [FieldOffset(96)]
                     internal byte isIncomplete;
@@ -7975,6 +7990,11 @@ namespace CppSharp
 
                     [SuppressUnmanagedCodeSecurity]
                     [DllImport("CppSharp.CppParser.dll", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.ThisCall,
+                        EntryPoint="?FindItemByName@Enumeration@AST@CppParser@CppSharp@@QAEPAVItem@1234@ABV?$basic_string@DU?$char_traits@D@std@@V?$allocator@D@2@@std@@@Z")]
+                    internal static extern global::System.IntPtr FindItemByName_0(global::System.IntPtr instance, global::System.IntPtr Name);
+
+                    [SuppressUnmanagedCodeSecurity]
+                    [DllImport("CppSharp.CppParser.dll", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.ThisCall,
                         EntryPoint="?getItemsCount@Enumeration@AST@CppParser@CppSharp@@QAEIXZ")]
                     internal static extern uint GetItemsCount(global::System.IntPtr instance);
                 }
@@ -8011,13 +8031,13 @@ namespace CppSharp
                         internal int lineNumberEnd;
 
                         [FieldOffset(24)]
-                        internal global::Std.BasicString.__Internal Name;
+                        internal global::Std.BasicString.__Internal name;
 
                         [FieldOffset(48)]
                         internal global::Std.BasicString.__Internal USR;
 
                         [FieldOffset(72)]
-                        internal global::Std.BasicString.__Internal DebugText;
+                        internal global::Std.BasicString.__Internal debugText;
 
                         [FieldOffset(96)]
                         internal byte isIncomplete;
@@ -8047,7 +8067,7 @@ namespace CppSharp
                         internal global::System.IntPtr comment;
 
                         [FieldOffset(140)]
-                        internal global::Std.BasicString.__Internal Expression;
+                        internal global::Std.BasicString.__Internal expression;
 
                         [FieldOffset(168)]
                         internal ulong value;
@@ -8066,16 +8086,6 @@ namespace CppSharp
                         [DllImport("CppSharp.CppParser.dll", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.ThisCall,
                             EntryPoint="??1Item@Enumeration@AST@CppParser@CppSharp@@QAE@XZ")]
                         internal static extern void dtor_0(global::System.IntPtr instance, int delete);
-
-                        [SuppressUnmanagedCodeSecurity]
-                        [DllImport("CppSharp.CppParser.dll", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.ThisCall,
-                            EntryPoint="?getExpression@Item@Enumeration@AST@CppParser@CppSharp@@QAEPBDXZ")]
-                        internal static extern global::System.IntPtr GetExpression(global::System.IntPtr instance);
-
-                        [SuppressUnmanagedCodeSecurity]
-                        [DllImport("CppSharp.CppParser.dll", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.ThisCall,
-                            EntryPoint="?setExpression@Item@Enumeration@AST@CppParser@CppSharp@@QAEXPBD@Z")]
-                        internal static extern void SetExpression(global::System.IntPtr instance, [MarshalAs(UnmanagedType.LPStr)] string s);
                     }
 
                     internal static new global::CppSharp.Parser.AST.Enumeration.Item __CreateInstance(global::System.IntPtr native, bool skipVTables = false)
@@ -8145,6 +8155,21 @@ namespace CppSharp
                         __Instance = IntPtr.Zero;
                     }
 
+                    public string Expression
+                    {
+                        get
+                        {
+                            return global::Std.BasicString.__CreateInstance(((global::CppSharp.Parser.AST.Enumeration.Item.__Internal*) __Instance)->expression).CStr();
+                        }
+
+                        set
+                        {
+                            var __allocator0 = new global::Std.Allocator();
+                            var __basicString0 = new global::Std.BasicString(value, __allocator0);
+                            ((global::CppSharp.Parser.AST.Enumeration.Item.__Internal*) __Instance)->expression = *(global::Std.BasicString.__Internal*) __basicString0.__Instance;
+                        }
+                    }
+
                     public ulong Value
                     {
                         get
@@ -8155,20 +8180,6 @@ namespace CppSharp
                         set
                         {
                             ((global::CppSharp.Parser.AST.Enumeration.Item.__Internal*) __Instance)->value = value;
-                        }
-                    }
-
-                    public string Expression
-                    {
-                        get
-                        {
-                            var __ret = __Internal.GetExpression((__Instance + __PointerAdjustment));
-                            return Marshal.PtrToStringAnsi(__ret);
-                        }
-
-                        set
-                        {
-                            __Internal.SetExpression((__Instance + __PointerAdjustment), value);
                         }
                     }
                 }
@@ -8264,6 +8275,22 @@ namespace CppSharp
                     __Internal.ClearItems_0((__Instance + __PointerAdjustment));
                 }
 
+                public global::CppSharp.Parser.AST.Enumeration.Item FindItemByName(string Name)
+                {
+                    var __allocator0 = new global::Std.Allocator();
+                    var __basicString0 = new global::Std.BasicString(Name, __allocator0);
+                    var __arg0 = __basicString0.__Instance;
+                    var __ret = __Internal.FindItemByName_0((__Instance + __PointerAdjustment), __arg0);
+                    __basicString0.Dispose(false);
+                    __allocator0.Dispose();
+                    global::CppSharp.Parser.AST.Enumeration.Item __result0;
+                    if (__ret == IntPtr.Zero) __result0 = null;
+                    else if (global::CppSharp.Parser.AST.Enumeration.Item.NativeToManagedMap.ContainsKey(__ret))
+                        __result0 = (global::CppSharp.Parser.AST.Enumeration.Item) global::CppSharp.Parser.AST.Enumeration.Item.NativeToManagedMap[__ret];
+                    else __result0 = global::CppSharp.Parser.AST.Enumeration.Item.__CreateInstance(__ret);
+                    return __result0;
+                }
+
                 public global::CppSharp.Parser.AST.Enumeration.EnumModifiers Modifiers
                 {
                     get
@@ -8347,13 +8374,13 @@ namespace CppSharp
                     internal int lineNumberEnd;
 
                     [FieldOffset(24)]
-                    internal global::Std.BasicString.__Internal Name;
+                    internal global::Std.BasicString.__Internal name;
 
                     [FieldOffset(48)]
                     internal global::Std.BasicString.__Internal USR;
 
                     [FieldOffset(72)]
-                    internal global::Std.BasicString.__Internal DebugText;
+                    internal global::Std.BasicString.__Internal debugText;
 
                     [FieldOffset(96)]
                     internal byte isIncomplete;
@@ -8383,7 +8410,7 @@ namespace CppSharp
                     internal global::System.IntPtr comment;
 
                     [FieldOffset(140)]
-                    internal global::Std.BasicString.__Internal Mangled;
+                    internal global::Std.BasicString.__Internal mangled;
 
                     [FieldOffset(164)]
                     internal global::CppSharp.Parser.AST.QualifiedType.__Internal qualifiedType;
@@ -8402,16 +8429,6 @@ namespace CppSharp
                     [DllImport("CppSharp.CppParser.dll", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.ThisCall,
                         EntryPoint="??1Variable@AST@CppParser@CppSharp@@QAE@XZ")]
                     internal static extern void dtor_0(global::System.IntPtr instance, int delete);
-
-                    [SuppressUnmanagedCodeSecurity]
-                    [DllImport("CppSharp.CppParser.dll", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.ThisCall,
-                        EntryPoint="?getMangled@Variable@AST@CppParser@CppSharp@@QAEPBDXZ")]
-                    internal static extern global::System.IntPtr GetMangled(global::System.IntPtr instance);
-
-                    [SuppressUnmanagedCodeSecurity]
-                    [DllImport("CppSharp.CppParser.dll", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.ThisCall,
-                        EntryPoint="?setMangled@Variable@AST@CppParser@CppSharp@@QAEXPBD@Z")]
-                    internal static extern void SetMangled(global::System.IntPtr instance, [MarshalAs(UnmanagedType.LPStr)] string s);
                 }
 
                 internal static new global::CppSharp.Parser.AST.Variable __CreateInstance(global::System.IntPtr native, bool skipVTables = false)
@@ -8481,6 +8498,21 @@ namespace CppSharp
                     __Instance = IntPtr.Zero;
                 }
 
+                public string Mangled
+                {
+                    get
+                    {
+                        return global::Std.BasicString.__CreateInstance(((global::CppSharp.Parser.AST.Variable.__Internal*) __Instance)->mangled).CStr();
+                    }
+
+                    set
+                    {
+                        var __allocator0 = new global::Std.Allocator();
+                        var __basicString0 = new global::Std.BasicString(value, __allocator0);
+                        ((global::CppSharp.Parser.AST.Variable.__Internal*) __Instance)->mangled = *(global::Std.BasicString.__Internal*) __basicString0.__Instance;
+                    }
+                }
+
                 public global::CppSharp.Parser.AST.QualifiedType QualifiedType
                 {
                     get
@@ -8491,20 +8523,6 @@ namespace CppSharp
                     set
                     {
                         ((global::CppSharp.Parser.AST.Variable.__Internal*) __Instance)->qualifiedType = ReferenceEquals(value, null) ? new global::CppSharp.Parser.AST.QualifiedType.__Internal() : *(global::CppSharp.Parser.AST.QualifiedType.__Internal*) value.__Instance;
-                    }
-                }
-
-                public string Mangled
-                {
-                    get
-                    {
-                        var __ret = __Internal.GetMangled((__Instance + __PointerAdjustment));
-                        return Marshal.PtrToStringAnsi(__ret);
-                    }
-
-                    set
-                    {
-                        __Internal.SetMangled((__Instance + __PointerAdjustment), value);
                     }
                 }
             }
@@ -8690,13 +8708,13 @@ namespace CppSharp
                     internal int lineNumberEnd;
 
                     [FieldOffset(24)]
-                    internal global::Std.BasicString.__Internal Name;
+                    internal global::Std.BasicString.__Internal name;
 
                     [FieldOffset(48)]
                     internal global::Std.BasicString.__Internal USR;
 
                     [FieldOffset(72)]
-                    internal global::Std.BasicString.__Internal DebugText;
+                    internal global::Std.BasicString.__Internal debugText;
 
                     [FieldOffset(96)]
                     internal byte isIncomplete;
@@ -8902,13 +8920,13 @@ namespace CppSharp
                     internal int lineNumberEnd;
 
                     [FieldOffset(24)]
-                    internal global::Std.BasicString.__Internal Name;
+                    internal global::Std.BasicString.__Internal name;
 
                     [FieldOffset(48)]
                     internal global::Std.BasicString.__Internal USR;
 
                     [FieldOffset(72)]
-                    internal global::Std.BasicString.__Internal DebugText;
+                    internal global::Std.BasicString.__Internal debugText;
 
                     [FieldOffset(96)]
                     internal byte isIncomplete;
@@ -9045,13 +9063,13 @@ namespace CppSharp
                     internal int lineNumberEnd;
 
                     [FieldOffset(24)]
-                    internal global::Std.BasicString.__Internal Name;
+                    internal global::Std.BasicString.__Internal name;
 
                     [FieldOffset(48)]
                     internal global::Std.BasicString.__Internal USR;
 
                     [FieldOffset(72)]
-                    internal global::Std.BasicString.__Internal DebugText;
+                    internal global::Std.BasicString.__Internal debugText;
 
                     [FieldOffset(96)]
                     internal byte isIncomplete;
@@ -9626,13 +9644,13 @@ namespace CppSharp
                     internal int lineNumberEnd;
 
                     [FieldOffset(24)]
-                    internal global::Std.BasicString.__Internal Name;
+                    internal global::Std.BasicString.__Internal name;
 
                     [FieldOffset(48)]
                     internal global::Std.BasicString.__Internal USR;
 
                     [FieldOffset(72)]
-                    internal global::Std.BasicString.__Internal DebugText;
+                    internal global::Std.BasicString.__Internal debugText;
 
                     [FieldOffset(96)]
                     internal byte isIncomplete;
@@ -9865,13 +9883,13 @@ namespace CppSharp
                     internal int lineNumberEnd;
 
                     [FieldOffset(24)]
-                    internal global::Std.BasicString.__Internal Name;
+                    internal global::Std.BasicString.__Internal name;
 
                     [FieldOffset(48)]
                     internal global::Std.BasicString.__Internal USR;
 
                     [FieldOffset(72)]
-                    internal global::Std.BasicString.__Internal DebugText;
+                    internal global::Std.BasicString.__Internal debugText;
 
                     [FieldOffset(96)]
                     internal byte isIncomplete;
@@ -10014,13 +10032,13 @@ namespace CppSharp
                     internal int lineNumberEnd;
 
                     [FieldOffset(24)]
-                    internal global::Std.BasicString.__Internal Name;
+                    internal global::Std.BasicString.__Internal name;
 
                     [FieldOffset(48)]
                     internal global::Std.BasicString.__Internal USR;
 
                     [FieldOffset(72)]
-                    internal global::Std.BasicString.__Internal DebugText;
+                    internal global::Std.BasicString.__Internal debugText;
 
                     [FieldOffset(96)]
                     internal byte isIncomplete;
@@ -10210,13 +10228,13 @@ namespace CppSharp
                     internal int lineNumberEnd;
 
                     [FieldOffset(24)]
-                    internal global::Std.BasicString.__Internal Name;
+                    internal global::Std.BasicString.__Internal name;
 
                     [FieldOffset(48)]
                     internal global::Std.BasicString.__Internal USR;
 
                     [FieldOffset(72)]
-                    internal global::Std.BasicString.__Internal DebugText;
+                    internal global::Std.BasicString.__Internal debugText;
 
                     [FieldOffset(96)]
                     internal byte isIncomplete;
@@ -10407,13 +10425,13 @@ namespace CppSharp
                     internal int lineNumberEnd;
 
                     [FieldOffset(24)]
-                    internal global::Std.BasicString.__Internal Name;
+                    internal global::Std.BasicString.__Internal name;
 
                     [FieldOffset(48)]
                     internal global::Std.BasicString.__Internal USR;
 
                     [FieldOffset(72)]
-                    internal global::Std.BasicString.__Internal DebugText;
+                    internal global::Std.BasicString.__Internal debugText;
 
                     [FieldOffset(96)]
                     internal byte isIncomplete;
@@ -10575,13 +10593,13 @@ namespace CppSharp
                     internal int lineNumberEnd;
 
                     [FieldOffset(24)]
-                    internal global::Std.BasicString.__Internal Name;
+                    internal global::Std.BasicString.__Internal name;
 
                     [FieldOffset(48)]
                     internal global::Std.BasicString.__Internal USR;
 
                     [FieldOffset(72)]
-                    internal global::Std.BasicString.__Internal DebugText;
+                    internal global::Std.BasicString.__Internal debugText;
 
                     [FieldOffset(96)]
                     internal byte isIncomplete;
@@ -10796,13 +10814,13 @@ namespace CppSharp
                     internal int lineNumberEnd;
 
                     [FieldOffset(24)]
-                    internal global::Std.BasicString.__Internal Name;
+                    internal global::Std.BasicString.__Internal name;
 
                     [FieldOffset(48)]
                     internal global::Std.BasicString.__Internal USR;
 
                     [FieldOffset(72)]
-                    internal global::Std.BasicString.__Internal DebugText;
+                    internal global::Std.BasicString.__Internal debugText;
 
                     [FieldOffset(96)]
                     internal byte isIncomplete;
@@ -10869,6 +10887,16 @@ namespace CppSharp
                     [DllImport("CppSharp.CppParser.dll", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.ThisCall,
                         EntryPoint="?clearSpecializations@ClassTemplate@AST@CppParser@CppSharp@@QAEXXZ")]
                     internal static extern void ClearSpecializations_0(global::System.IntPtr instance);
+
+                    [SuppressUnmanagedCodeSecurity]
+                    [DllImport("CppSharp.CppParser.dll", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.ThisCall,
+                        EntryPoint="?FindSpecialization@ClassTemplate@AST@CppParser@CppSharp@@QAEPAVClassTemplateSpecialization@234@ABV?$basic_string@DU?$char_traits@D@std@@V?$allocator@D@2@@std@@@Z")]
+                    internal static extern global::System.IntPtr FindSpecialization_0(global::System.IntPtr instance, global::System.IntPtr usr);
+
+                    [SuppressUnmanagedCodeSecurity]
+                    [DllImport("CppSharp.CppParser.dll", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.ThisCall,
+                        EntryPoint="?FindPartialSpecialization@ClassTemplate@AST@CppParser@CppSharp@@QAEPAVClassTemplatePartialSpecialization@234@ABV?$basic_string@DU?$char_traits@D@std@@V?$allocator@D@2@@std@@@Z")]
+                    internal static extern global::System.IntPtr FindPartialSpecialization_0(global::System.IntPtr instance, global::System.IntPtr usr);
 
                     [SuppressUnmanagedCodeSecurity]
                     [DllImport("CppSharp.CppParser.dll", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.ThisCall,
@@ -10967,6 +10995,38 @@ namespace CppSharp
                     __Internal.ClearSpecializations_0((__Instance + __PointerAdjustment));
                 }
 
+                public global::CppSharp.Parser.AST.ClassTemplateSpecialization FindSpecialization(string usr)
+                {
+                    var __allocator0 = new global::Std.Allocator();
+                    var __basicString0 = new global::Std.BasicString(usr, __allocator0);
+                    var __arg0 = __basicString0.__Instance;
+                    var __ret = __Internal.FindSpecialization_0((__Instance + __PointerAdjustment), __arg0);
+                    __basicString0.Dispose(false);
+                    __allocator0.Dispose();
+                    global::CppSharp.Parser.AST.ClassTemplateSpecialization __result0;
+                    if (__ret == IntPtr.Zero) __result0 = null;
+                    else if (global::CppSharp.Parser.AST.ClassTemplateSpecialization.NativeToManagedMap.ContainsKey(__ret))
+                        __result0 = (global::CppSharp.Parser.AST.ClassTemplateSpecialization) global::CppSharp.Parser.AST.ClassTemplateSpecialization.NativeToManagedMap[__ret];
+                    else __result0 = global::CppSharp.Parser.AST.ClassTemplateSpecialization.__CreateInstance(__ret);
+                    return __result0;
+                }
+
+                public global::CppSharp.Parser.AST.ClassTemplatePartialSpecialization FindPartialSpecialization(string usr)
+                {
+                    var __allocator0 = new global::Std.Allocator();
+                    var __basicString0 = new global::Std.BasicString(usr, __allocator0);
+                    var __arg0 = __basicString0.__Instance;
+                    var __ret = __Internal.FindPartialSpecialization_0((__Instance + __PointerAdjustment), __arg0);
+                    __basicString0.Dispose(false);
+                    __allocator0.Dispose();
+                    global::CppSharp.Parser.AST.ClassTemplatePartialSpecialization __result0;
+                    if (__ret == IntPtr.Zero) __result0 = null;
+                    else if (global::CppSharp.Parser.AST.ClassTemplatePartialSpecialization.NativeToManagedMap.ContainsKey(__ret))
+                        __result0 = (global::CppSharp.Parser.AST.ClassTemplatePartialSpecialization) global::CppSharp.Parser.AST.ClassTemplatePartialSpecialization.NativeToManagedMap[__ret];
+                    else __result0 = global::CppSharp.Parser.AST.ClassTemplatePartialSpecialization.__CreateInstance(__ret);
+                    return __result0;
+                }
+
                 public uint SpecializationsCount
                 {
                     get
@@ -11001,13 +11061,13 @@ namespace CppSharp
                     internal int lineNumberEnd;
 
                     [FieldOffset(24)]
-                    internal global::Std.BasicString.__Internal Name;
+                    internal global::Std.BasicString.__Internal name;
 
                     [FieldOffset(48)]
                     internal global::Std.BasicString.__Internal USR;
 
                     [FieldOffset(72)]
-                    internal global::Std.BasicString.__Internal DebugText;
+                    internal global::Std.BasicString.__Internal debugText;
 
                     [FieldOffset(96)]
                     internal byte isIncomplete;
@@ -11311,13 +11371,13 @@ namespace CppSharp
                     internal int lineNumberEnd;
 
                     [FieldOffset(24)]
-                    internal global::Std.BasicString.__Internal Name;
+                    internal global::Std.BasicString.__Internal name;
 
                     [FieldOffset(48)]
                     internal global::Std.BasicString.__Internal USR;
 
                     [FieldOffset(72)]
-                    internal global::Std.BasicString.__Internal DebugText;
+                    internal global::Std.BasicString.__Internal debugText;
 
                     [FieldOffset(96)]
                     internal byte isIncomplete;
@@ -11541,13 +11601,13 @@ namespace CppSharp
                     internal int lineNumberEnd;
 
                     [FieldOffset(24)]
-                    internal global::Std.BasicString.__Internal Name;
+                    internal global::Std.BasicString.__Internal name;
 
                     [FieldOffset(48)]
                     internal global::Std.BasicString.__Internal USR;
 
                     [FieldOffset(72)]
-                    internal global::Std.BasicString.__Internal DebugText;
+                    internal global::Std.BasicString.__Internal debugText;
 
                     [FieldOffset(96)]
                     internal byte isIncomplete;
@@ -11614,6 +11674,11 @@ namespace CppSharp
                     [DllImport("CppSharp.CppParser.dll", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.ThisCall,
                         EntryPoint="?clearSpecializations@FunctionTemplate@AST@CppParser@CppSharp@@QAEXXZ")]
                     internal static extern void ClearSpecializations_0(global::System.IntPtr instance);
+
+                    [SuppressUnmanagedCodeSecurity]
+                    [DllImport("CppSharp.CppParser.dll", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.ThisCall,
+                        EntryPoint="?FindSpecialization@FunctionTemplate@AST@CppParser@CppSharp@@QAEPAVFunctionTemplateSpecialization@234@ABV?$basic_string@DU?$char_traits@D@std@@V?$allocator@D@2@@std@@@Z")]
+                    internal static extern global::System.IntPtr FindSpecialization_0(global::System.IntPtr instance, global::System.IntPtr usr);
 
                     [SuppressUnmanagedCodeSecurity]
                     [DllImport("CppSharp.CppParser.dll", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.ThisCall,
@@ -11710,6 +11775,22 @@ namespace CppSharp
                 public void ClearSpecializations()
                 {
                     __Internal.ClearSpecializations_0((__Instance + __PointerAdjustment));
+                }
+
+                public global::CppSharp.Parser.AST.FunctionTemplateSpecialization FindSpecialization(string usr)
+                {
+                    var __allocator0 = new global::Std.Allocator();
+                    var __basicString0 = new global::Std.BasicString(usr, __allocator0);
+                    var __arg0 = __basicString0.__Instance;
+                    var __ret = __Internal.FindSpecialization_0((__Instance + __PointerAdjustment), __arg0);
+                    __basicString0.Dispose(false);
+                    __allocator0.Dispose();
+                    global::CppSharp.Parser.AST.FunctionTemplateSpecialization __result0;
+                    if (__ret == IntPtr.Zero) __result0 = null;
+                    else if (global::CppSharp.Parser.AST.FunctionTemplateSpecialization.NativeToManagedMap.ContainsKey(__ret))
+                        __result0 = (global::CppSharp.Parser.AST.FunctionTemplateSpecialization) global::CppSharp.Parser.AST.FunctionTemplateSpecialization.NativeToManagedMap[__ret];
+                    else __result0 = global::CppSharp.Parser.AST.FunctionTemplateSpecialization.__CreateInstance(__ret);
+                    return __result0;
                 }
 
                 public uint SpecializationsCount
@@ -11954,13 +12035,13 @@ namespace CppSharp
                     internal int lineNumberEnd;
 
                     [FieldOffset(24)]
-                    internal global::Std.BasicString.__Internal Name;
+                    internal global::Std.BasicString.__Internal name;
 
                     [FieldOffset(48)]
                     internal global::Std.BasicString.__Internal USR;
 
                     [FieldOffset(72)]
-                    internal global::Std.BasicString.__Internal DebugText;
+                    internal global::Std.BasicString.__Internal debugText;
 
                     [FieldOffset(96)]
                     internal byte isIncomplete;
@@ -12027,6 +12108,16 @@ namespace CppSharp
                     [DllImport("CppSharp.CppParser.dll", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.ThisCall,
                         EntryPoint="?clearSpecializations@VarTemplate@AST@CppParser@CppSharp@@QAEXXZ")]
                     internal static extern void ClearSpecializations_0(global::System.IntPtr instance);
+
+                    [SuppressUnmanagedCodeSecurity]
+                    [DllImport("CppSharp.CppParser.dll", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.ThisCall,
+                        EntryPoint="?FindSpecialization@VarTemplate@AST@CppParser@CppSharp@@QAEPAVVarTemplateSpecialization@234@ABV?$basic_string@DU?$char_traits@D@std@@V?$allocator@D@2@@std@@@Z")]
+                    internal static extern global::System.IntPtr FindSpecialization_0(global::System.IntPtr instance, global::System.IntPtr usr);
+
+                    [SuppressUnmanagedCodeSecurity]
+                    [DllImport("CppSharp.CppParser.dll", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.ThisCall,
+                        EntryPoint="?FindPartialSpecialization@VarTemplate@AST@CppParser@CppSharp@@QAEPAVVarTemplatePartialSpecialization@234@ABV?$basic_string@DU?$char_traits@D@std@@V?$allocator@D@2@@std@@@Z")]
+                    internal static extern global::System.IntPtr FindPartialSpecialization_0(global::System.IntPtr instance, global::System.IntPtr usr);
 
                     [SuppressUnmanagedCodeSecurity]
                     [DllImport("CppSharp.CppParser.dll", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.ThisCall,
@@ -12125,6 +12216,38 @@ namespace CppSharp
                     __Internal.ClearSpecializations_0((__Instance + __PointerAdjustment));
                 }
 
+                public global::CppSharp.Parser.AST.VarTemplateSpecialization FindSpecialization(string usr)
+                {
+                    var __allocator0 = new global::Std.Allocator();
+                    var __basicString0 = new global::Std.BasicString(usr, __allocator0);
+                    var __arg0 = __basicString0.__Instance;
+                    var __ret = __Internal.FindSpecialization_0((__Instance + __PointerAdjustment), __arg0);
+                    __basicString0.Dispose(false);
+                    __allocator0.Dispose();
+                    global::CppSharp.Parser.AST.VarTemplateSpecialization __result0;
+                    if (__ret == IntPtr.Zero) __result0 = null;
+                    else if (global::CppSharp.Parser.AST.VarTemplateSpecialization.NativeToManagedMap.ContainsKey(__ret))
+                        __result0 = (global::CppSharp.Parser.AST.VarTemplateSpecialization) global::CppSharp.Parser.AST.VarTemplateSpecialization.NativeToManagedMap[__ret];
+                    else __result0 = global::CppSharp.Parser.AST.VarTemplateSpecialization.__CreateInstance(__ret);
+                    return __result0;
+                }
+
+                public global::CppSharp.Parser.AST.VarTemplatePartialSpecialization FindPartialSpecialization(string usr)
+                {
+                    var __allocator0 = new global::Std.Allocator();
+                    var __basicString0 = new global::Std.BasicString(usr, __allocator0);
+                    var __arg0 = __basicString0.__Instance;
+                    var __ret = __Internal.FindPartialSpecialization_0((__Instance + __PointerAdjustment), __arg0);
+                    __basicString0.Dispose(false);
+                    __allocator0.Dispose();
+                    global::CppSharp.Parser.AST.VarTemplatePartialSpecialization __result0;
+                    if (__ret == IntPtr.Zero) __result0 = null;
+                    else if (global::CppSharp.Parser.AST.VarTemplatePartialSpecialization.NativeToManagedMap.ContainsKey(__ret))
+                        __result0 = (global::CppSharp.Parser.AST.VarTemplatePartialSpecialization) global::CppSharp.Parser.AST.VarTemplatePartialSpecialization.NativeToManagedMap[__ret];
+                    else __result0 = global::CppSharp.Parser.AST.VarTemplatePartialSpecialization.__CreateInstance(__ret);
+                    return __result0;
+                }
+
                 public uint SpecializationsCount
                 {
                     get
@@ -12159,13 +12282,13 @@ namespace CppSharp
                     internal int lineNumberEnd;
 
                     [FieldOffset(24)]
-                    internal global::Std.BasicString.__Internal Name;
+                    internal global::Std.BasicString.__Internal name;
 
                     [FieldOffset(48)]
                     internal global::Std.BasicString.__Internal USR;
 
                     [FieldOffset(72)]
-                    internal global::Std.BasicString.__Internal DebugText;
+                    internal global::Std.BasicString.__Internal debugText;
 
                     [FieldOffset(96)]
                     internal byte isIncomplete;
@@ -12195,7 +12318,7 @@ namespace CppSharp
                     internal global::System.IntPtr comment;
 
                     [FieldOffset(140)]
-                    internal global::Std.BasicString.__Internal Mangled;
+                    internal global::Std.BasicString.__Internal mangled;
 
                     [FieldOffset(164)]
                     internal global::CppSharp.Parser.AST.QualifiedType.__Internal qualifiedType;
@@ -12397,13 +12520,13 @@ namespace CppSharp
                     internal int lineNumberEnd;
 
                     [FieldOffset(24)]
-                    internal global::Std.BasicString.__Internal Name;
+                    internal global::Std.BasicString.__Internal name;
 
                     [FieldOffset(48)]
                     internal global::Std.BasicString.__Internal USR;
 
                     [FieldOffset(72)]
-                    internal global::Std.BasicString.__Internal DebugText;
+                    internal global::Std.BasicString.__Internal debugText;
 
                     [FieldOffset(96)]
                     internal byte isIncomplete;
@@ -12433,7 +12556,7 @@ namespace CppSharp
                     internal global::System.IntPtr comment;
 
                     [FieldOffset(140)]
-                    internal global::Std.BasicString.__Internal Mangled;
+                    internal global::Std.BasicString.__Internal mangled;
 
                     [FieldOffset(164)]
                     internal global::CppSharp.Parser.AST.QualifiedType.__Internal qualifiedType;
@@ -12555,13 +12678,13 @@ namespace CppSharp
                     internal int lineNumberEnd;
 
                     [FieldOffset(24)]
-                    internal global::Std.BasicString.__Internal Name;
+                    internal global::Std.BasicString.__Internal name;
 
                     [FieldOffset(48)]
                     internal global::Std.BasicString.__Internal USR;
 
                     [FieldOffset(72)]
-                    internal global::Std.BasicString.__Internal DebugText;
+                    internal global::Std.BasicString.__Internal debugText;
 
                     [FieldOffset(96)]
                     internal byte isIncomplete;
@@ -12874,10 +12997,10 @@ namespace CppSharp
                     internal global::CppSharp.Parser.AST.DeclarationKind kind;
 
                     [FieldOffset(12)]
-                    internal global::Std.BasicString.__Internal Name;
+                    internal global::Std.BasicString.__Internal name;
 
                     [FieldOffset(36)]
-                    internal global::Std.BasicString.__Internal Expression;
+                    internal global::Std.BasicString.__Internal expression;
 
                     [FieldOffset(60)]
                     internal int lineNumberStart;
@@ -12899,26 +13022,6 @@ namespace CppSharp
                     [DllImport("CppSharp.CppParser.dll", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.ThisCall,
                         EntryPoint="??1MacroDefinition@AST@CppParser@CppSharp@@QAE@XZ")]
                     internal static extern void dtor_0(global::System.IntPtr instance, int delete);
-
-                    [SuppressUnmanagedCodeSecurity]
-                    [DllImport("CppSharp.CppParser.dll", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.ThisCall,
-                        EntryPoint="?getName@MacroDefinition@AST@CppParser@CppSharp@@QAEPBDXZ")]
-                    internal static extern global::System.IntPtr GetName(global::System.IntPtr instance);
-
-                    [SuppressUnmanagedCodeSecurity]
-                    [DllImport("CppSharp.CppParser.dll", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.ThisCall,
-                        EntryPoint="?setName@MacroDefinition@AST@CppParser@CppSharp@@QAEXPBD@Z")]
-                    internal static extern void SetName(global::System.IntPtr instance, [MarshalAs(UnmanagedType.LPStr)] string s);
-
-                    [SuppressUnmanagedCodeSecurity]
-                    [DllImport("CppSharp.CppParser.dll", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.ThisCall,
-                        EntryPoint="?getExpression@MacroDefinition@AST@CppParser@CppSharp@@QAEPBDXZ")]
-                    internal static extern global::System.IntPtr GetExpression(global::System.IntPtr instance);
-
-                    [SuppressUnmanagedCodeSecurity]
-                    [DllImport("CppSharp.CppParser.dll", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.ThisCall,
-                        EntryPoint="?setExpression@MacroDefinition@AST@CppParser@CppSharp@@QAEXPBD@Z")]
-                    internal static extern void SetExpression(global::System.IntPtr instance, [MarshalAs(UnmanagedType.LPStr)] string s);
                 }
 
                 internal static new global::CppSharp.Parser.AST.MacroDefinition __CreateInstance(global::System.IntPtr native, bool skipVTables = false)
@@ -12988,6 +13091,36 @@ namespace CppSharp
                     __Instance = IntPtr.Zero;
                 }
 
+                public string Name
+                {
+                    get
+                    {
+                        return global::Std.BasicString.__CreateInstance(((global::CppSharp.Parser.AST.MacroDefinition.__Internal*) __Instance)->name).CStr();
+                    }
+
+                    set
+                    {
+                        var __allocator0 = new global::Std.Allocator();
+                        var __basicString0 = new global::Std.BasicString(value, __allocator0);
+                        ((global::CppSharp.Parser.AST.MacroDefinition.__Internal*) __Instance)->name = *(global::Std.BasicString.__Internal*) __basicString0.__Instance;
+                    }
+                }
+
+                public string Expression
+                {
+                    get
+                    {
+                        return global::Std.BasicString.__CreateInstance(((global::CppSharp.Parser.AST.MacroDefinition.__Internal*) __Instance)->expression).CStr();
+                    }
+
+                    set
+                    {
+                        var __allocator0 = new global::Std.Allocator();
+                        var __basicString0 = new global::Std.BasicString(value, __allocator0);
+                        ((global::CppSharp.Parser.AST.MacroDefinition.__Internal*) __Instance)->expression = *(global::Std.BasicString.__Internal*) __basicString0.__Instance;
+                    }
+                }
+
                 public int LineNumberStart
                 {
                     get
@@ -13013,34 +13146,6 @@ namespace CppSharp
                         ((global::CppSharp.Parser.AST.MacroDefinition.__Internal*) __Instance)->lineNumberEnd = value;
                     }
                 }
-
-                public string Name
-                {
-                    get
-                    {
-                        var __ret = __Internal.GetName((__Instance + __PointerAdjustment));
-                        return Marshal.PtrToStringAnsi(__ret);
-                    }
-
-                    set
-                    {
-                        __Internal.SetName((__Instance + __PointerAdjustment), value);
-                    }
-                }
-
-                public string Expression
-                {
-                    get
-                    {
-                        var __ret = __Internal.GetExpression((__Instance + __PointerAdjustment));
-                        return Marshal.PtrToStringAnsi(__ret);
-                    }
-
-                    set
-                    {
-                        __Internal.SetExpression((__Instance + __PointerAdjustment), value);
-                    }
-                }
             }
 
             public unsafe partial class MacroExpansion : global::CppSharp.Parser.AST.PreprocessedEntity, IDisposable
@@ -13058,10 +13163,10 @@ namespace CppSharp
                     internal global::CppSharp.Parser.AST.DeclarationKind kind;
 
                     [FieldOffset(12)]
-                    internal global::Std.BasicString.__Internal Name;
+                    internal global::Std.BasicString.__Internal name;
 
                     [FieldOffset(36)]
-                    internal global::Std.BasicString.__Internal Text;
+                    internal global::Std.BasicString.__Internal text;
 
                     [FieldOffset(60)]
                     internal global::System.IntPtr definition;
@@ -13080,26 +13185,6 @@ namespace CppSharp
                     [DllImport("CppSharp.CppParser.dll", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.ThisCall,
                         EntryPoint="??1MacroExpansion@AST@CppParser@CppSharp@@QAE@XZ")]
                     internal static extern void dtor_0(global::System.IntPtr instance, int delete);
-
-                    [SuppressUnmanagedCodeSecurity]
-                    [DllImport("CppSharp.CppParser.dll", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.ThisCall,
-                        EntryPoint="?getName@MacroExpansion@AST@CppParser@CppSharp@@QAEPBDXZ")]
-                    internal static extern global::System.IntPtr GetName(global::System.IntPtr instance);
-
-                    [SuppressUnmanagedCodeSecurity]
-                    [DllImport("CppSharp.CppParser.dll", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.ThisCall,
-                        EntryPoint="?setName@MacroExpansion@AST@CppParser@CppSharp@@QAEXPBD@Z")]
-                    internal static extern void SetName(global::System.IntPtr instance, [MarshalAs(UnmanagedType.LPStr)] string s);
-
-                    [SuppressUnmanagedCodeSecurity]
-                    [DllImport("CppSharp.CppParser.dll", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.ThisCall,
-                        EntryPoint="?getText@MacroExpansion@AST@CppParser@CppSharp@@QAEPBDXZ")]
-                    internal static extern global::System.IntPtr GetText(global::System.IntPtr instance);
-
-                    [SuppressUnmanagedCodeSecurity]
-                    [DllImport("CppSharp.CppParser.dll", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.ThisCall,
-                        EntryPoint="?setText@MacroExpansion@AST@CppParser@CppSharp@@QAEXPBD@Z")]
-                    internal static extern void SetText(global::System.IntPtr instance, [MarshalAs(UnmanagedType.LPStr)] string s);
                 }
 
                 internal static new global::CppSharp.Parser.AST.MacroExpansion __CreateInstance(global::System.IntPtr native, bool skipVTables = false)
@@ -13169,6 +13254,36 @@ namespace CppSharp
                     __Instance = IntPtr.Zero;
                 }
 
+                public string Name
+                {
+                    get
+                    {
+                        return global::Std.BasicString.__CreateInstance(((global::CppSharp.Parser.AST.MacroExpansion.__Internal*) __Instance)->name).CStr();
+                    }
+
+                    set
+                    {
+                        var __allocator0 = new global::Std.Allocator();
+                        var __basicString0 = new global::Std.BasicString(value, __allocator0);
+                        ((global::CppSharp.Parser.AST.MacroExpansion.__Internal*) __Instance)->name = *(global::Std.BasicString.__Internal*) __basicString0.__Instance;
+                    }
+                }
+
+                public string Text
+                {
+                    get
+                    {
+                        return global::Std.BasicString.__CreateInstance(((global::CppSharp.Parser.AST.MacroExpansion.__Internal*) __Instance)->text).CStr();
+                    }
+
+                    set
+                    {
+                        var __allocator0 = new global::Std.Allocator();
+                        var __basicString0 = new global::Std.BasicString(value, __allocator0);
+                        ((global::CppSharp.Parser.AST.MacroExpansion.__Internal*) __Instance)->text = *(global::Std.BasicString.__Internal*) __basicString0.__Instance;
+                    }
+                }
+
                 public global::CppSharp.Parser.AST.MacroDefinition Definition
                 {
                     get
@@ -13184,34 +13299,6 @@ namespace CppSharp
                     set
                     {
                         ((global::CppSharp.Parser.AST.MacroExpansion.__Internal*) __Instance)->definition = ReferenceEquals(value, null) ? global::System.IntPtr.Zero : value.__Instance;
-                    }
-                }
-
-                public string Name
-                {
-                    get
-                    {
-                        var __ret = __Internal.GetName((__Instance + __PointerAdjustment));
-                        return Marshal.PtrToStringAnsi(__ret);
-                    }
-
-                    set
-                    {
-                        __Internal.SetName((__Instance + __PointerAdjustment), value);
-                    }
-                }
-
-                public string Text
-                {
-                    get
-                    {
-                        var __ret = __Internal.GetText((__Instance + __PointerAdjustment));
-                        return Marshal.PtrToStringAnsi(__ret);
-                    }
-
-                    set
-                    {
-                        __Internal.SetText((__Instance + __PointerAdjustment), value);
                     }
                 }
             }
@@ -13240,13 +13327,13 @@ namespace CppSharp
                     internal int lineNumberEnd;
 
                     [FieldOffset(24)]
-                    internal global::Std.BasicString.__Internal Name;
+                    internal global::Std.BasicString.__Internal name;
 
                     [FieldOffset(48)]
                     internal global::Std.BasicString.__Internal USR;
 
                     [FieldOffset(72)]
-                    internal global::Std.BasicString.__Internal DebugText;
+                    internal global::Std.BasicString.__Internal debugText;
 
                     [FieldOffset(96)]
                     internal byte isIncomplete;
@@ -13312,7 +13399,7 @@ namespace CppSharp
                     internal byte isInline;
 
                     [FieldOffset(264)]
-                    internal global::Std.BasicString.__Internal FileName;
+                    internal global::Std.BasicString.__Internal fileName;
 
                     [FieldOffset(288)]
                     internal byte isSystemHeader;
@@ -13349,16 +13436,6 @@ namespace CppSharp
                     [DllImport("CppSharp.CppParser.dll", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.ThisCall,
                         EntryPoint="?clearMacros@TranslationUnit@AST@CppParser@CppSharp@@QAEXXZ")]
                     internal static extern void ClearMacros_0(global::System.IntPtr instance);
-
-                    [SuppressUnmanagedCodeSecurity]
-                    [DllImport("CppSharp.CppParser.dll", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.ThisCall,
-                        EntryPoint="?getFileName@TranslationUnit@AST@CppParser@CppSharp@@QAEPBDXZ")]
-                    internal static extern global::System.IntPtr GetFileName(global::System.IntPtr instance);
-
-                    [SuppressUnmanagedCodeSecurity]
-                    [DllImport("CppSharp.CppParser.dll", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.ThisCall,
-                        EntryPoint="?setFileName@TranslationUnit@AST@CppParser@CppSharp@@QAEXPBD@Z")]
-                    internal static extern void SetFileName(global::System.IntPtr instance, [MarshalAs(UnmanagedType.LPStr)] string s);
 
                     [SuppressUnmanagedCodeSecurity]
                     [DllImport("CppSharp.CppParser.dll", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.ThisCall,
@@ -13457,6 +13534,21 @@ namespace CppSharp
                     __Internal.ClearMacros_0((__Instance + __PointerAdjustment));
                 }
 
+                public string FileName
+                {
+                    get
+                    {
+                        return global::Std.BasicString.__CreateInstance(((global::CppSharp.Parser.AST.TranslationUnit.__Internal*) __Instance)->fileName).CStr();
+                    }
+
+                    set
+                    {
+                        var __allocator0 = new global::Std.Allocator();
+                        var __basicString0 = new global::Std.BasicString(value, __allocator0);
+                        ((global::CppSharp.Parser.AST.TranslationUnit.__Internal*) __Instance)->fileName = *(global::Std.BasicString.__Internal*) __basicString0.__Instance;
+                    }
+                }
+
                 public bool IsSystemHeader
                 {
                     get
@@ -13467,20 +13559,6 @@ namespace CppSharp
                     set
                     {
                         ((global::CppSharp.Parser.AST.TranslationUnit.__Internal*) __Instance)->isSystemHeader = (byte) (value ? 1 : 0);
-                    }
-                }
-
-                public string FileName
-                {
-                    get
-                    {
-                        var __ret = __Internal.GetFileName((__Instance + __PointerAdjustment));
-                        return Marshal.PtrToStringAnsi(__ret);
-                    }
-
-                    set
-                    {
-                        __Internal.SetFileName((__Instance + __PointerAdjustment), value);
                     }
                 }
 
@@ -13500,7 +13578,7 @@ namespace CppSharp
                 public partial struct __Internal
                 {
                     [FieldOffset(0)]
-                    internal global::Std.BasicString.__Internal FileName;
+                    internal global::Std.BasicString.__Internal fileName;
 
                     [FieldOffset(24)]
                     internal global::CppSharp.Parser.AST.ArchType archType;
@@ -13555,16 +13633,6 @@ namespace CppSharp
                     [DllImport("CppSharp.CppParser.dll", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.ThisCall,
                         EntryPoint="?clearDependencies@NativeLibrary@AST@CppParser@CppSharp@@QAEXXZ")]
                     internal static extern void ClearDependencies_0(global::System.IntPtr instance);
-
-                    [SuppressUnmanagedCodeSecurity]
-                    [DllImport("CppSharp.CppParser.dll", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.ThisCall,
-                        EntryPoint="?getFileName@NativeLibrary@AST@CppParser@CppSharp@@QAEPBDXZ")]
-                    internal static extern global::System.IntPtr GetFileName(global::System.IntPtr instance);
-
-                    [SuppressUnmanagedCodeSecurity]
-                    [DllImport("CppSharp.CppParser.dll", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.ThisCall,
-                        EntryPoint="?setFileName@NativeLibrary@AST@CppParser@CppSharp@@QAEXPBD@Z")]
-                    internal static extern void SetFileName(global::System.IntPtr instance, [MarshalAs(UnmanagedType.LPStr)] string s);
 
                     [SuppressUnmanagedCodeSecurity]
                     [DllImport("CppSharp.CppParser.dll", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.ThisCall,
@@ -13685,6 +13753,21 @@ namespace CppSharp
                     __Internal.ClearDependencies_0((__Instance + __PointerAdjustment));
                 }
 
+                public string FileName
+                {
+                    get
+                    {
+                        return global::Std.BasicString.__CreateInstance(((global::CppSharp.Parser.AST.NativeLibrary.__Internal*) __Instance)->fileName).CStr();
+                    }
+
+                    set
+                    {
+                        var __allocator0 = new global::Std.Allocator();
+                        var __basicString0 = new global::Std.BasicString(value, __allocator0);
+                        ((global::CppSharp.Parser.AST.NativeLibrary.__Internal*) __Instance)->fileName = *(global::Std.BasicString.__Internal*) __basicString0.__Instance;
+                    }
+                }
+
                 public global::CppSharp.Parser.AST.ArchType ArchType
                 {
                     get
@@ -13695,20 +13778,6 @@ namespace CppSharp
                     set
                     {
                         ((global::CppSharp.Parser.AST.NativeLibrary.__Internal*) __Instance)->archType = value;
-                    }
-                }
-
-                public string FileName
-                {
-                    get
-                    {
-                        var __ret = __Internal.GetFileName((__Instance + __PointerAdjustment));
-                        return Marshal.PtrToStringAnsi(__ret);
-                    }
-
-                    set
-                    {
-                        __Internal.SetFileName((__Instance + __PointerAdjustment), value);
                     }
                 }
 
@@ -13753,6 +13822,11 @@ namespace CppSharp
                     [DllImport("CppSharp.CppParser.dll", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.ThisCall,
                         EntryPoint="??1ASTContext@AST@CppParser@CppSharp@@QAE@XZ")]
                     internal static extern void dtor_0(global::System.IntPtr instance, int delete);
+
+                    [SuppressUnmanagedCodeSecurity]
+                    [DllImport("CppSharp.CppParser.dll", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.ThisCall,
+                        EntryPoint="?FindOrCreateModule@ASTContext@AST@CppParser@CppSharp@@QAEPAVTranslationUnit@234@V?$basic_string@DU?$char_traits@D@std@@V?$allocator@D@2@@std@@@Z")]
+                    internal static extern global::System.IntPtr FindOrCreateModule_0(global::System.IntPtr instance, global::Std.BasicString.__Internal File);
 
                     [SuppressUnmanagedCodeSecurity]
                     [DllImport("CppSharp.CppParser.dll", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.ThisCall,
@@ -13849,6 +13923,22 @@ namespace CppSharp
                     if (__ownsNativeInstance)
                         Marshal.FreeHGlobal(__Instance);
                     __Instance = IntPtr.Zero;
+                }
+
+                public global::CppSharp.Parser.AST.TranslationUnit FindOrCreateModule(string File)
+                {
+                    var __allocator0 = new global::Std.Allocator();
+                    var __basicString0 = new global::Std.BasicString(File, __allocator0);
+                    var __arg0 = *(global::Std.BasicString.__Internal*) __basicString0.__Instance;
+                    var __ret = __Internal.FindOrCreateModule_0((__Instance + __PointerAdjustment), __arg0);
+                    __basicString0.Dispose(false);
+                    __allocator0.Dispose();
+                    global::CppSharp.Parser.AST.TranslationUnit __result0;
+                    if (__ret == IntPtr.Zero) __result0 = null;
+                    else if (global::CppSharp.Parser.AST.TranslationUnit.NativeToManagedMap.ContainsKey(__ret))
+                        __result0 = (global::CppSharp.Parser.AST.TranslationUnit) global::CppSharp.Parser.AST.TranslationUnit.NativeToManagedMap[__ret];
+                    else __result0 = global::CppSharp.Parser.AST.TranslationUnit.__CreateInstance(__ret);
+                    return __result0;
                 }
 
                 public global::CppSharp.Parser.AST.TranslationUnit GetTranslationUnits(uint i)
@@ -14566,7 +14656,7 @@ namespace CppSharp
                     public partial struct __Internal
                     {
                         [FieldOffset(0)]
-                        internal global::Std.BasicString.__Internal Text;
+                        internal global::Std.BasicString.__Internal text;
 
                         [SuppressUnmanagedCodeSecurity]
                         [DllImport("CppSharp.CppParser.dll", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.ThisCall,
@@ -14582,16 +14672,6 @@ namespace CppSharp
                         [DllImport("CppSharp.CppParser.dll", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.ThisCall,
                             EntryPoint="??1Argument@BlockCommandComment@AST@CppParser@CppSharp@@QAE@XZ")]
                         internal static extern void dtor_0(global::System.IntPtr instance, int delete);
-
-                        [SuppressUnmanagedCodeSecurity]
-                        [DllImport("CppSharp.CppParser.dll", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.ThisCall,
-                            EntryPoint="?getText@Argument@BlockCommandComment@AST@CppParser@CppSharp@@QAEPBDXZ")]
-                        internal static extern global::System.IntPtr GetText(global::System.IntPtr instance);
-
-                        [SuppressUnmanagedCodeSecurity]
-                        [DllImport("CppSharp.CppParser.dll", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.ThisCall,
-                            EntryPoint="?setText@Argument@BlockCommandComment@AST@CppParser@CppSharp@@QAEXPBD@Z")]
-                        internal static extern void SetText(global::System.IntPtr instance, [MarshalAs(UnmanagedType.LPStr)] string s);
                     }
 
                     public global::System.IntPtr __Instance { get; protected set; }
@@ -14674,13 +14754,14 @@ namespace CppSharp
                     {
                         get
                         {
-                            var __ret = __Internal.GetText((__Instance + __PointerAdjustment));
-                            return Marshal.PtrToStringAnsi(__ret);
+                            return global::Std.BasicString.__CreateInstance(((global::CppSharp.Parser.AST.BlockCommandComment.Argument.__Internal*) __Instance)->text).CStr();
                         }
 
                         set
                         {
-                            __Internal.SetText((__Instance + __PointerAdjustment), value);
+                            var __allocator0 = new global::Std.Allocator();
+                            var __basicString0 = new global::Std.BasicString(value, __allocator0);
+                            ((global::CppSharp.Parser.AST.BlockCommandComment.Argument.__Internal*) __Instance)->text = *(global::Std.BasicString.__Internal*) __basicString0.__Instance;
                         }
                     }
                 }
@@ -15129,7 +15210,7 @@ namespace CppSharp
                     internal global::CppSharp.Parser.AST.CommentKind kind;
 
                     [FieldOffset(4)]
-                    internal global::Std.BasicString.__Internal Text;
+                    internal global::Std.BasicString.__Internal text;
 
                     [SuppressUnmanagedCodeSecurity]
                     [DllImport("CppSharp.CppParser.dll", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.ThisCall,
@@ -15145,16 +15226,6 @@ namespace CppSharp
                     [DllImport("CppSharp.CppParser.dll", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.ThisCall,
                         EntryPoint="??1VerbatimBlockLineComment@AST@CppParser@CppSharp@@QAE@XZ")]
                     internal static extern void dtor_0(global::System.IntPtr instance, int delete);
-
-                    [SuppressUnmanagedCodeSecurity]
-                    [DllImport("CppSharp.CppParser.dll", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.ThisCall,
-                        EntryPoint="?getText@VerbatimBlockLineComment@AST@CppParser@CppSharp@@QAEPBDXZ")]
-                    internal static extern global::System.IntPtr GetText(global::System.IntPtr instance);
-
-                    [SuppressUnmanagedCodeSecurity]
-                    [DllImport("CppSharp.CppParser.dll", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.ThisCall,
-                        EntryPoint="?setText@VerbatimBlockLineComment@AST@CppParser@CppSharp@@QAEXPBD@Z")]
-                    internal static extern void SetText(global::System.IntPtr instance, [MarshalAs(UnmanagedType.LPStr)] string s);
                 }
 
                 internal static new global::CppSharp.Parser.AST.VerbatimBlockLineComment __CreateInstance(global::System.IntPtr native, bool skipVTables = false)
@@ -15228,13 +15299,14 @@ namespace CppSharp
                 {
                     get
                     {
-                        var __ret = __Internal.GetText((__Instance + __PointerAdjustment));
-                        return Marshal.PtrToStringAnsi(__ret);
+                        return global::Std.BasicString.__CreateInstance(((global::CppSharp.Parser.AST.VerbatimBlockLineComment.__Internal*) __Instance)->text).CStr();
                     }
 
                     set
                     {
-                        __Internal.SetText((__Instance + __PointerAdjustment), value);
+                        var __allocator0 = new global::Std.Allocator();
+                        var __basicString0 = new global::Std.BasicString(value, __allocator0);
+                        ((global::CppSharp.Parser.AST.VerbatimBlockLineComment.__Internal*) __Instance)->text = *(global::Std.BasicString.__Internal*) __basicString0.__Instance;
                     }
                 }
             }
@@ -15414,7 +15486,7 @@ namespace CppSharp
                     internal global::Std.Vector.__Internal Arguments;
 
                     [FieldOffset(24)]
-                    internal global::Std.BasicString.__Internal Text;
+                    internal global::Std.BasicString.__Internal text;
 
                     [SuppressUnmanagedCodeSecurity]
                     [DllImport("CppSharp.CppParser.dll", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.ThisCall,
@@ -15430,16 +15502,6 @@ namespace CppSharp
                     [DllImport("CppSharp.CppParser.dll", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.ThisCall,
                         EntryPoint="??1VerbatimLineComment@AST@CppParser@CppSharp@@QAE@XZ")]
                     internal static extern void dtor_0(global::System.IntPtr instance, int delete);
-
-                    [SuppressUnmanagedCodeSecurity]
-                    [DllImport("CppSharp.CppParser.dll", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.ThisCall,
-                        EntryPoint="?getText@VerbatimLineComment@AST@CppParser@CppSharp@@QAEPBDXZ")]
-                    internal static extern global::System.IntPtr GetText(global::System.IntPtr instance);
-
-                    [SuppressUnmanagedCodeSecurity]
-                    [DllImport("CppSharp.CppParser.dll", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.ThisCall,
-                        EntryPoint="?setText@VerbatimLineComment@AST@CppParser@CppSharp@@QAEXPBD@Z")]
-                    internal static extern void SetText(global::System.IntPtr instance, [MarshalAs(UnmanagedType.LPStr)] string s);
                 }
 
                 internal static new global::CppSharp.Parser.AST.VerbatimLineComment __CreateInstance(global::System.IntPtr native, bool skipVTables = false)
@@ -15513,13 +15575,14 @@ namespace CppSharp
                 {
                     get
                     {
-                        var __ret = __Internal.GetText((__Instance + __PointerAdjustment));
-                        return Marshal.PtrToStringAnsi(__ret);
+                        return global::Std.BasicString.__CreateInstance(((global::CppSharp.Parser.AST.VerbatimLineComment.__Internal*) __Instance)->text).CStr();
                     }
 
                     set
                     {
-                        __Internal.SetText((__Instance + __PointerAdjustment), value);
+                        var __allocator0 = new global::Std.Allocator();
+                        var __basicString0 = new global::Std.BasicString(value, __allocator0);
+                        ((global::CppSharp.Parser.AST.VerbatimLineComment.__Internal*) __Instance)->text = *(global::Std.BasicString.__Internal*) __basicString0.__Instance;
                     }
                 }
             }
@@ -15594,7 +15657,7 @@ namespace CppSharp
                     public partial struct __Internal
                     {
                         [FieldOffset(0)]
-                        internal global::Std.BasicString.__Internal Text;
+                        internal global::Std.BasicString.__Internal text;
 
                         [SuppressUnmanagedCodeSecurity]
                         [DllImport("CppSharp.CppParser.dll", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.ThisCall,
@@ -15610,16 +15673,6 @@ namespace CppSharp
                         [DllImport("CppSharp.CppParser.dll", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.ThisCall,
                             EntryPoint="??1Argument@InlineCommandComment@AST@CppParser@CppSharp@@QAE@XZ")]
                         internal static extern void dtor_0(global::System.IntPtr instance, int delete);
-
-                        [SuppressUnmanagedCodeSecurity]
-                        [DllImport("CppSharp.CppParser.dll", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.ThisCall,
-                            EntryPoint="?getText@Argument@InlineCommandComment@AST@CppParser@CppSharp@@QAEPBDXZ")]
-                        internal static extern global::System.IntPtr GetText(global::System.IntPtr instance);
-
-                        [SuppressUnmanagedCodeSecurity]
-                        [DllImport("CppSharp.CppParser.dll", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.ThisCall,
-                            EntryPoint="?setText@Argument@InlineCommandComment@AST@CppParser@CppSharp@@QAEXPBD@Z")]
-                        internal static extern void SetText(global::System.IntPtr instance, [MarshalAs(UnmanagedType.LPStr)] string s);
                     }
 
                     public global::System.IntPtr __Instance { get; protected set; }
@@ -15702,13 +15755,14 @@ namespace CppSharp
                     {
                         get
                         {
-                            var __ret = __Internal.GetText((__Instance + __PointerAdjustment));
-                            return Marshal.PtrToStringAnsi(__ret);
+                            return global::Std.BasicString.__CreateInstance(((global::CppSharp.Parser.AST.InlineCommandComment.Argument.__Internal*) __Instance)->text).CStr();
                         }
 
                         set
                         {
-                            __Internal.SetText((__Instance + __PointerAdjustment), value);
+                            var __allocator0 = new global::Std.Allocator();
+                            var __basicString0 = new global::Std.BasicString(value, __allocator0);
+                            ((global::CppSharp.Parser.AST.InlineCommandComment.Argument.__Internal*) __Instance)->text = *(global::Std.BasicString.__Internal*) __basicString0.__Instance;
                         }
                     }
                 }
@@ -15941,7 +15995,7 @@ namespace CppSharp
                     internal byte hasTrailingNewline;
 
                     [FieldOffset(8)]
-                    internal global::Std.BasicString.__Internal TagName;
+                    internal global::Std.BasicString.__Internal tagName;
 
                     [FieldOffset(32)]
                     internal global::Std.Vector.__Internal Attributes;
@@ -15978,16 +16032,6 @@ namespace CppSharp
 
                     [SuppressUnmanagedCodeSecurity]
                     [DllImport("CppSharp.CppParser.dll", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.ThisCall,
-                        EntryPoint="?getTagName@HTMLStartTagComment@AST@CppParser@CppSharp@@QAEPBDXZ")]
-                    internal static extern global::System.IntPtr GetTagName(global::System.IntPtr instance);
-
-                    [SuppressUnmanagedCodeSecurity]
-                    [DllImport("CppSharp.CppParser.dll", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.ThisCall,
-                        EntryPoint="?setTagName@HTMLStartTagComment@AST@CppParser@CppSharp@@QAEXPBD@Z")]
-                    internal static extern void SetTagName(global::System.IntPtr instance, [MarshalAs(UnmanagedType.LPStr)] string s);
-
-                    [SuppressUnmanagedCodeSecurity]
-                    [DllImport("CppSharp.CppParser.dll", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.ThisCall,
                         EntryPoint="?getAttributesCount@HTMLStartTagComment@AST@CppParser@CppSharp@@QAEIXZ")]
                     internal static extern uint GetAttributesCount(global::System.IntPtr instance);
                 }
@@ -15998,10 +16042,10 @@ namespace CppSharp
                     public partial struct __Internal
                     {
                         [FieldOffset(0)]
-                        internal global::Std.BasicString.__Internal Name;
+                        internal global::Std.BasicString.__Internal name;
 
                         [FieldOffset(24)]
-                        internal global::Std.BasicString.__Internal Value;
+                        internal global::Std.BasicString.__Internal value;
 
                         [SuppressUnmanagedCodeSecurity]
                         [DllImport("CppSharp.CppParser.dll", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.ThisCall,
@@ -16017,26 +16061,6 @@ namespace CppSharp
                         [DllImport("CppSharp.CppParser.dll", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.ThisCall,
                             EntryPoint="??1Attribute@HTMLStartTagComment@AST@CppParser@CppSharp@@QAE@XZ")]
                         internal static extern void dtor_0(global::System.IntPtr instance, int delete);
-
-                        [SuppressUnmanagedCodeSecurity]
-                        [DllImport("CppSharp.CppParser.dll", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.ThisCall,
-                            EntryPoint="?getName@Attribute@HTMLStartTagComment@AST@CppParser@CppSharp@@QAEPBDXZ")]
-                        internal static extern global::System.IntPtr GetName(global::System.IntPtr instance);
-
-                        [SuppressUnmanagedCodeSecurity]
-                        [DllImport("CppSharp.CppParser.dll", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.ThisCall,
-                            EntryPoint="?setName@Attribute@HTMLStartTagComment@AST@CppParser@CppSharp@@QAEXPBD@Z")]
-                        internal static extern void SetName(global::System.IntPtr instance, [MarshalAs(UnmanagedType.LPStr)] string s);
-
-                        [SuppressUnmanagedCodeSecurity]
-                        [DllImport("CppSharp.CppParser.dll", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.ThisCall,
-                            EntryPoint="?getValue@Attribute@HTMLStartTagComment@AST@CppParser@CppSharp@@QAEPBDXZ")]
-                        internal static extern global::System.IntPtr GetValue(global::System.IntPtr instance);
-
-                        [SuppressUnmanagedCodeSecurity]
-                        [DllImport("CppSharp.CppParser.dll", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.ThisCall,
-                            EntryPoint="?setValue@Attribute@HTMLStartTagComment@AST@CppParser@CppSharp@@QAEXPBD@Z")]
-                        internal static extern void SetValue(global::System.IntPtr instance, [MarshalAs(UnmanagedType.LPStr)] string s);
                     }
 
                     public global::System.IntPtr __Instance { get; protected set; }
@@ -16119,13 +16143,14 @@ namespace CppSharp
                     {
                         get
                         {
-                            var __ret = __Internal.GetName((__Instance + __PointerAdjustment));
-                            return Marshal.PtrToStringAnsi(__ret);
+                            return global::Std.BasicString.__CreateInstance(((global::CppSharp.Parser.AST.HTMLStartTagComment.Attribute.__Internal*) __Instance)->name).CStr();
                         }
 
                         set
                         {
-                            __Internal.SetName((__Instance + __PointerAdjustment), value);
+                            var __allocator0 = new global::Std.Allocator();
+                            var __basicString0 = new global::Std.BasicString(value, __allocator0);
+                            ((global::CppSharp.Parser.AST.HTMLStartTagComment.Attribute.__Internal*) __Instance)->name = *(global::Std.BasicString.__Internal*) __basicString0.__Instance;
                         }
                     }
 
@@ -16133,13 +16158,14 @@ namespace CppSharp
                     {
                         get
                         {
-                            var __ret = __Internal.GetValue((__Instance + __PointerAdjustment));
-                            return Marshal.PtrToStringAnsi(__ret);
+                            return global::Std.BasicString.__CreateInstance(((global::CppSharp.Parser.AST.HTMLStartTagComment.Attribute.__Internal*) __Instance)->value).CStr();
                         }
 
                         set
                         {
-                            __Internal.SetValue((__Instance + __PointerAdjustment), value);
+                            var __allocator0 = new global::Std.Allocator();
+                            var __basicString0 = new global::Std.BasicString(value, __allocator0);
+                            ((global::CppSharp.Parser.AST.HTMLStartTagComment.Attribute.__Internal*) __Instance)->value = *(global::Std.BasicString.__Internal*) __basicString0.__Instance;
                         }
                     }
                 }
@@ -16235,13 +16261,14 @@ namespace CppSharp
                 {
                     get
                     {
-                        var __ret = __Internal.GetTagName((__Instance + __PointerAdjustment));
-                        return Marshal.PtrToStringAnsi(__ret);
+                        return global::Std.BasicString.__CreateInstance(((global::CppSharp.Parser.AST.HTMLStartTagComment.__Internal*) __Instance)->tagName).CStr();
                     }
 
                     set
                     {
-                        __Internal.SetTagName((__Instance + __PointerAdjustment), value);
+                        var __allocator0 = new global::Std.Allocator();
+                        var __basicString0 = new global::Std.BasicString(value, __allocator0);
+                        ((global::CppSharp.Parser.AST.HTMLStartTagComment.__Internal*) __Instance)->tagName = *(global::Std.BasicString.__Internal*) __basicString0.__Instance;
                     }
                 }
 
@@ -16267,7 +16294,7 @@ namespace CppSharp
                     internal byte hasTrailingNewline;
 
                     [FieldOffset(8)]
-                    internal global::Std.BasicString.__Internal TagName;
+                    internal global::Std.BasicString.__Internal tagName;
 
                     [SuppressUnmanagedCodeSecurity]
                     [DllImport("CppSharp.CppParser.dll", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.ThisCall,
@@ -16283,16 +16310,6 @@ namespace CppSharp
                     [DllImport("CppSharp.CppParser.dll", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.ThisCall,
                         EntryPoint="??1HTMLEndTagComment@AST@CppParser@CppSharp@@QAE@XZ")]
                     internal static extern void dtor_0(global::System.IntPtr instance, int delete);
-
-                    [SuppressUnmanagedCodeSecurity]
-                    [DllImport("CppSharp.CppParser.dll", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.ThisCall,
-                        EntryPoint="?getTagName@HTMLEndTagComment@AST@CppParser@CppSharp@@QAEPBDXZ")]
-                    internal static extern global::System.IntPtr GetTagName(global::System.IntPtr instance);
-
-                    [SuppressUnmanagedCodeSecurity]
-                    [DllImport("CppSharp.CppParser.dll", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.ThisCall,
-                        EntryPoint="?setTagName@HTMLEndTagComment@AST@CppParser@CppSharp@@QAEXPBD@Z")]
-                    internal static extern void SetTagName(global::System.IntPtr instance, [MarshalAs(UnmanagedType.LPStr)] string s);
                 }
 
                 internal static new global::CppSharp.Parser.AST.HTMLEndTagComment __CreateInstance(global::System.IntPtr native, bool skipVTables = false)
@@ -16366,13 +16383,14 @@ namespace CppSharp
                 {
                     get
                     {
-                        var __ret = __Internal.GetTagName((__Instance + __PointerAdjustment));
-                        return Marshal.PtrToStringAnsi(__ret);
+                        return global::Std.BasicString.__CreateInstance(((global::CppSharp.Parser.AST.HTMLEndTagComment.__Internal*) __Instance)->tagName).CStr();
                     }
 
                     set
                     {
-                        __Internal.SetTagName((__Instance + __PointerAdjustment), value);
+                        var __allocator0 = new global::Std.Allocator();
+                        var __basicString0 = new global::Std.BasicString(value, __allocator0);
+                        ((global::CppSharp.Parser.AST.HTMLEndTagComment.__Internal*) __Instance)->tagName = *(global::Std.BasicString.__Internal*) __basicString0.__Instance;
                     }
                 }
             }
@@ -16389,7 +16407,7 @@ namespace CppSharp
                     internal byte hasTrailingNewline;
 
                     [FieldOffset(8)]
-                    internal global::Std.BasicString.__Internal Text;
+                    internal global::Std.BasicString.__Internal text;
 
                     [SuppressUnmanagedCodeSecurity]
                     [DllImport("CppSharp.CppParser.dll", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.ThisCall,
@@ -16405,16 +16423,6 @@ namespace CppSharp
                     [DllImport("CppSharp.CppParser.dll", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.ThisCall,
                         EntryPoint="??1TextComment@AST@CppParser@CppSharp@@QAE@XZ")]
                     internal static extern void dtor_0(global::System.IntPtr instance, int delete);
-
-                    [SuppressUnmanagedCodeSecurity]
-                    [DllImport("CppSharp.CppParser.dll", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.ThisCall,
-                        EntryPoint="?getText@TextComment@AST@CppParser@CppSharp@@QAEPBDXZ")]
-                    internal static extern global::System.IntPtr GetText(global::System.IntPtr instance);
-
-                    [SuppressUnmanagedCodeSecurity]
-                    [DllImport("CppSharp.CppParser.dll", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.ThisCall,
-                        EntryPoint="?setText@TextComment@AST@CppParser@CppSharp@@QAEXPBD@Z")]
-                    internal static extern void SetText(global::System.IntPtr instance, [MarshalAs(UnmanagedType.LPStr)] string s);
                 }
 
                 internal static new global::CppSharp.Parser.AST.TextComment __CreateInstance(global::System.IntPtr native, bool skipVTables = false)
@@ -16488,13 +16496,14 @@ namespace CppSharp
                 {
                     get
                     {
-                        var __ret = __Internal.GetText((__Instance + __PointerAdjustment));
-                        return Marshal.PtrToStringAnsi(__ret);
+                        return global::Std.BasicString.__CreateInstance(((global::CppSharp.Parser.AST.TextComment.__Internal*) __Instance)->text).CStr();
                     }
 
                     set
                     {
-                        __Internal.SetText((__Instance + __PointerAdjustment), value);
+                        var __allocator0 = new global::Std.Allocator();
+                        var __basicString0 = new global::Std.BasicString(value, __allocator0);
+                        ((global::CppSharp.Parser.AST.TextComment.__Internal*) __Instance)->text = *(global::Std.BasicString.__Internal*) __basicString0.__Instance;
                     }
                 }
             }
@@ -16508,10 +16517,10 @@ namespace CppSharp
                     internal global::CppSharp.Parser.AST.RawCommentKind kind;
 
                     [FieldOffset(4)]
-                    internal global::Std.BasicString.__Internal Text;
+                    internal global::Std.BasicString.__Internal text;
 
                     [FieldOffset(28)]
-                    internal global::Std.BasicString.__Internal BriefText;
+                    internal global::Std.BasicString.__Internal briefText;
 
                     [FieldOffset(52)]
                     internal global::System.IntPtr fullCommentBlock;
@@ -16530,26 +16539,6 @@ namespace CppSharp
                     [DllImport("CppSharp.CppParser.dll", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.ThisCall,
                         EntryPoint="??1RawComment@AST@CppParser@CppSharp@@QAE@XZ")]
                     internal static extern void dtor_0(global::System.IntPtr instance, int delete);
-
-                    [SuppressUnmanagedCodeSecurity]
-                    [DllImport("CppSharp.CppParser.dll", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.ThisCall,
-                        EntryPoint="?getText@RawComment@AST@CppParser@CppSharp@@QAEPBDXZ")]
-                    internal static extern global::System.IntPtr GetText(global::System.IntPtr instance);
-
-                    [SuppressUnmanagedCodeSecurity]
-                    [DllImport("CppSharp.CppParser.dll", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.ThisCall,
-                        EntryPoint="?setText@RawComment@AST@CppParser@CppSharp@@QAEXPBD@Z")]
-                    internal static extern void SetText(global::System.IntPtr instance, [MarshalAs(UnmanagedType.LPStr)] string s);
-
-                    [SuppressUnmanagedCodeSecurity]
-                    [DllImport("CppSharp.CppParser.dll", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.ThisCall,
-                        EntryPoint="?getBriefText@RawComment@AST@CppParser@CppSharp@@QAEPBDXZ")]
-                    internal static extern global::System.IntPtr GetBriefText(global::System.IntPtr instance);
-
-                    [SuppressUnmanagedCodeSecurity]
-                    [DllImport("CppSharp.CppParser.dll", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.ThisCall,
-                        EntryPoint="?setBriefText@RawComment@AST@CppParser@CppSharp@@QAEXPBD@Z")]
-                    internal static extern void SetBriefText(global::System.IntPtr instance, [MarshalAs(UnmanagedType.LPStr)] string s);
                 }
 
                 public global::System.IntPtr __Instance { get; protected set; }
@@ -16641,6 +16630,36 @@ namespace CppSharp
                     }
                 }
 
+                public string Text
+                {
+                    get
+                    {
+                        return global::Std.BasicString.__CreateInstance(((global::CppSharp.Parser.AST.RawComment.__Internal*) __Instance)->text).CStr();
+                    }
+
+                    set
+                    {
+                        var __allocator0 = new global::Std.Allocator();
+                        var __basicString0 = new global::Std.BasicString(value, __allocator0);
+                        ((global::CppSharp.Parser.AST.RawComment.__Internal*) __Instance)->text = *(global::Std.BasicString.__Internal*) __basicString0.__Instance;
+                    }
+                }
+
+                public string BriefText
+                {
+                    get
+                    {
+                        return global::Std.BasicString.__CreateInstance(((global::CppSharp.Parser.AST.RawComment.__Internal*) __Instance)->briefText).CStr();
+                    }
+
+                    set
+                    {
+                        var __allocator0 = new global::Std.Allocator();
+                        var __basicString0 = new global::Std.BasicString(value, __allocator0);
+                        ((global::CppSharp.Parser.AST.RawComment.__Internal*) __Instance)->briefText = *(global::Std.BasicString.__Internal*) __basicString0.__Instance;
+                    }
+                }
+
                 public global::CppSharp.Parser.AST.FullComment FullCommentBlock
                 {
                     get
@@ -16656,34 +16675,6 @@ namespace CppSharp
                     set
                     {
                         ((global::CppSharp.Parser.AST.RawComment.__Internal*) __Instance)->fullCommentBlock = ReferenceEquals(value, null) ? global::System.IntPtr.Zero : value.__Instance;
-                    }
-                }
-
-                public string Text
-                {
-                    get
-                    {
-                        var __ret = __Internal.GetText((__Instance + __PointerAdjustment));
-                        return Marshal.PtrToStringAnsi(__ret);
-                    }
-
-                    set
-                    {
-                        __Internal.SetText((__Instance + __PointerAdjustment), value);
-                    }
-                }
-
-                public string BriefText
-                {
-                    get
-                    {
-                        var __ret = __Internal.GetBriefText((__Instance + __PointerAdjustment));
-                        return Marshal.PtrToStringAnsi(__ret);
-                    }
-
-                    set
-                    {
-                        __Internal.SetBriefText((__Instance + __PointerAdjustment), value);
                     }
                 }
             }
@@ -16945,16 +16936,6 @@ namespace CppSharp
                 [DllImport("CppSharp.CppParser.dll", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.ThisCall,
                     EntryPoint="??1ParserTargetInfo@CppParser@CppSharp@@QAE@XZ")]
                 internal static extern void dtor_0(global::System.IntPtr instance, int delete);
-
-                [SuppressUnmanagedCodeSecurity]
-                [DllImport("CppSharp.CppParser.dll", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.ThisCall,
-                    EntryPoint="?getABI@ParserTargetInfo@CppParser@CppSharp@@QAEPBDXZ")]
-                internal static extern global::System.IntPtr GetABI(global::System.IntPtr instance);
-
-                [SuppressUnmanagedCodeSecurity]
-                [DllImport("CppSharp.CppParser.dll", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.ThisCall,
-                    EntryPoint="?setABI@ParserTargetInfo@CppParser@CppSharp@@QAEXPBD@Z")]
-                internal static extern void SetABI(global::System.IntPtr instance, [MarshalAs(UnmanagedType.LPStr)] string s);
             }
 
             public global::System.IntPtr __Instance { get; protected set; }
@@ -17031,6 +17012,21 @@ namespace CppSharp
                 if (__ownsNativeInstance)
                     Marshal.FreeHGlobal(__Instance);
                 __Instance = IntPtr.Zero;
+            }
+
+            public string ABI
+            {
+                get
+                {
+                    return global::Std.BasicString.__CreateInstance(((global::CppSharp.Parser.ParserTargetInfo.__Internal*) __Instance)->ABI).CStr();
+                }
+
+                set
+                {
+                    var __allocator0 = new global::Std.Allocator();
+                    var __basicString0 = new global::Std.BasicString(value, __allocator0);
+                    ((global::CppSharp.Parser.ParserTargetInfo.__Internal*) __Instance)->ABI = *(global::Std.BasicString.__Internal*) __basicString0.__Instance;
+                }
             }
 
             public global::CppSharp.Parser.ParserIntType Char16Type
@@ -17552,20 +17548,6 @@ namespace CppSharp
                     ((global::CppSharp.Parser.ParserTargetInfo.__Internal*) __Instance)->float128Width = value;
                 }
             }
-
-            public string ABI
-            {
-                get
-                {
-                    var __ret = __Internal.GetABI((__Instance + __PointerAdjustment));
-                    return Marshal.PtrToStringAnsi(__ret);
-                }
-
-                set
-                {
-                    __Internal.SetABI((__Instance + __PointerAdjustment), value);
-                }
-            }
         }
     }
 }
@@ -17671,7 +17653,7 @@ namespace CppSharp
                 internal global::Std.Vector.__Internal Arguments;
 
                 [FieldOffset(12)]
-                internal global::Std.BasicString.__Internal LibraryFile;
+                internal global::Std.BasicString.__Internal libraryFile;
 
                 [FieldOffset(36)]
                 internal global::Std.Vector.__Internal SourceFiles;
@@ -17698,7 +17680,7 @@ namespace CppSharp
                 internal int toolSetToUse;
 
                 [FieldOffset(116)]
-                internal global::Std.BasicString.__Internal TargetTriple;
+                internal global::Std.BasicString.__Internal targetTriple;
 
                 [FieldOffset(140)]
                 internal global::CppSharp.Parser.AST.CppAbi abi;
@@ -17840,26 +17822,6 @@ namespace CppSharp
                 [DllImport("CppSharp.CppParser.dll", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.ThisCall,
                     EntryPoint="?clearLibraryDirs@CppParserOptions@CppParser@CppSharp@@QAEXXZ")]
                 internal static extern void ClearLibraryDirs_0(global::System.IntPtr instance);
-
-                [SuppressUnmanagedCodeSecurity]
-                [DllImport("CppSharp.CppParser.dll", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.ThisCall,
-                    EntryPoint="?getLibraryFile@CppParserOptions@CppParser@CppSharp@@QAEPBDXZ")]
-                internal static extern global::System.IntPtr GetLibraryFile(global::System.IntPtr instance);
-
-                [SuppressUnmanagedCodeSecurity]
-                [DllImport("CppSharp.CppParser.dll", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.ThisCall,
-                    EntryPoint="?setLibraryFile@CppParserOptions@CppParser@CppSharp@@QAEXPBD@Z")]
-                internal static extern void SetLibraryFile(global::System.IntPtr instance, [MarshalAs(UnmanagedType.LPStr)] string s);
-
-                [SuppressUnmanagedCodeSecurity]
-                [DllImport("CppSharp.CppParser.dll", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.ThisCall,
-                    EntryPoint="?getTargetTriple@CppParserOptions@CppParser@CppSharp@@QAEPBDXZ")]
-                internal static extern global::System.IntPtr GetTargetTriple(global::System.IntPtr instance);
-
-                [SuppressUnmanagedCodeSecurity]
-                [DllImport("CppSharp.CppParser.dll", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.ThisCall,
-                    EntryPoint="?setTargetTriple@CppParserOptions@CppParser@CppSharp@@QAEXPBD@Z")]
-                internal static extern void SetTargetTriple(global::System.IntPtr instance, [MarshalAs(UnmanagedType.LPStr)] string s);
 
                 [SuppressUnmanagedCodeSecurity]
                 [DllImport("CppSharp.CppParser.dll", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.ThisCall,
@@ -18085,6 +18047,21 @@ namespace CppSharp
                 __Internal.ClearLibraryDirs_0((__Instance + __PointerAdjustment));
             }
 
+            public string LibraryFile
+            {
+                get
+                {
+                    return global::Std.BasicString.__CreateInstance(((global::CppSharp.Parser.CppParserOptions.__Internal*) __Instance)->libraryFile).CStr();
+                }
+
+                set
+                {
+                    var __allocator0 = new global::Std.Allocator();
+                    var __basicString0 = new global::Std.BasicString(value, __allocator0);
+                    ((global::CppSharp.Parser.CppParserOptions.__Internal*) __Instance)->libraryFile = *(global::Std.BasicString.__Internal*) __basicString0.__Instance;
+                }
+            }
+
             public global::CppSharp.Parser.AST.ASTContext ASTContext
             {
                 get
@@ -18113,6 +18090,21 @@ namespace CppSharp
                 set
                 {
                     ((global::CppSharp.Parser.CppParserOptions.__Internal*) __Instance)->toolSetToUse = value;
+                }
+            }
+
+            public string TargetTriple
+            {
+                get
+                {
+                    return global::Std.BasicString.__CreateInstance(((global::CppSharp.Parser.CppParserOptions.__Internal*) __Instance)->targetTriple).CStr();
+                }
+
+                set
+                {
+                    var __allocator0 = new global::Std.Allocator();
+                    var __basicString0 = new global::Std.BasicString(value, __allocator0);
+                    ((global::CppSharp.Parser.CppParserOptions.__Internal*) __Instance)->targetTriple = *(global::Std.BasicString.__Internal*) __basicString0.__Instance;
                 }
             }
 
@@ -18212,34 +18204,6 @@ namespace CppSharp
                 }
             }
 
-            public string LibraryFile
-            {
-                get
-                {
-                    var __ret = __Internal.GetLibraryFile((__Instance + __PointerAdjustment));
-                    return Marshal.PtrToStringAnsi(__ret);
-                }
-
-                set
-                {
-                    __Internal.SetLibraryFile((__Instance + __PointerAdjustment), value);
-                }
-            }
-
-            public string TargetTriple
-            {
-                get
-                {
-                    var __ret = __Internal.GetTargetTriple((__Instance + __PointerAdjustment));
-                    return Marshal.PtrToStringAnsi(__ret);
-                }
-
-                set
-                {
-                    __Internal.SetTargetTriple((__Instance + __PointerAdjustment), value);
-                }
-            }
-
             public uint ArgumentsCount
             {
                 get
@@ -18310,10 +18274,10 @@ namespace CppSharp
             public partial struct __Internal
             {
                 [FieldOffset(0)]
-                internal global::Std.BasicString.__Internal FileName;
+                internal global::Std.BasicString.__Internal fileName;
 
                 [FieldOffset(24)]
-                internal global::Std.BasicString.__Internal Message;
+                internal global::Std.BasicString.__Internal message;
 
                 [FieldOffset(48)]
                 internal global::CppSharp.Parser.ParserDiagnosticLevel level;
@@ -18338,26 +18302,6 @@ namespace CppSharp
                 [DllImport("CppSharp.CppParser.dll", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.ThisCall,
                     EntryPoint="??1ParserDiagnostic@CppParser@CppSharp@@QAE@XZ")]
                 internal static extern void dtor_0(global::System.IntPtr instance, int delete);
-
-                [SuppressUnmanagedCodeSecurity]
-                [DllImport("CppSharp.CppParser.dll", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.ThisCall,
-                    EntryPoint="?getFileName@ParserDiagnostic@CppParser@CppSharp@@QAEPBDXZ")]
-                internal static extern global::System.IntPtr GetFileName(global::System.IntPtr instance);
-
-                [SuppressUnmanagedCodeSecurity]
-                [DllImport("CppSharp.CppParser.dll", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.ThisCall,
-                    EntryPoint="?setFileName@ParserDiagnostic@CppParser@CppSharp@@QAEXPBD@Z")]
-                internal static extern void SetFileName(global::System.IntPtr instance, [MarshalAs(UnmanagedType.LPStr)] string s);
-
-                [SuppressUnmanagedCodeSecurity]
-                [DllImport("CppSharp.CppParser.dll", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.ThisCall,
-                    EntryPoint="?getMessage@ParserDiagnostic@CppParser@CppSharp@@QAEPBDXZ")]
-                internal static extern global::System.IntPtr GetMessage(global::System.IntPtr instance);
-
-                [SuppressUnmanagedCodeSecurity]
-                [DllImport("CppSharp.CppParser.dll", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.ThisCall,
-                    EntryPoint="?setMessage@ParserDiagnostic@CppParser@CppSharp@@QAEXPBD@Z")]
-                internal static extern void SetMessage(global::System.IntPtr instance, [MarshalAs(UnmanagedType.LPStr)] string s);
             }
 
             public global::System.IntPtr __Instance { get; protected set; }
@@ -18436,6 +18380,36 @@ namespace CppSharp
                 __Instance = IntPtr.Zero;
             }
 
+            public string FileName
+            {
+                get
+                {
+                    return global::Std.BasicString.__CreateInstance(((global::CppSharp.Parser.ParserDiagnostic.__Internal*) __Instance)->fileName).CStr();
+                }
+
+                set
+                {
+                    var __allocator0 = new global::Std.Allocator();
+                    var __basicString0 = new global::Std.BasicString(value, __allocator0);
+                    ((global::CppSharp.Parser.ParserDiagnostic.__Internal*) __Instance)->fileName = *(global::Std.BasicString.__Internal*) __basicString0.__Instance;
+                }
+            }
+
+            public string Message
+            {
+                get
+                {
+                    return global::Std.BasicString.__CreateInstance(((global::CppSharp.Parser.ParserDiagnostic.__Internal*) __Instance)->message).CStr();
+                }
+
+                set
+                {
+                    var __allocator0 = new global::Std.Allocator();
+                    var __basicString0 = new global::Std.BasicString(value, __allocator0);
+                    ((global::CppSharp.Parser.ParserDiagnostic.__Internal*) __Instance)->message = *(global::Std.BasicString.__Internal*) __basicString0.__Instance;
+                }
+            }
+
             public global::CppSharp.Parser.ParserDiagnosticLevel Level
             {
                 get
@@ -18472,34 +18446,6 @@ namespace CppSharp
                 set
                 {
                     ((global::CppSharp.Parser.ParserDiagnostic.__Internal*) __Instance)->columnNumber = value;
-                }
-            }
-
-            public string FileName
-            {
-                get
-                {
-                    var __ret = __Internal.GetFileName((__Instance + __PointerAdjustment));
-                    return Marshal.PtrToStringAnsi(__ret);
-                }
-
-                set
-                {
-                    __Internal.SetFileName((__Instance + __PointerAdjustment), value);
-                }
-            }
-
-            public string Message
-            {
-                get
-                {
-                    var __ret = __Internal.GetMessage((__Instance + __PointerAdjustment));
-                    return Marshal.PtrToStringAnsi(__ret);
-                }
-
-                set
-                {
-                    __Internal.SetMessage((__Instance + __PointerAdjustment), value);
                 }
             }
         }

--- a/src/CppParser/Bindings/CSharp/i686-pc-win32-msvc/Std.cs
+++ b/src/CppParser/Bindings/CSharp/i686-pc-win32-msvc/Std.cs
@@ -57,68 +57,6 @@ public unsafe partial class StdExceptionData
 
 namespace Std
 {
-    public unsafe partial class CharTraits : IDisposable
-    {
-        [StructLayout(LayoutKind.Explicit, Size = 0)]
-        public unsafe partial struct __Internal
-        {
-        }
-
-        public global::System.IntPtr __Instance { get; protected set; }
-
-        protected int __PointerAdjustment;
-        internal static readonly global::System.Collections.Concurrent.ConcurrentDictionary<IntPtr, global::Std.CharTraits> NativeToManagedMap = new global::System.Collections.Concurrent.ConcurrentDictionary<IntPtr, global::Std.CharTraits>();
-        protected void*[] __OriginalVTables;
-
-        protected bool __ownsNativeInstance;
-
-        internal static global::Std.CharTraits __CreateInstance(global::System.IntPtr native, bool skipVTables = false)
-        {
-            return new global::Std.CharTraits(native.ToPointer(), skipVTables);
-        }
-
-        internal static global::Std.CharTraits __CreateInstance(global::Std.CharTraits.__Internal native, bool skipVTables = false)
-        {
-            return new global::Std.CharTraits(native, skipVTables);
-        }
-
-        private static void* __CopyValue(global::Std.CharTraits.__Internal native)
-        {
-            var ret = Marshal.AllocHGlobal(sizeof(global::Std.CharTraits.__Internal));
-            *(global::Std.CharTraits.__Internal*) ret = native;
-            return ret.ToPointer();
-        }
-
-        private CharTraits(global::Std.CharTraits.__Internal native, bool skipVTables = false)
-            : this(__CopyValue(native), skipVTables)
-        {
-            __ownsNativeInstance = true;
-            NativeToManagedMap[__Instance] = this;
-        }
-
-        protected CharTraits(void* native, bool skipVTables = false)
-        {
-            if (native == null)
-                return;
-            __Instance = new global::System.IntPtr(native);
-        }
-
-        public void Dispose()
-        {
-            Dispose(disposing: true);
-        }
-
-        public virtual void Dispose(bool disposing)
-        {
-            if (__Instance == IntPtr.Zero)
-                return;
-            global::Std.CharTraits __dummy;
-            NativeToManagedMap.TryRemove(__Instance, out __dummy);
-            if (__ownsNativeInstance)
-                Marshal.FreeHGlobal(__Instance);
-            __Instance = IntPtr.Zero;
-        }
-    }
 }
 
 namespace Std
@@ -558,6 +496,11 @@ namespace Std
 
             [SuppressUnmanagedCodeSecurity]
             [DllImport("Std-symbols", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.ThisCall,
+                EntryPoint="??0?$basic_string@DU?$char_traits@D@std@@V?$allocator@D@2@@std@@QAE@PBDABV?$allocator@D@1@@Z")]
+            internal static extern global::System.IntPtr ctorc__N_std_S_basic_string__C___N_std_S_char_traits__C___N_std_S_allocator__C_0(global::System.IntPtr instance, [MarshalAs(UnmanagedType.LPStr)] string _Ptr, global::System.IntPtr _Al);
+
+            [SuppressUnmanagedCodeSecurity]
+            [DllImport("Std-symbols", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.ThisCall,
                 EntryPoint="??1?$basic_string@DU?$char_traits@D@std@@V?$allocator@D@2@@std@@QAE@XZ")]
             internal static extern void dtorc__N_std_S_basic_string__C___N_std_S_char_traits__C___N_std_S_allocator__C_0(global::System.IntPtr instance, int delete);
 
@@ -604,6 +547,17 @@ namespace Std
             if (native == null)
                 return;
             __Instance = new global::System.IntPtr(native);
+        }
+
+        public BasicString(string _Ptr, global::Std.Allocator _Al)
+        {
+            __Instance = Marshal.AllocHGlobal(sizeof(global::Std.BasicString.__Internal));
+            __ownsNativeInstance = true;
+            NativeToManagedMap[__Instance] = this;
+            if (ReferenceEquals(_Al, null))
+                throw new global::System.ArgumentNullException("_Al", "Cannot be null because it is a C++ reference (&).");
+            var __arg1 = ((global::Std.Allocator) (object) _Al).__Instance;
+            global::Std.BasicString.__Internal.ctorc__N_std_S_basic_string__C___N_std_S_char_traits__C___N_std_S_allocator__C_0((__Instance + __PointerAdjustment), _Ptr, __arg1);
         }
 
         public void Dispose()

--- a/src/CppParser/Bindings/CSharp/x86_64-apple-darwin12.4.0/CppSharp.CppParser.cs
+++ b/src/CppParser/Bindings/CSharp/x86_64-apple-darwin12.4.0/CppSharp.CppParser.cs
@@ -2589,7 +2589,7 @@ namespace CppSharp
                     internal global::CppSharp.Parser.AST.QualifiedType.__Internal qualifier;
 
                     [FieldOffset(24)]
-                    internal global::Std.__1.BasicString.__Internal Identifier;
+                    internal global::Std.__1.BasicString.__Internal identifier;
 
                     [SuppressUnmanagedCodeSecurity]
                     [DllImport("CppSharp.CppParser", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
@@ -2605,16 +2605,6 @@ namespace CppSharp
                     [DllImport("CppSharp.CppParser", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
                         EntryPoint="_ZN8CppSharp9CppParser3AST17DependentNameTypeD2Ev")]
                     internal static extern void dtor_0(global::System.IntPtr instance);
-
-                    [SuppressUnmanagedCodeSecurity]
-                    [DllImport("CppSharp.CppParser", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
-                        EntryPoint="_ZN8CppSharp9CppParser3AST17DependentNameType13getIdentifierEv")]
-                    internal static extern global::System.IntPtr GetIdentifier(global::System.IntPtr instance);
-
-                    [SuppressUnmanagedCodeSecurity]
-                    [DllImport("CppSharp.CppParser", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
-                        EntryPoint="_ZN8CppSharp9CppParser3AST17DependentNameType13setIdentifierEPKc")]
-                    internal static extern void SetIdentifier(global::System.IntPtr instance, [MarshalAs(UnmanagedType.LPStr)] string s);
                 }
 
                 internal static new global::CppSharp.Parser.AST.DependentNameType __CreateInstance(global::System.IntPtr native, bool skipVTables = false)
@@ -2701,13 +2691,14 @@ namespace CppSharp
                 {
                     get
                     {
-                        var __ret = __Internal.GetIdentifier((__Instance + __PointerAdjustment));
-                        return Marshal.PtrToStringAnsi(__ret);
+                        return global::Std.__1.BasicString.__CreateInstance(((global::CppSharp.Parser.AST.DependentNameType.__Internal*) __Instance)->identifier).CStr();
                     }
 
                     set
                     {
-                        __Internal.SetIdentifier((__Instance + __PointerAdjustment), value);
+                        var __allocator0 = new global::Std.__1.Allocator();
+                        var __basicString0 = new global::Std.__1.BasicString(value, __allocator0);
+                        ((global::CppSharp.Parser.AST.DependentNameType.__Internal*) __Instance)->identifier = *(global::Std.__1.BasicString.__Internal*) __basicString0.__Instance;
                     }
                 }
             }
@@ -3561,7 +3552,7 @@ namespace CppSharp
                     internal uint offset;
 
                     [FieldOffset(8)]
-                    internal global::Std.__1.BasicString.__Internal Name;
+                    internal global::Std.__1.BasicString.__Internal name;
 
                     [FieldOffset(32)]
                     internal global::CppSharp.Parser.AST.QualifiedType.__Internal qualifiedType;
@@ -3583,16 +3574,6 @@ namespace CppSharp
                     [DllImport("CppSharp.CppParser", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
                         EntryPoint="_ZN8CppSharp9CppParser3AST11LayoutFieldD2Ev")]
                     internal static extern void dtor_0(global::System.IntPtr instance);
-
-                    [SuppressUnmanagedCodeSecurity]
-                    [DllImport("CppSharp.CppParser", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
-                        EntryPoint="_ZN8CppSharp9CppParser3AST11LayoutField7getNameEv")]
-                    internal static extern global::System.IntPtr GetName(global::System.IntPtr instance);
-
-                    [SuppressUnmanagedCodeSecurity]
-                    [DllImport("CppSharp.CppParser", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
-                        EntryPoint="_ZN8CppSharp9CppParser3AST11LayoutField7setNameEPKc")]
-                    internal static extern void SetName(global::System.IntPtr instance, [MarshalAs(UnmanagedType.LPStr)] string s);
                 }
 
                 public global::System.IntPtr __Instance { get; protected set; }
@@ -3684,6 +3665,21 @@ namespace CppSharp
                     }
                 }
 
+                public string Name
+                {
+                    get
+                    {
+                        return global::Std.__1.BasicString.__CreateInstance(((global::CppSharp.Parser.AST.LayoutField.__Internal*) __Instance)->name).CStr();
+                    }
+
+                    set
+                    {
+                        var __allocator0 = new global::Std.__1.Allocator();
+                        var __basicString0 = new global::Std.__1.BasicString(value, __allocator0);
+                        ((global::CppSharp.Parser.AST.LayoutField.__Internal*) __Instance)->name = *(global::Std.__1.BasicString.__Internal*) __basicString0.__Instance;
+                    }
+                }
+
                 public global::CppSharp.Parser.AST.QualifiedType QualifiedType
                 {
                     get
@@ -3707,20 +3703,6 @@ namespace CppSharp
                     set
                     {
                         ((global::CppSharp.Parser.AST.LayoutField.__Internal*) __Instance)->fieldPtr = (global::System.IntPtr) value;
-                    }
-                }
-
-                public string Name
-                {
-                    get
-                    {
-                        var __ret = __Internal.GetName((__Instance + __PointerAdjustment));
-                        return Marshal.PtrToStringAnsi(__ret);
-                    }
-
-                    set
-                    {
-                        __Internal.SetName((__Instance + __PointerAdjustment), value);
                     }
                 }
             }
@@ -4250,13 +4232,13 @@ namespace CppSharp
                     internal int lineNumberEnd;
 
                     [FieldOffset(32)]
-                    internal global::Std.__1.BasicString.__Internal Name;
+                    internal global::Std.__1.BasicString.__Internal name;
 
                     [FieldOffset(56)]
                     internal global::Std.__1.BasicString.__Internal USR;
 
                     [FieldOffset(80)]
-                    internal global::Std.__1.BasicString.__Internal DebugText;
+                    internal global::Std.__1.BasicString.__Internal debugText;
 
                     [FieldOffset(104)]
                     internal byte isIncomplete;
@@ -4329,36 +4311,6 @@ namespace CppSharp
                     [DllImport("CppSharp.CppParser", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
                         EntryPoint="_ZN8CppSharp9CppParser3AST11Declaration19clearRedeclarationsEv")]
                     internal static extern void ClearRedeclarations_0(global::System.IntPtr instance);
-
-                    [SuppressUnmanagedCodeSecurity]
-                    [DllImport("CppSharp.CppParser", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
-                        EntryPoint="_ZN8CppSharp9CppParser3AST11Declaration7getNameEv")]
-                    internal static extern global::System.IntPtr GetName(global::System.IntPtr instance);
-
-                    [SuppressUnmanagedCodeSecurity]
-                    [DllImport("CppSharp.CppParser", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
-                        EntryPoint="_ZN8CppSharp9CppParser3AST11Declaration7setNameEPKc")]
-                    internal static extern void SetName(global::System.IntPtr instance, [MarshalAs(UnmanagedType.LPStr)] string s);
-
-                    [SuppressUnmanagedCodeSecurity]
-                    [DllImport("CppSharp.CppParser", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
-                        EntryPoint="_ZN8CppSharp9CppParser3AST11Declaration6getUSREv")]
-                    internal static extern global::System.IntPtr GetUSR(global::System.IntPtr instance);
-
-                    [SuppressUnmanagedCodeSecurity]
-                    [DllImport("CppSharp.CppParser", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
-                        EntryPoint="_ZN8CppSharp9CppParser3AST11Declaration6setUSREPKc")]
-                    internal static extern void SetUSR(global::System.IntPtr instance, [MarshalAs(UnmanagedType.LPStr)] string s);
-
-                    [SuppressUnmanagedCodeSecurity]
-                    [DllImport("CppSharp.CppParser", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
-                        EntryPoint="_ZN8CppSharp9CppParser3AST11Declaration12getDebugTextEv")]
-                    internal static extern global::System.IntPtr GetDebugText(global::System.IntPtr instance);
-
-                    [SuppressUnmanagedCodeSecurity]
-                    [DllImport("CppSharp.CppParser", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
-                        EntryPoint="_ZN8CppSharp9CppParser3AST11Declaration12setDebugTextEPKc")]
-                    internal static extern void SetDebugText(global::System.IntPtr instance, [MarshalAs(UnmanagedType.LPStr)] string s);
 
                     [SuppressUnmanagedCodeSecurity]
                     [DllImport("CppSharp.CppParser", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
@@ -4583,6 +4535,51 @@ namespace CppSharp
                     }
                 }
 
+                public string Name
+                {
+                    get
+                    {
+                        return global::Std.__1.BasicString.__CreateInstance(((global::CppSharp.Parser.AST.Declaration.__Internal*) __Instance)->name).CStr();
+                    }
+
+                    set
+                    {
+                        var __allocator0 = new global::Std.__1.Allocator();
+                        var __basicString0 = new global::Std.__1.BasicString(value, __allocator0);
+                        ((global::CppSharp.Parser.AST.Declaration.__Internal*) __Instance)->name = *(global::Std.__1.BasicString.__Internal*) __basicString0.__Instance;
+                    }
+                }
+
+                public string USR
+                {
+                    get
+                    {
+                        return global::Std.__1.BasicString.__CreateInstance(((global::CppSharp.Parser.AST.Declaration.__Internal*) __Instance)->USR).CStr();
+                    }
+
+                    set
+                    {
+                        var __allocator0 = new global::Std.__1.Allocator();
+                        var __basicString0 = new global::Std.__1.BasicString(value, __allocator0);
+                        ((global::CppSharp.Parser.AST.Declaration.__Internal*) __Instance)->USR = *(global::Std.__1.BasicString.__Internal*) __basicString0.__Instance;
+                    }
+                }
+
+                public string DebugText
+                {
+                    get
+                    {
+                        return global::Std.__1.BasicString.__CreateInstance(((global::CppSharp.Parser.AST.Declaration.__Internal*) __Instance)->debugText).CStr();
+                    }
+
+                    set
+                    {
+                        var __allocator0 = new global::Std.__1.Allocator();
+                        var __basicString0 = new global::Std.__1.BasicString(value, __allocator0);
+                        ((global::CppSharp.Parser.AST.Declaration.__Internal*) __Instance)->debugText = *(global::Std.__1.BasicString.__Internal*) __basicString0.__Instance;
+                    }
+                }
+
                 public bool IsIncomplete
                 {
                     get
@@ -4684,48 +4681,6 @@ namespace CppSharp
                     }
                 }
 
-                public string Name
-                {
-                    get
-                    {
-                        var __ret = __Internal.GetName((__Instance + __PointerAdjustment));
-                        return Marshal.PtrToStringAnsi(__ret);
-                    }
-
-                    set
-                    {
-                        __Internal.SetName((__Instance + __PointerAdjustment), value);
-                    }
-                }
-
-                public string USR
-                {
-                    get
-                    {
-                        var __ret = __Internal.GetUSR((__Instance + __PointerAdjustment));
-                        return Marshal.PtrToStringAnsi(__ret);
-                    }
-
-                    set
-                    {
-                        __Internal.SetUSR((__Instance + __PointerAdjustment), value);
-                    }
-                }
-
-                public string DebugText
-                {
-                    get
-                    {
-                        var __ret = __Internal.GetDebugText((__Instance + __PointerAdjustment));
-                        return Marshal.PtrToStringAnsi(__ret);
-                    }
-
-                    set
-                    {
-                        __Internal.SetDebugText((__Instance + __PointerAdjustment), value);
-                    }
-                }
-
                 public uint PreprocessedEntitiesCount
                 {
                     get
@@ -4769,13 +4724,13 @@ namespace CppSharp
                     internal int lineNumberEnd;
 
                     [FieldOffset(32)]
-                    internal global::Std.__1.BasicString.__Internal Name;
+                    internal global::Std.__1.BasicString.__Internal name;
 
                     [FieldOffset(56)]
                     internal global::Std.__1.BasicString.__Internal USR;
 
                     [FieldOffset(80)]
-                    internal global::Std.__1.BasicString.__Internal DebugText;
+                    internal global::Std.__1.BasicString.__Internal debugText;
 
                     [FieldOffset(104)]
                     internal byte isIncomplete;
@@ -5440,13 +5395,13 @@ namespace CppSharp
                     internal int lineNumberEnd;
 
                     [FieldOffset(32)]
-                    internal global::Std.__1.BasicString.__Internal Name;
+                    internal global::Std.__1.BasicString.__Internal name;
 
                     [FieldOffset(56)]
                     internal global::Std.__1.BasicString.__Internal USR;
 
                     [FieldOffset(80)]
-                    internal global::Std.__1.BasicString.__Internal DebugText;
+                    internal global::Std.__1.BasicString.__Internal debugText;
 
                     [FieldOffset(104)]
                     internal byte isIncomplete;
@@ -5604,13 +5559,13 @@ namespace CppSharp
                     internal int lineNumberEnd;
 
                     [FieldOffset(32)]
-                    internal global::Std.__1.BasicString.__Internal Name;
+                    internal global::Std.__1.BasicString.__Internal name;
 
                     [FieldOffset(56)]
                     internal global::Std.__1.BasicString.__Internal USR;
 
                     [FieldOffset(80)]
-                    internal global::Std.__1.BasicString.__Internal DebugText;
+                    internal global::Std.__1.BasicString.__Internal debugText;
 
                     [FieldOffset(104)]
                     internal byte isIncomplete;
@@ -5750,13 +5705,13 @@ namespace CppSharp
                     internal int lineNumberEnd;
 
                     [FieldOffset(32)]
-                    internal global::Std.__1.BasicString.__Internal Name;
+                    internal global::Std.__1.BasicString.__Internal name;
 
                     [FieldOffset(56)]
                     internal global::Std.__1.BasicString.__Internal USR;
 
                     [FieldOffset(80)]
-                    internal global::Std.__1.BasicString.__Internal DebugText;
+                    internal global::Std.__1.BasicString.__Internal debugText;
 
                     [FieldOffset(104)]
                     internal byte isIncomplete;
@@ -5917,13 +5872,13 @@ namespace CppSharp
                     internal int lineNumberEnd;
 
                     [FieldOffset(32)]
-                    internal global::Std.__1.BasicString.__Internal Name;
+                    internal global::Std.__1.BasicString.__Internal name;
 
                     [FieldOffset(56)]
                     internal global::Std.__1.BasicString.__Internal USR;
 
                     [FieldOffset(80)]
-                    internal global::Std.__1.BasicString.__Internal DebugText;
+                    internal global::Std.__1.BasicString.__Internal debugText;
 
                     [FieldOffset(104)]
                     internal byte isIncomplete;
@@ -6069,27 +6024,22 @@ namespace CppSharp
                     internal global::System.IntPtr decl;
 
                     [FieldOffset(16)]
-                    internal global::Std.__1.BasicString.__Internal String;
+                    internal global::Std.__1.BasicString.__Internal @string;
+
+                    [SuppressUnmanagedCodeSecurity]
+                    [DllImport("CppSharp.CppParser", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
+                        EntryPoint="_ZN8CppSharp9CppParser3AST9StatementC2ERKNSt3__112basic_stringIcNS3_11char_traitsIcEENS3_9allocatorIcEEEENS1_14StatementClassEPNS1_11DeclarationE")]
+                    internal static extern void ctor_0(global::System.IntPtr instance, global::System.IntPtr str, global::CppSharp.Parser.AST.StatementClass Class, global::System.IntPtr decl);
 
                     [SuppressUnmanagedCodeSecurity]
                     [DllImport("CppSharp.CppParser", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
                         EntryPoint="_ZN8CppSharp9CppParser3AST9StatementC2ERKS2_")]
-                    internal static extern void cctor_0(global::System.IntPtr instance, global::System.IntPtr _0);
+                    internal static extern void cctor_1(global::System.IntPtr instance, global::System.IntPtr _0);
 
                     [SuppressUnmanagedCodeSecurity]
                     [DllImport("CppSharp.CppParser", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
                         EntryPoint="_ZN8CppSharp9CppParser3AST9StatementD2Ev")]
                     internal static extern void dtor_0(global::System.IntPtr instance);
-
-                    [SuppressUnmanagedCodeSecurity]
-                    [DllImport("CppSharp.CppParser", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
-                        EntryPoint="_ZN8CppSharp9CppParser3AST9Statement9getStringEv")]
-                    internal static extern global::System.IntPtr GetString(global::System.IntPtr instance);
-
-                    [SuppressUnmanagedCodeSecurity]
-                    [DllImport("CppSharp.CppParser", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
-                        EntryPoint="_ZN8CppSharp9CppParser3AST9Statement9setStringEPKc")]
-                    internal static extern void SetString(global::System.IntPtr instance, [MarshalAs(UnmanagedType.LPStr)] string s);
                 }
 
                 public global::System.IntPtr __Instance { get; protected set; }
@@ -6113,7 +6063,7 @@ namespace CppSharp
                 private static void* __CopyValue(global::CppSharp.Parser.AST.Statement.__Internal native)
                 {
                     var ret = Marshal.AllocHGlobal(sizeof(global::CppSharp.Parser.AST.Statement.__Internal));
-                    global::CppSharp.Parser.AST.Statement.__Internal.cctor_0(ret, new global::System.IntPtr(&native));
+                    global::CppSharp.Parser.AST.Statement.__Internal.cctor_1(ret, new global::System.IntPtr(&native));
                     return ret.ToPointer();
                 }
 
@@ -6131,6 +6081,20 @@ namespace CppSharp
                     __Instance = new global::System.IntPtr(native);
                 }
 
+                public Statement(string str, global::CppSharp.Parser.AST.StatementClass Class, global::CppSharp.Parser.AST.Declaration decl)
+                {
+                    __Instance = Marshal.AllocHGlobal(sizeof(global::CppSharp.Parser.AST.Statement.__Internal));
+                    __ownsNativeInstance = true;
+                    NativeToManagedMap[__Instance] = this;
+                    var __allocator0 = new global::Std.__1.Allocator();
+                    var __basicString0 = new global::Std.__1.BasicString(str, __allocator0);
+                    var __arg0 = __basicString0.__Instance;
+                    var __arg2 = ReferenceEquals(decl, null) ? global::System.IntPtr.Zero : decl.__Instance;
+                    __Internal.ctor_0((__Instance + __PointerAdjustment), __arg0, Class, __arg2);
+                    __basicString0.Dispose(false);
+                    __allocator0.Dispose();
+                }
+
                 public Statement(global::CppSharp.Parser.AST.Statement _0)
                 {
                     __Instance = Marshal.AllocHGlobal(sizeof(global::CppSharp.Parser.AST.Statement.__Internal));
@@ -6139,7 +6103,7 @@ namespace CppSharp
                     if (ReferenceEquals(_0, null))
                         throw new global::System.ArgumentNullException("_0", "Cannot be null because it is a C++ reference (&).");
                     var __arg0 = _0.__Instance;
-                    __Internal.cctor_0((__Instance + __PointerAdjustment), __arg0);
+                    __Internal.cctor_1((__Instance + __PointerAdjustment), __arg0);
                 }
 
                 public void Dispose()
@@ -6195,13 +6159,14 @@ namespace CppSharp
                 {
                     get
                     {
-                        var __ret = __Internal.GetString((__Instance + __PointerAdjustment));
-                        return Marshal.PtrToStringAnsi(__ret);
+                        return global::Std.__1.BasicString.__CreateInstance(((global::CppSharp.Parser.AST.Statement.__Internal*) __Instance)->@string).CStr();
                     }
 
                     set
                     {
-                        __Internal.SetString((__Instance + __PointerAdjustment), value);
+                        var __allocator0 = new global::Std.__1.Allocator();
+                        var __basicString0 = new global::Std.__1.BasicString(value, __allocator0);
+                        ((global::CppSharp.Parser.AST.Statement.__Internal*) __Instance)->@string = *(global::Std.__1.BasicString.__Internal*) __basicString0.__Instance;
                     }
                 }
             }
@@ -6218,12 +6183,17 @@ namespace CppSharp
                     internal global::System.IntPtr decl;
 
                     [FieldOffset(16)]
-                    internal global::Std.__1.BasicString.__Internal String;
+                    internal global::Std.__1.BasicString.__Internal @string;
+
+                    [SuppressUnmanagedCodeSecurity]
+                    [DllImport("CppSharp.CppParser", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
+                        EntryPoint="_ZN8CppSharp9CppParser3AST10ExpressionC2ERKNSt3__112basic_stringIcNS3_11char_traitsIcEENS3_9allocatorIcEEEENS1_14StatementClassEPNS1_11DeclarationE")]
+                    internal static extern void ctor_0(global::System.IntPtr instance, global::System.IntPtr str, global::CppSharp.Parser.AST.StatementClass Class, global::System.IntPtr decl);
 
                     [SuppressUnmanagedCodeSecurity]
                     [DllImport("CppSharp.CppParser", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
                         EntryPoint="_ZN8CppSharp9CppParser3AST10ExpressionC2ERKS2_")]
-                    internal static extern void cctor_0(global::System.IntPtr instance, global::System.IntPtr _0);
+                    internal static extern void cctor_1(global::System.IntPtr instance, global::System.IntPtr _0);
 
                     [SuppressUnmanagedCodeSecurity]
                     [DllImport("CppSharp.CppParser", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
@@ -6244,7 +6214,7 @@ namespace CppSharp
                 private static void* __CopyValue(global::CppSharp.Parser.AST.Expression.__Internal native)
                 {
                     var ret = Marshal.AllocHGlobal(sizeof(global::CppSharp.Parser.AST.Expression.__Internal));
-                    global::CppSharp.Parser.AST.Expression.__Internal.cctor_0(ret, new global::System.IntPtr(&native));
+                    global::CppSharp.Parser.AST.Expression.__Internal.cctor_1(ret, new global::System.IntPtr(&native));
                     return ret.ToPointer();
                 }
 
@@ -6264,6 +6234,21 @@ namespace CppSharp
                     __Instance = new global::System.IntPtr(native);
                 }
 
+                public Expression(string str, global::CppSharp.Parser.AST.StatementClass Class, global::CppSharp.Parser.AST.Declaration decl)
+                    : this((void*) null)
+                {
+                    __Instance = Marshal.AllocHGlobal(sizeof(global::CppSharp.Parser.AST.Expression.__Internal));
+                    __ownsNativeInstance = true;
+                    NativeToManagedMap[__Instance] = this;
+                    var __allocator0 = new global::Std.__1.Allocator();
+                    var __basicString0 = new global::Std.__1.BasicString(str, __allocator0);
+                    var __arg0 = __basicString0.__Instance;
+                    var __arg2 = ReferenceEquals(decl, null) ? global::System.IntPtr.Zero : decl.__Instance;
+                    __Internal.ctor_0((__Instance + __PointerAdjustment), __arg0, Class, __arg2);
+                    __basicString0.Dispose(false);
+                    __allocator0.Dispose();
+                }
+
                 public Expression(global::CppSharp.Parser.AST.Expression _0)
                     : this((void*) null)
                 {
@@ -6273,7 +6258,7 @@ namespace CppSharp
                     if (ReferenceEquals(_0, null))
                         throw new global::System.ArgumentNullException("_0", "Cannot be null because it is a C++ reference (&).");
                     var __arg0 = _0.__Instance;
-                    __Internal.cctor_0((__Instance + __PointerAdjustment), __arg0);
+                    __Internal.cctor_1((__Instance + __PointerAdjustment), __arg0);
                 }
 
                 public override void Dispose(bool disposing)
@@ -6302,7 +6287,7 @@ namespace CppSharp
                     internal global::System.IntPtr decl;
 
                     [FieldOffset(16)]
-                    internal global::Std.__1.BasicString.__Internal String;
+                    internal global::Std.__1.BasicString.__Internal @string;
 
                     [FieldOffset(40)]
                     internal global::System.IntPtr LHS;
@@ -6311,27 +6296,22 @@ namespace CppSharp
                     internal global::System.IntPtr RHS;
 
                     [FieldOffset(56)]
-                    internal global::Std.__1.BasicString.__Internal OpcodeStr;
+                    internal global::Std.__1.BasicString.__Internal opcodeStr;
+
+                    [SuppressUnmanagedCodeSecurity]
+                    [DllImport("CppSharp.CppParser", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
+                        EntryPoint="_ZN8CppSharp9CppParser3AST14BinaryOperatorC2ERKNSt3__112basic_stringIcNS3_11char_traitsIcEENS3_9allocatorIcEEEEPNS1_10ExpressionESD_SB_")]
+                    internal static extern void ctor_0(global::System.IntPtr instance, global::System.IntPtr str, global::System.IntPtr lhs, global::System.IntPtr rhs, global::System.IntPtr opcodeStr);
 
                     [SuppressUnmanagedCodeSecurity]
                     [DllImport("CppSharp.CppParser", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
                         EntryPoint="_ZN8CppSharp9CppParser3AST14BinaryOperatorC2ERKS2_")]
-                    internal static extern void cctor_0(global::System.IntPtr instance, global::System.IntPtr _0);
+                    internal static extern void cctor_1(global::System.IntPtr instance, global::System.IntPtr _0);
 
                     [SuppressUnmanagedCodeSecurity]
                     [DllImport("CppSharp.CppParser", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
                         EntryPoint="_ZN8CppSharp9CppParser3AST14BinaryOperatorD2Ev")]
                     internal static extern void dtor_0(global::System.IntPtr instance);
-
-                    [SuppressUnmanagedCodeSecurity]
-                    [DllImport("CppSharp.CppParser", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
-                        EntryPoint="_ZN8CppSharp9CppParser3AST14BinaryOperator12getOpcodeStrEv")]
-                    internal static extern global::System.IntPtr GetOpcodeStr(global::System.IntPtr instance);
-
-                    [SuppressUnmanagedCodeSecurity]
-                    [DllImport("CppSharp.CppParser", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
-                        EntryPoint="_ZN8CppSharp9CppParser3AST14BinaryOperator12setOpcodeStrEPKc")]
-                    internal static extern void SetOpcodeStr(global::System.IntPtr instance, [MarshalAs(UnmanagedType.LPStr)] string s);
                 }
 
                 internal static new global::CppSharp.Parser.AST.BinaryOperator __CreateInstance(global::System.IntPtr native, bool skipVTables = false)
@@ -6347,7 +6327,7 @@ namespace CppSharp
                 private static void* __CopyValue(global::CppSharp.Parser.AST.BinaryOperator.__Internal native)
                 {
                     var ret = Marshal.AllocHGlobal(sizeof(global::CppSharp.Parser.AST.BinaryOperator.__Internal));
-                    global::CppSharp.Parser.AST.BinaryOperator.__Internal.cctor_0(ret, new global::System.IntPtr(&native));
+                    global::CppSharp.Parser.AST.BinaryOperator.__Internal.cctor_1(ret, new global::System.IntPtr(&native));
                     return ret.ToPointer();
                 }
 
@@ -6367,6 +6347,27 @@ namespace CppSharp
                     __Instance = new global::System.IntPtr(native);
                 }
 
+                public BinaryOperator(string str, global::CppSharp.Parser.AST.Expression lhs, global::CppSharp.Parser.AST.Expression rhs, string opcodeStr)
+                    : this((void*) null)
+                {
+                    __Instance = Marshal.AllocHGlobal(sizeof(global::CppSharp.Parser.AST.BinaryOperator.__Internal));
+                    __ownsNativeInstance = true;
+                    NativeToManagedMap[__Instance] = this;
+                    var __allocator0 = new global::Std.__1.Allocator();
+                    var __basicString0 = new global::Std.__1.BasicString(str, __allocator0);
+                    var __arg0 = __basicString0.__Instance;
+                    var __arg1 = ReferenceEquals(lhs, null) ? global::System.IntPtr.Zero : lhs.__Instance;
+                    var __arg2 = ReferenceEquals(rhs, null) ? global::System.IntPtr.Zero : rhs.__Instance;
+                    var __allocator3 = new global::Std.__1.Allocator();
+                    var __basicString3 = new global::Std.__1.BasicString(opcodeStr, __allocator3);
+                    var __arg3 = __basicString3.__Instance;
+                    __Internal.ctor_0((__Instance + __PointerAdjustment), __arg0, __arg1, __arg2, __arg3);
+                    __basicString0.Dispose(false);
+                    __allocator0.Dispose();
+                    __basicString3.Dispose(false);
+                    __allocator3.Dispose();
+                }
+
                 public BinaryOperator(global::CppSharp.Parser.AST.BinaryOperator _0)
                     : this((void*) null)
                 {
@@ -6376,7 +6377,7 @@ namespace CppSharp
                     if (ReferenceEquals(_0, null))
                         throw new global::System.ArgumentNullException("_0", "Cannot be null because it is a C++ reference (&).");
                     var __arg0 = _0.__Instance;
-                    __Internal.cctor_0((__Instance + __PointerAdjustment), __arg0);
+                    __Internal.cctor_1((__Instance + __PointerAdjustment), __arg0);
                 }
 
                 public override void Dispose(bool disposing)
@@ -6432,13 +6433,14 @@ namespace CppSharp
                 {
                     get
                     {
-                        var __ret = __Internal.GetOpcodeStr((__Instance + __PointerAdjustment));
-                        return Marshal.PtrToStringAnsi(__ret);
+                        return global::Std.__1.BasicString.__CreateInstance(((global::CppSharp.Parser.AST.BinaryOperator.__Internal*) __Instance)->opcodeStr).CStr();
                     }
 
                     set
                     {
-                        __Internal.SetOpcodeStr((__Instance + __PointerAdjustment), value);
+                        var __allocator0 = new global::Std.__1.Allocator();
+                        var __basicString0 = new global::Std.__1.BasicString(value, __allocator0);
+                        ((global::CppSharp.Parser.AST.BinaryOperator.__Internal*) __Instance)->opcodeStr = *(global::Std.__1.BasicString.__Internal*) __basicString0.__Instance;
                     }
                 }
             }
@@ -6455,15 +6457,20 @@ namespace CppSharp
                     internal global::System.IntPtr decl;
 
                     [FieldOffset(16)]
-                    internal global::Std.__1.BasicString.__Internal String;
+                    internal global::Std.__1.BasicString.__Internal @string;
 
                     [FieldOffset(40)]
                     internal global::Std.__1.Vector.__Internal Arguments;
 
                     [SuppressUnmanagedCodeSecurity]
                     [DllImport("CppSharp.CppParser", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
+                        EntryPoint="_ZN8CppSharp9CppParser3AST8CallExprC2ERKNSt3__112basic_stringIcNS3_11char_traitsIcEENS3_9allocatorIcEEEEPNS1_11DeclarationE")]
+                    internal static extern void ctor_0(global::System.IntPtr instance, global::System.IntPtr str, global::System.IntPtr decl);
+
+                    [SuppressUnmanagedCodeSecurity]
+                    [DllImport("CppSharp.CppParser", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
                         EntryPoint="_ZN8CppSharp9CppParser3AST8CallExprC2ERKS2_")]
-                    internal static extern void cctor_0(global::System.IntPtr instance, global::System.IntPtr _0);
+                    internal static extern void cctor_1(global::System.IntPtr instance, global::System.IntPtr _0);
 
                     [SuppressUnmanagedCodeSecurity]
                     [DllImport("CppSharp.CppParser", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
@@ -6504,7 +6511,7 @@ namespace CppSharp
                 private static void* __CopyValue(global::CppSharp.Parser.AST.CallExpr.__Internal native)
                 {
                     var ret = Marshal.AllocHGlobal(sizeof(global::CppSharp.Parser.AST.CallExpr.__Internal));
-                    global::CppSharp.Parser.AST.CallExpr.__Internal.cctor_0(ret, new global::System.IntPtr(&native));
+                    global::CppSharp.Parser.AST.CallExpr.__Internal.cctor_1(ret, new global::System.IntPtr(&native));
                     return ret.ToPointer();
                 }
 
@@ -6524,6 +6531,21 @@ namespace CppSharp
                     __Instance = new global::System.IntPtr(native);
                 }
 
+                public CallExpr(string str, global::CppSharp.Parser.AST.Declaration decl)
+                    : this((void*) null)
+                {
+                    __Instance = Marshal.AllocHGlobal(sizeof(global::CppSharp.Parser.AST.CallExpr.__Internal));
+                    __ownsNativeInstance = true;
+                    NativeToManagedMap[__Instance] = this;
+                    var __allocator0 = new global::Std.__1.Allocator();
+                    var __basicString0 = new global::Std.__1.BasicString(str, __allocator0);
+                    var __arg0 = __basicString0.__Instance;
+                    var __arg1 = ReferenceEquals(decl, null) ? global::System.IntPtr.Zero : decl.__Instance;
+                    __Internal.ctor_0((__Instance + __PointerAdjustment), __arg0, __arg1);
+                    __basicString0.Dispose(false);
+                    __allocator0.Dispose();
+                }
+
                 public CallExpr(global::CppSharp.Parser.AST.CallExpr _0)
                     : this((void*) null)
                 {
@@ -6533,7 +6555,7 @@ namespace CppSharp
                     if (ReferenceEquals(_0, null))
                         throw new global::System.ArgumentNullException("_0", "Cannot be null because it is a C++ reference (&).");
                     var __arg0 = _0.__Instance;
-                    __Internal.cctor_0((__Instance + __PointerAdjustment), __arg0);
+                    __Internal.cctor_1((__Instance + __PointerAdjustment), __arg0);
                 }
 
                 public override void Dispose(bool disposing)
@@ -6595,15 +6617,20 @@ namespace CppSharp
                     internal global::System.IntPtr decl;
 
                     [FieldOffset(16)]
-                    internal global::Std.__1.BasicString.__Internal String;
+                    internal global::Std.__1.BasicString.__Internal @string;
 
                     [FieldOffset(40)]
                     internal global::Std.__1.Vector.__Internal Arguments;
 
                     [SuppressUnmanagedCodeSecurity]
                     [DllImport("CppSharp.CppParser", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
+                        EntryPoint="_ZN8CppSharp9CppParser3AST16CXXConstructExprC2ERKNSt3__112basic_stringIcNS3_11char_traitsIcEENS3_9allocatorIcEEEEPNS1_11DeclarationE")]
+                    internal static extern void ctor_0(global::System.IntPtr instance, global::System.IntPtr str, global::System.IntPtr decl);
+
+                    [SuppressUnmanagedCodeSecurity]
+                    [DllImport("CppSharp.CppParser", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
                         EntryPoint="_ZN8CppSharp9CppParser3AST16CXXConstructExprC2ERKS2_")]
-                    internal static extern void cctor_0(global::System.IntPtr instance, global::System.IntPtr _0);
+                    internal static extern void cctor_1(global::System.IntPtr instance, global::System.IntPtr _0);
 
                     [SuppressUnmanagedCodeSecurity]
                     [DllImport("CppSharp.CppParser", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
@@ -6644,7 +6671,7 @@ namespace CppSharp
                 private static void* __CopyValue(global::CppSharp.Parser.AST.CXXConstructExpr.__Internal native)
                 {
                     var ret = Marshal.AllocHGlobal(sizeof(global::CppSharp.Parser.AST.CXXConstructExpr.__Internal));
-                    global::CppSharp.Parser.AST.CXXConstructExpr.__Internal.cctor_0(ret, new global::System.IntPtr(&native));
+                    global::CppSharp.Parser.AST.CXXConstructExpr.__Internal.cctor_1(ret, new global::System.IntPtr(&native));
                     return ret.ToPointer();
                 }
 
@@ -6664,6 +6691,21 @@ namespace CppSharp
                     __Instance = new global::System.IntPtr(native);
                 }
 
+                public CXXConstructExpr(string str, global::CppSharp.Parser.AST.Declaration decl)
+                    : this((void*) null)
+                {
+                    __Instance = Marshal.AllocHGlobal(sizeof(global::CppSharp.Parser.AST.CXXConstructExpr.__Internal));
+                    __ownsNativeInstance = true;
+                    NativeToManagedMap[__Instance] = this;
+                    var __allocator0 = new global::Std.__1.Allocator();
+                    var __basicString0 = new global::Std.__1.BasicString(str, __allocator0);
+                    var __arg0 = __basicString0.__Instance;
+                    var __arg1 = ReferenceEquals(decl, null) ? global::System.IntPtr.Zero : decl.__Instance;
+                    __Internal.ctor_0((__Instance + __PointerAdjustment), __arg0, __arg1);
+                    __basicString0.Dispose(false);
+                    __allocator0.Dispose();
+                }
+
                 public CXXConstructExpr(global::CppSharp.Parser.AST.CXXConstructExpr _0)
                     : this((void*) null)
                 {
@@ -6673,7 +6715,7 @@ namespace CppSharp
                     if (ReferenceEquals(_0, null))
                         throw new global::System.ArgumentNullException("_0", "Cannot be null because it is a C++ reference (&).");
                     var __arg0 = _0.__Instance;
-                    __Internal.cctor_0((__Instance + __PointerAdjustment), __arg0);
+                    __Internal.cctor_1((__Instance + __PointerAdjustment), __arg0);
                 }
 
                 public override void Dispose(bool disposing)
@@ -6747,13 +6789,13 @@ namespace CppSharp
                     internal int lineNumberEnd;
 
                     [FieldOffset(32)]
-                    internal global::Std.__1.BasicString.__Internal Name;
+                    internal global::Std.__1.BasicString.__Internal name;
 
                     [FieldOffset(56)]
                     internal global::Std.__1.BasicString.__Internal USR;
 
                     [FieldOffset(80)]
-                    internal global::Std.__1.BasicString.__Internal DebugText;
+                    internal global::Std.__1.BasicString.__Internal debugText;
 
                     [FieldOffset(104)]
                     internal byte isIncomplete;
@@ -6975,13 +7017,13 @@ namespace CppSharp
                     internal int lineNumberEnd;
 
                     [FieldOffset(32)]
-                    internal global::Std.__1.BasicString.__Internal Name;
+                    internal global::Std.__1.BasicString.__Internal name;
 
                     [FieldOffset(56)]
                     internal global::Std.__1.BasicString.__Internal USR;
 
                     [FieldOffset(80)]
-                    internal global::Std.__1.BasicString.__Internal DebugText;
+                    internal global::Std.__1.BasicString.__Internal debugText;
 
                     [FieldOffset(104)]
                     internal byte isIncomplete;
@@ -7041,13 +7083,13 @@ namespace CppSharp
                     internal global::CppSharp.Parser.AST.CXXOperatorKind operatorKind;
 
                     [FieldOffset(224)]
-                    internal global::Std.__1.BasicString.__Internal Mangled;
+                    internal global::Std.__1.BasicString.__Internal mangled;
 
                     [FieldOffset(248)]
-                    internal global::Std.__1.BasicString.__Internal Signature;
+                    internal global::Std.__1.BasicString.__Internal signature;
 
                     [FieldOffset(272)]
-                    internal global::Std.__1.BasicString.__Internal Body;
+                    internal global::Std.__1.BasicString.__Internal body;
 
                     [FieldOffset(296)]
                     internal global::CppSharp.Parser.AST.CallingConvention callingConvention;
@@ -7093,36 +7135,6 @@ namespace CppSharp
                     [DllImport("CppSharp.CppParser", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
                         EntryPoint="_ZN8CppSharp9CppParser3AST8Function15clearParametersEv")]
                     internal static extern void ClearParameters_0(global::System.IntPtr instance);
-
-                    [SuppressUnmanagedCodeSecurity]
-                    [DllImport("CppSharp.CppParser", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
-                        EntryPoint="_ZN8CppSharp9CppParser3AST8Function10getMangledEv")]
-                    internal static extern global::System.IntPtr GetMangled(global::System.IntPtr instance);
-
-                    [SuppressUnmanagedCodeSecurity]
-                    [DllImport("CppSharp.CppParser", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
-                        EntryPoint="_ZN8CppSharp9CppParser3AST8Function10setMangledEPKc")]
-                    internal static extern void SetMangled(global::System.IntPtr instance, [MarshalAs(UnmanagedType.LPStr)] string s);
-
-                    [SuppressUnmanagedCodeSecurity]
-                    [DllImport("CppSharp.CppParser", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
-                        EntryPoint="_ZN8CppSharp9CppParser3AST8Function12getSignatureEv")]
-                    internal static extern global::System.IntPtr GetSignature(global::System.IntPtr instance);
-
-                    [SuppressUnmanagedCodeSecurity]
-                    [DllImport("CppSharp.CppParser", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
-                        EntryPoint="_ZN8CppSharp9CppParser3AST8Function12setSignatureEPKc")]
-                    internal static extern void SetSignature(global::System.IntPtr instance, [MarshalAs(UnmanagedType.LPStr)] string s);
-
-                    [SuppressUnmanagedCodeSecurity]
-                    [DllImport("CppSharp.CppParser", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
-                        EntryPoint="_ZN8CppSharp9CppParser3AST8Function7getBodyEv")]
-                    internal static extern global::System.IntPtr GetBody(global::System.IntPtr instance);
-
-                    [SuppressUnmanagedCodeSecurity]
-                    [DllImport("CppSharp.CppParser", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
-                        EntryPoint="_ZN8CppSharp9CppParser3AST8Function7setBodyEPKc")]
-                    internal static extern void SetBody(global::System.IntPtr instance, [MarshalAs(UnmanagedType.LPStr)] string s);
 
                     [SuppressUnmanagedCodeSecurity]
                     [DllImport("CppSharp.CppParser", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
@@ -7351,6 +7363,51 @@ namespace CppSharp
                     }
                 }
 
+                public string Mangled
+                {
+                    get
+                    {
+                        return global::Std.__1.BasicString.__CreateInstance(((global::CppSharp.Parser.AST.Function.__Internal*) __Instance)->mangled).CStr();
+                    }
+
+                    set
+                    {
+                        var __allocator0 = new global::Std.__1.Allocator();
+                        var __basicString0 = new global::Std.__1.BasicString(value, __allocator0);
+                        ((global::CppSharp.Parser.AST.Function.__Internal*) __Instance)->mangled = *(global::Std.__1.BasicString.__Internal*) __basicString0.__Instance;
+                    }
+                }
+
+                public string Signature
+                {
+                    get
+                    {
+                        return global::Std.__1.BasicString.__CreateInstance(((global::CppSharp.Parser.AST.Function.__Internal*) __Instance)->signature).CStr();
+                    }
+
+                    set
+                    {
+                        var __allocator0 = new global::Std.__1.Allocator();
+                        var __basicString0 = new global::Std.__1.BasicString(value, __allocator0);
+                        ((global::CppSharp.Parser.AST.Function.__Internal*) __Instance)->signature = *(global::Std.__1.BasicString.__Internal*) __basicString0.__Instance;
+                    }
+                }
+
+                public string Body
+                {
+                    get
+                    {
+                        return global::Std.__1.BasicString.__CreateInstance(((global::CppSharp.Parser.AST.Function.__Internal*) __Instance)->body).CStr();
+                    }
+
+                    set
+                    {
+                        var __allocator0 = new global::Std.__1.Allocator();
+                        var __basicString0 = new global::Std.__1.BasicString(value, __allocator0);
+                        ((global::CppSharp.Parser.AST.Function.__Internal*) __Instance)->body = *(global::Std.__1.BasicString.__Internal*) __basicString0.__Instance;
+                    }
+                }
+
                 public global::CppSharp.Parser.AST.CallingConvention CallingConvention
                 {
                     get
@@ -7413,48 +7470,6 @@ namespace CppSharp
                     }
                 }
 
-                public string Mangled
-                {
-                    get
-                    {
-                        var __ret = __Internal.GetMangled((__Instance + __PointerAdjustment));
-                        return Marshal.PtrToStringAnsi(__ret);
-                    }
-
-                    set
-                    {
-                        __Internal.SetMangled((__Instance + __PointerAdjustment), value);
-                    }
-                }
-
-                public string Signature
-                {
-                    get
-                    {
-                        var __ret = __Internal.GetSignature((__Instance + __PointerAdjustment));
-                        return Marshal.PtrToStringAnsi(__ret);
-                    }
-
-                    set
-                    {
-                        __Internal.SetSignature((__Instance + __PointerAdjustment), value);
-                    }
-                }
-
-                public string Body
-                {
-                    get
-                    {
-                        var __ret = __Internal.GetBody((__Instance + __PointerAdjustment));
-                        return Marshal.PtrToStringAnsi(__ret);
-                    }
-
-                    set
-                    {
-                        __Internal.SetBody((__Instance + __PointerAdjustment), value);
-                    }
-                }
-
                 public uint ParametersCount
                 {
                     get
@@ -7489,13 +7504,13 @@ namespace CppSharp
                     internal int lineNumberEnd;
 
                     [FieldOffset(32)]
-                    internal global::Std.__1.BasicString.__Internal Name;
+                    internal global::Std.__1.BasicString.__Internal name;
 
                     [FieldOffset(56)]
                     internal global::Std.__1.BasicString.__Internal USR;
 
                     [FieldOffset(80)]
-                    internal global::Std.__1.BasicString.__Internal DebugText;
+                    internal global::Std.__1.BasicString.__Internal debugText;
 
                     [FieldOffset(104)]
                     internal byte isIncomplete;
@@ -7555,13 +7570,13 @@ namespace CppSharp
                     internal global::CppSharp.Parser.AST.CXXOperatorKind operatorKind;
 
                     [FieldOffset(224)]
-                    internal global::Std.__1.BasicString.__Internal Mangled;
+                    internal global::Std.__1.BasicString.__Internal mangled;
 
                     [FieldOffset(248)]
-                    internal global::Std.__1.BasicString.__Internal Signature;
+                    internal global::Std.__1.BasicString.__Internal signature;
 
                     [FieldOffset(272)]
-                    internal global::Std.__1.BasicString.__Internal Body;
+                    internal global::Std.__1.BasicString.__Internal body;
 
                     [FieldOffset(296)]
                     internal global::CppSharp.Parser.AST.CallingConvention callingConvention;
@@ -7862,13 +7877,13 @@ namespace CppSharp
                     internal int lineNumberEnd;
 
                     [FieldOffset(32)]
-                    internal global::Std.__1.BasicString.__Internal Name;
+                    internal global::Std.__1.BasicString.__Internal name;
 
                     [FieldOffset(56)]
                     internal global::Std.__1.BasicString.__Internal USR;
 
                     [FieldOffset(80)]
-                    internal global::Std.__1.BasicString.__Internal DebugText;
+                    internal global::Std.__1.BasicString.__Internal debugText;
 
                     [FieldOffset(104)]
                     internal byte isIncomplete;
@@ -7974,6 +7989,11 @@ namespace CppSharp
 
                     [SuppressUnmanagedCodeSecurity]
                     [DllImport("CppSharp.CppParser", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
+                        EntryPoint="_ZN8CppSharp9CppParser3AST11Enumeration14FindItemByNameERKNSt3__112basic_stringIcNS3_11char_traitsIcEENS3_9allocatorIcEEEE")]
+                    internal static extern global::System.IntPtr FindItemByName_0(global::System.IntPtr instance, global::System.IntPtr Name);
+
+                    [SuppressUnmanagedCodeSecurity]
+                    [DllImport("CppSharp.CppParser", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
                         EntryPoint="_ZN8CppSharp9CppParser3AST11Enumeration13getItemsCountEv")]
                     internal static extern uint GetItemsCount(global::System.IntPtr instance);
                 }
@@ -8010,13 +8030,13 @@ namespace CppSharp
                         internal int lineNumberEnd;
 
                         [FieldOffset(32)]
-                        internal global::Std.__1.BasicString.__Internal Name;
+                        internal global::Std.__1.BasicString.__Internal name;
 
                         [FieldOffset(56)]
                         internal global::Std.__1.BasicString.__Internal USR;
 
                         [FieldOffset(80)]
-                        internal global::Std.__1.BasicString.__Internal DebugText;
+                        internal global::Std.__1.BasicString.__Internal debugText;
 
                         [FieldOffset(104)]
                         internal byte isIncomplete;
@@ -8046,7 +8066,7 @@ namespace CppSharp
                         internal global::System.IntPtr comment;
 
                         [FieldOffset(192)]
-                        internal global::Std.__1.BasicString.__Internal Expression;
+                        internal global::Std.__1.BasicString.__Internal expression;
 
                         [FieldOffset(216)]
                         internal ulong value;
@@ -8065,16 +8085,6 @@ namespace CppSharp
                         [DllImport("CppSharp.CppParser", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
                             EntryPoint="_ZN8CppSharp9CppParser3AST11Enumeration4ItemD2Ev")]
                         internal static extern void dtor_0(global::System.IntPtr instance);
-
-                        [SuppressUnmanagedCodeSecurity]
-                        [DllImport("CppSharp.CppParser", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
-                            EntryPoint="_ZN8CppSharp9CppParser3AST11Enumeration4Item13getExpressionEv")]
-                        internal static extern global::System.IntPtr GetExpression(global::System.IntPtr instance);
-
-                        [SuppressUnmanagedCodeSecurity]
-                        [DllImport("CppSharp.CppParser", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
-                            EntryPoint="_ZN8CppSharp9CppParser3AST11Enumeration4Item13setExpressionEPKc")]
-                        internal static extern void SetExpression(global::System.IntPtr instance, [MarshalAs(UnmanagedType.LPStr)] string s);
                     }
 
                     internal static new global::CppSharp.Parser.AST.Enumeration.Item __CreateInstance(global::System.IntPtr native, bool skipVTables = false)
@@ -8144,6 +8154,21 @@ namespace CppSharp
                         __Instance = IntPtr.Zero;
                     }
 
+                    public string Expression
+                    {
+                        get
+                        {
+                            return global::Std.__1.BasicString.__CreateInstance(((global::CppSharp.Parser.AST.Enumeration.Item.__Internal*) __Instance)->expression).CStr();
+                        }
+
+                        set
+                        {
+                            var __allocator0 = new global::Std.__1.Allocator();
+                            var __basicString0 = new global::Std.__1.BasicString(value, __allocator0);
+                            ((global::CppSharp.Parser.AST.Enumeration.Item.__Internal*) __Instance)->expression = *(global::Std.__1.BasicString.__Internal*) __basicString0.__Instance;
+                        }
+                    }
+
                     public ulong Value
                     {
                         get
@@ -8154,20 +8179,6 @@ namespace CppSharp
                         set
                         {
                             ((global::CppSharp.Parser.AST.Enumeration.Item.__Internal*) __Instance)->value = value;
-                        }
-                    }
-
-                    public string Expression
-                    {
-                        get
-                        {
-                            var __ret = __Internal.GetExpression((__Instance + __PointerAdjustment));
-                            return Marshal.PtrToStringAnsi(__ret);
-                        }
-
-                        set
-                        {
-                            __Internal.SetExpression((__Instance + __PointerAdjustment), value);
                         }
                     }
                 }
@@ -8263,6 +8274,22 @@ namespace CppSharp
                     __Internal.ClearItems_0((__Instance + __PointerAdjustment));
                 }
 
+                public global::CppSharp.Parser.AST.Enumeration.Item FindItemByName(string Name)
+                {
+                    var __allocator0 = new global::Std.__1.Allocator();
+                    var __basicString0 = new global::Std.__1.BasicString(Name, __allocator0);
+                    var __arg0 = __basicString0.__Instance;
+                    var __ret = __Internal.FindItemByName_0((__Instance + __PointerAdjustment), __arg0);
+                    __basicString0.Dispose(false);
+                    __allocator0.Dispose();
+                    global::CppSharp.Parser.AST.Enumeration.Item __result0;
+                    if (__ret == IntPtr.Zero) __result0 = null;
+                    else if (global::CppSharp.Parser.AST.Enumeration.Item.NativeToManagedMap.ContainsKey(__ret))
+                        __result0 = (global::CppSharp.Parser.AST.Enumeration.Item) global::CppSharp.Parser.AST.Enumeration.Item.NativeToManagedMap[__ret];
+                    else __result0 = global::CppSharp.Parser.AST.Enumeration.Item.__CreateInstance(__ret);
+                    return __result0;
+                }
+
                 public global::CppSharp.Parser.AST.Enumeration.EnumModifiers Modifiers
                 {
                     get
@@ -8346,13 +8373,13 @@ namespace CppSharp
                     internal int lineNumberEnd;
 
                     [FieldOffset(32)]
-                    internal global::Std.__1.BasicString.__Internal Name;
+                    internal global::Std.__1.BasicString.__Internal name;
 
                     [FieldOffset(56)]
                     internal global::Std.__1.BasicString.__Internal USR;
 
                     [FieldOffset(80)]
-                    internal global::Std.__1.BasicString.__Internal DebugText;
+                    internal global::Std.__1.BasicString.__Internal debugText;
 
                     [FieldOffset(104)]
                     internal byte isIncomplete;
@@ -8382,7 +8409,7 @@ namespace CppSharp
                     internal global::System.IntPtr comment;
 
                     [FieldOffset(192)]
-                    internal global::Std.__1.BasicString.__Internal Mangled;
+                    internal global::Std.__1.BasicString.__Internal mangled;
 
                     [FieldOffset(216)]
                     internal global::CppSharp.Parser.AST.QualifiedType.__Internal qualifiedType;
@@ -8401,16 +8428,6 @@ namespace CppSharp
                     [DllImport("CppSharp.CppParser", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
                         EntryPoint="_ZN8CppSharp9CppParser3AST8VariableD2Ev")]
                     internal static extern void dtor_0(global::System.IntPtr instance);
-
-                    [SuppressUnmanagedCodeSecurity]
-                    [DllImport("CppSharp.CppParser", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
-                        EntryPoint="_ZN8CppSharp9CppParser3AST8Variable10getMangledEv")]
-                    internal static extern global::System.IntPtr GetMangled(global::System.IntPtr instance);
-
-                    [SuppressUnmanagedCodeSecurity]
-                    [DllImport("CppSharp.CppParser", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
-                        EntryPoint="_ZN8CppSharp9CppParser3AST8Variable10setMangledEPKc")]
-                    internal static extern void SetMangled(global::System.IntPtr instance, [MarshalAs(UnmanagedType.LPStr)] string s);
                 }
 
                 internal static new global::CppSharp.Parser.AST.Variable __CreateInstance(global::System.IntPtr native, bool skipVTables = false)
@@ -8480,6 +8497,21 @@ namespace CppSharp
                     __Instance = IntPtr.Zero;
                 }
 
+                public string Mangled
+                {
+                    get
+                    {
+                        return global::Std.__1.BasicString.__CreateInstance(((global::CppSharp.Parser.AST.Variable.__Internal*) __Instance)->mangled).CStr();
+                    }
+
+                    set
+                    {
+                        var __allocator0 = new global::Std.__1.Allocator();
+                        var __basicString0 = new global::Std.__1.BasicString(value, __allocator0);
+                        ((global::CppSharp.Parser.AST.Variable.__Internal*) __Instance)->mangled = *(global::Std.__1.BasicString.__Internal*) __basicString0.__Instance;
+                    }
+                }
+
                 public global::CppSharp.Parser.AST.QualifiedType QualifiedType
                 {
                     get
@@ -8490,20 +8522,6 @@ namespace CppSharp
                     set
                     {
                         ((global::CppSharp.Parser.AST.Variable.__Internal*) __Instance)->qualifiedType = ReferenceEquals(value, null) ? new global::CppSharp.Parser.AST.QualifiedType.__Internal() : *(global::CppSharp.Parser.AST.QualifiedType.__Internal*) value.__Instance;
-                    }
-                }
-
-                public string Mangled
-                {
-                    get
-                    {
-                        var __ret = __Internal.GetMangled((__Instance + __PointerAdjustment));
-                        return Marshal.PtrToStringAnsi(__ret);
-                    }
-
-                    set
-                    {
-                        __Internal.SetMangled((__Instance + __PointerAdjustment), value);
                     }
                 }
             }
@@ -8689,13 +8707,13 @@ namespace CppSharp
                     internal int lineNumberEnd;
 
                     [FieldOffset(32)]
-                    internal global::Std.__1.BasicString.__Internal Name;
+                    internal global::Std.__1.BasicString.__Internal name;
 
                     [FieldOffset(56)]
                     internal global::Std.__1.BasicString.__Internal USR;
 
                     [FieldOffset(80)]
-                    internal global::Std.__1.BasicString.__Internal DebugText;
+                    internal global::Std.__1.BasicString.__Internal debugText;
 
                     [FieldOffset(104)]
                     internal byte isIncomplete;
@@ -8901,13 +8919,13 @@ namespace CppSharp
                     internal int lineNumberEnd;
 
                     [FieldOffset(32)]
-                    internal global::Std.__1.BasicString.__Internal Name;
+                    internal global::Std.__1.BasicString.__Internal name;
 
                     [FieldOffset(56)]
                     internal global::Std.__1.BasicString.__Internal USR;
 
                     [FieldOffset(80)]
-                    internal global::Std.__1.BasicString.__Internal DebugText;
+                    internal global::Std.__1.BasicString.__Internal debugText;
 
                     [FieldOffset(104)]
                     internal byte isIncomplete;
@@ -9044,13 +9062,13 @@ namespace CppSharp
                     internal int lineNumberEnd;
 
                     [FieldOffset(32)]
-                    internal global::Std.__1.BasicString.__Internal Name;
+                    internal global::Std.__1.BasicString.__Internal name;
 
                     [FieldOffset(56)]
                     internal global::Std.__1.BasicString.__Internal USR;
 
                     [FieldOffset(80)]
-                    internal global::Std.__1.BasicString.__Internal DebugText;
+                    internal global::Std.__1.BasicString.__Internal debugText;
 
                     [FieldOffset(104)]
                     internal byte isIncomplete;
@@ -9625,13 +9643,13 @@ namespace CppSharp
                     internal int lineNumberEnd;
 
                     [FieldOffset(32)]
-                    internal global::Std.__1.BasicString.__Internal Name;
+                    internal global::Std.__1.BasicString.__Internal name;
 
                     [FieldOffset(56)]
                     internal global::Std.__1.BasicString.__Internal USR;
 
                     [FieldOffset(80)]
-                    internal global::Std.__1.BasicString.__Internal DebugText;
+                    internal global::Std.__1.BasicString.__Internal debugText;
 
                     [FieldOffset(104)]
                     internal byte isIncomplete;
@@ -9864,13 +9882,13 @@ namespace CppSharp
                     internal int lineNumberEnd;
 
                     [FieldOffset(32)]
-                    internal global::Std.__1.BasicString.__Internal Name;
+                    internal global::Std.__1.BasicString.__Internal name;
 
                     [FieldOffset(56)]
                     internal global::Std.__1.BasicString.__Internal USR;
 
                     [FieldOffset(80)]
-                    internal global::Std.__1.BasicString.__Internal DebugText;
+                    internal global::Std.__1.BasicString.__Internal debugText;
 
                     [FieldOffset(104)]
                     internal byte isIncomplete;
@@ -10013,13 +10031,13 @@ namespace CppSharp
                     internal int lineNumberEnd;
 
                     [FieldOffset(32)]
-                    internal global::Std.__1.BasicString.__Internal Name;
+                    internal global::Std.__1.BasicString.__Internal name;
 
                     [FieldOffset(56)]
                     internal global::Std.__1.BasicString.__Internal USR;
 
                     [FieldOffset(80)]
-                    internal global::Std.__1.BasicString.__Internal DebugText;
+                    internal global::Std.__1.BasicString.__Internal debugText;
 
                     [FieldOffset(104)]
                     internal byte isIncomplete;
@@ -10209,13 +10227,13 @@ namespace CppSharp
                     internal int lineNumberEnd;
 
                     [FieldOffset(32)]
-                    internal global::Std.__1.BasicString.__Internal Name;
+                    internal global::Std.__1.BasicString.__Internal name;
 
                     [FieldOffset(56)]
                     internal global::Std.__1.BasicString.__Internal USR;
 
                     [FieldOffset(80)]
-                    internal global::Std.__1.BasicString.__Internal DebugText;
+                    internal global::Std.__1.BasicString.__Internal debugText;
 
                     [FieldOffset(104)]
                     internal byte isIncomplete;
@@ -10406,13 +10424,13 @@ namespace CppSharp
                     internal int lineNumberEnd;
 
                     [FieldOffset(32)]
-                    internal global::Std.__1.BasicString.__Internal Name;
+                    internal global::Std.__1.BasicString.__Internal name;
 
                     [FieldOffset(56)]
                     internal global::Std.__1.BasicString.__Internal USR;
 
                     [FieldOffset(80)]
-                    internal global::Std.__1.BasicString.__Internal DebugText;
+                    internal global::Std.__1.BasicString.__Internal debugText;
 
                     [FieldOffset(104)]
                     internal byte isIncomplete;
@@ -10574,13 +10592,13 @@ namespace CppSharp
                     internal int lineNumberEnd;
 
                     [FieldOffset(32)]
-                    internal global::Std.__1.BasicString.__Internal Name;
+                    internal global::Std.__1.BasicString.__Internal name;
 
                     [FieldOffset(56)]
                     internal global::Std.__1.BasicString.__Internal USR;
 
                     [FieldOffset(80)]
-                    internal global::Std.__1.BasicString.__Internal DebugText;
+                    internal global::Std.__1.BasicString.__Internal debugText;
 
                     [FieldOffset(104)]
                     internal byte isIncomplete;
@@ -10795,13 +10813,13 @@ namespace CppSharp
                     internal int lineNumberEnd;
 
                     [FieldOffset(32)]
-                    internal global::Std.__1.BasicString.__Internal Name;
+                    internal global::Std.__1.BasicString.__Internal name;
 
                     [FieldOffset(56)]
                     internal global::Std.__1.BasicString.__Internal USR;
 
                     [FieldOffset(80)]
-                    internal global::Std.__1.BasicString.__Internal DebugText;
+                    internal global::Std.__1.BasicString.__Internal debugText;
 
                     [FieldOffset(104)]
                     internal byte isIncomplete;
@@ -10868,6 +10886,16 @@ namespace CppSharp
                     [DllImport("CppSharp.CppParser", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
                         EntryPoint="_ZN8CppSharp9CppParser3AST13ClassTemplate20clearSpecializationsEv")]
                     internal static extern void ClearSpecializations_0(global::System.IntPtr instance);
+
+                    [SuppressUnmanagedCodeSecurity]
+                    [DllImport("CppSharp.CppParser", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
+                        EntryPoint="_ZN8CppSharp9CppParser3AST13ClassTemplate18FindSpecializationERKNSt3__112basic_stringIcNS3_11char_traitsIcEENS3_9allocatorIcEEEE")]
+                    internal static extern global::System.IntPtr FindSpecialization_0(global::System.IntPtr instance, global::System.IntPtr usr);
+
+                    [SuppressUnmanagedCodeSecurity]
+                    [DllImport("CppSharp.CppParser", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
+                        EntryPoint="_ZN8CppSharp9CppParser3AST13ClassTemplate25FindPartialSpecializationERKNSt3__112basic_stringIcNS3_11char_traitsIcEENS3_9allocatorIcEEEE")]
+                    internal static extern global::System.IntPtr FindPartialSpecialization_0(global::System.IntPtr instance, global::System.IntPtr usr);
 
                     [SuppressUnmanagedCodeSecurity]
                     [DllImport("CppSharp.CppParser", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
@@ -10966,6 +10994,38 @@ namespace CppSharp
                     __Internal.ClearSpecializations_0((__Instance + __PointerAdjustment));
                 }
 
+                public global::CppSharp.Parser.AST.ClassTemplateSpecialization FindSpecialization(string usr)
+                {
+                    var __allocator0 = new global::Std.__1.Allocator();
+                    var __basicString0 = new global::Std.__1.BasicString(usr, __allocator0);
+                    var __arg0 = __basicString0.__Instance;
+                    var __ret = __Internal.FindSpecialization_0((__Instance + __PointerAdjustment), __arg0);
+                    __basicString0.Dispose(false);
+                    __allocator0.Dispose();
+                    global::CppSharp.Parser.AST.ClassTemplateSpecialization __result0;
+                    if (__ret == IntPtr.Zero) __result0 = null;
+                    else if (global::CppSharp.Parser.AST.ClassTemplateSpecialization.NativeToManagedMap.ContainsKey(__ret))
+                        __result0 = (global::CppSharp.Parser.AST.ClassTemplateSpecialization) global::CppSharp.Parser.AST.ClassTemplateSpecialization.NativeToManagedMap[__ret];
+                    else __result0 = global::CppSharp.Parser.AST.ClassTemplateSpecialization.__CreateInstance(__ret);
+                    return __result0;
+                }
+
+                public global::CppSharp.Parser.AST.ClassTemplatePartialSpecialization FindPartialSpecialization(string usr)
+                {
+                    var __allocator0 = new global::Std.__1.Allocator();
+                    var __basicString0 = new global::Std.__1.BasicString(usr, __allocator0);
+                    var __arg0 = __basicString0.__Instance;
+                    var __ret = __Internal.FindPartialSpecialization_0((__Instance + __PointerAdjustment), __arg0);
+                    __basicString0.Dispose(false);
+                    __allocator0.Dispose();
+                    global::CppSharp.Parser.AST.ClassTemplatePartialSpecialization __result0;
+                    if (__ret == IntPtr.Zero) __result0 = null;
+                    else if (global::CppSharp.Parser.AST.ClassTemplatePartialSpecialization.NativeToManagedMap.ContainsKey(__ret))
+                        __result0 = (global::CppSharp.Parser.AST.ClassTemplatePartialSpecialization) global::CppSharp.Parser.AST.ClassTemplatePartialSpecialization.NativeToManagedMap[__ret];
+                    else __result0 = global::CppSharp.Parser.AST.ClassTemplatePartialSpecialization.__CreateInstance(__ret);
+                    return __result0;
+                }
+
                 public uint SpecializationsCount
                 {
                     get
@@ -11000,13 +11060,13 @@ namespace CppSharp
                     internal int lineNumberEnd;
 
                     [FieldOffset(32)]
-                    internal global::Std.__1.BasicString.__Internal Name;
+                    internal global::Std.__1.BasicString.__Internal name;
 
                     [FieldOffset(56)]
                     internal global::Std.__1.BasicString.__Internal USR;
 
                     [FieldOffset(80)]
-                    internal global::Std.__1.BasicString.__Internal DebugText;
+                    internal global::Std.__1.BasicString.__Internal debugText;
 
                     [FieldOffset(104)]
                     internal byte isIncomplete;
@@ -11310,13 +11370,13 @@ namespace CppSharp
                     internal int lineNumberEnd;
 
                     [FieldOffset(32)]
-                    internal global::Std.__1.BasicString.__Internal Name;
+                    internal global::Std.__1.BasicString.__Internal name;
 
                     [FieldOffset(56)]
                     internal global::Std.__1.BasicString.__Internal USR;
 
                     [FieldOffset(80)]
-                    internal global::Std.__1.BasicString.__Internal DebugText;
+                    internal global::Std.__1.BasicString.__Internal debugText;
 
                     [FieldOffset(104)]
                     internal byte isIncomplete;
@@ -11540,13 +11600,13 @@ namespace CppSharp
                     internal int lineNumberEnd;
 
                     [FieldOffset(32)]
-                    internal global::Std.__1.BasicString.__Internal Name;
+                    internal global::Std.__1.BasicString.__Internal name;
 
                     [FieldOffset(56)]
                     internal global::Std.__1.BasicString.__Internal USR;
 
                     [FieldOffset(80)]
-                    internal global::Std.__1.BasicString.__Internal DebugText;
+                    internal global::Std.__1.BasicString.__Internal debugText;
 
                     [FieldOffset(104)]
                     internal byte isIncomplete;
@@ -11613,6 +11673,11 @@ namespace CppSharp
                     [DllImport("CppSharp.CppParser", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
                         EntryPoint="_ZN8CppSharp9CppParser3AST16FunctionTemplate20clearSpecializationsEv")]
                     internal static extern void ClearSpecializations_0(global::System.IntPtr instance);
+
+                    [SuppressUnmanagedCodeSecurity]
+                    [DllImport("CppSharp.CppParser", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
+                        EntryPoint="_ZN8CppSharp9CppParser3AST16FunctionTemplate18FindSpecializationERKNSt3__112basic_stringIcNS3_11char_traitsIcEENS3_9allocatorIcEEEE")]
+                    internal static extern global::System.IntPtr FindSpecialization_0(global::System.IntPtr instance, global::System.IntPtr usr);
 
                     [SuppressUnmanagedCodeSecurity]
                     [DllImport("CppSharp.CppParser", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
@@ -11709,6 +11774,22 @@ namespace CppSharp
                 public void ClearSpecializations()
                 {
                     __Internal.ClearSpecializations_0((__Instance + __PointerAdjustment));
+                }
+
+                public global::CppSharp.Parser.AST.FunctionTemplateSpecialization FindSpecialization(string usr)
+                {
+                    var __allocator0 = new global::Std.__1.Allocator();
+                    var __basicString0 = new global::Std.__1.BasicString(usr, __allocator0);
+                    var __arg0 = __basicString0.__Instance;
+                    var __ret = __Internal.FindSpecialization_0((__Instance + __PointerAdjustment), __arg0);
+                    __basicString0.Dispose(false);
+                    __allocator0.Dispose();
+                    global::CppSharp.Parser.AST.FunctionTemplateSpecialization __result0;
+                    if (__ret == IntPtr.Zero) __result0 = null;
+                    else if (global::CppSharp.Parser.AST.FunctionTemplateSpecialization.NativeToManagedMap.ContainsKey(__ret))
+                        __result0 = (global::CppSharp.Parser.AST.FunctionTemplateSpecialization) global::CppSharp.Parser.AST.FunctionTemplateSpecialization.NativeToManagedMap[__ret];
+                    else __result0 = global::CppSharp.Parser.AST.FunctionTemplateSpecialization.__CreateInstance(__ret);
+                    return __result0;
                 }
 
                 public uint SpecializationsCount
@@ -11953,13 +12034,13 @@ namespace CppSharp
                     internal int lineNumberEnd;
 
                     [FieldOffset(32)]
-                    internal global::Std.__1.BasicString.__Internal Name;
+                    internal global::Std.__1.BasicString.__Internal name;
 
                     [FieldOffset(56)]
                     internal global::Std.__1.BasicString.__Internal USR;
 
                     [FieldOffset(80)]
-                    internal global::Std.__1.BasicString.__Internal DebugText;
+                    internal global::Std.__1.BasicString.__Internal debugText;
 
                     [FieldOffset(104)]
                     internal byte isIncomplete;
@@ -12026,6 +12107,16 @@ namespace CppSharp
                     [DllImport("CppSharp.CppParser", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
                         EntryPoint="_ZN8CppSharp9CppParser3AST11VarTemplate20clearSpecializationsEv")]
                     internal static extern void ClearSpecializations_0(global::System.IntPtr instance);
+
+                    [SuppressUnmanagedCodeSecurity]
+                    [DllImport("CppSharp.CppParser", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
+                        EntryPoint="_ZN8CppSharp9CppParser3AST11VarTemplate18FindSpecializationERKNSt3__112basic_stringIcNS3_11char_traitsIcEENS3_9allocatorIcEEEE")]
+                    internal static extern global::System.IntPtr FindSpecialization_0(global::System.IntPtr instance, global::System.IntPtr usr);
+
+                    [SuppressUnmanagedCodeSecurity]
+                    [DllImport("CppSharp.CppParser", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
+                        EntryPoint="_ZN8CppSharp9CppParser3AST11VarTemplate25FindPartialSpecializationERKNSt3__112basic_stringIcNS3_11char_traitsIcEENS3_9allocatorIcEEEE")]
+                    internal static extern global::System.IntPtr FindPartialSpecialization_0(global::System.IntPtr instance, global::System.IntPtr usr);
 
                     [SuppressUnmanagedCodeSecurity]
                     [DllImport("CppSharp.CppParser", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
@@ -12124,6 +12215,38 @@ namespace CppSharp
                     __Internal.ClearSpecializations_0((__Instance + __PointerAdjustment));
                 }
 
+                public global::CppSharp.Parser.AST.VarTemplateSpecialization FindSpecialization(string usr)
+                {
+                    var __allocator0 = new global::Std.__1.Allocator();
+                    var __basicString0 = new global::Std.__1.BasicString(usr, __allocator0);
+                    var __arg0 = __basicString0.__Instance;
+                    var __ret = __Internal.FindSpecialization_0((__Instance + __PointerAdjustment), __arg0);
+                    __basicString0.Dispose(false);
+                    __allocator0.Dispose();
+                    global::CppSharp.Parser.AST.VarTemplateSpecialization __result0;
+                    if (__ret == IntPtr.Zero) __result0 = null;
+                    else if (global::CppSharp.Parser.AST.VarTemplateSpecialization.NativeToManagedMap.ContainsKey(__ret))
+                        __result0 = (global::CppSharp.Parser.AST.VarTemplateSpecialization) global::CppSharp.Parser.AST.VarTemplateSpecialization.NativeToManagedMap[__ret];
+                    else __result0 = global::CppSharp.Parser.AST.VarTemplateSpecialization.__CreateInstance(__ret);
+                    return __result0;
+                }
+
+                public global::CppSharp.Parser.AST.VarTemplatePartialSpecialization FindPartialSpecialization(string usr)
+                {
+                    var __allocator0 = new global::Std.__1.Allocator();
+                    var __basicString0 = new global::Std.__1.BasicString(usr, __allocator0);
+                    var __arg0 = __basicString0.__Instance;
+                    var __ret = __Internal.FindPartialSpecialization_0((__Instance + __PointerAdjustment), __arg0);
+                    __basicString0.Dispose(false);
+                    __allocator0.Dispose();
+                    global::CppSharp.Parser.AST.VarTemplatePartialSpecialization __result0;
+                    if (__ret == IntPtr.Zero) __result0 = null;
+                    else if (global::CppSharp.Parser.AST.VarTemplatePartialSpecialization.NativeToManagedMap.ContainsKey(__ret))
+                        __result0 = (global::CppSharp.Parser.AST.VarTemplatePartialSpecialization) global::CppSharp.Parser.AST.VarTemplatePartialSpecialization.NativeToManagedMap[__ret];
+                    else __result0 = global::CppSharp.Parser.AST.VarTemplatePartialSpecialization.__CreateInstance(__ret);
+                    return __result0;
+                }
+
                 public uint SpecializationsCount
                 {
                     get
@@ -12158,13 +12281,13 @@ namespace CppSharp
                     internal int lineNumberEnd;
 
                     [FieldOffset(32)]
-                    internal global::Std.__1.BasicString.__Internal Name;
+                    internal global::Std.__1.BasicString.__Internal name;
 
                     [FieldOffset(56)]
                     internal global::Std.__1.BasicString.__Internal USR;
 
                     [FieldOffset(80)]
-                    internal global::Std.__1.BasicString.__Internal DebugText;
+                    internal global::Std.__1.BasicString.__Internal debugText;
 
                     [FieldOffset(104)]
                     internal byte isIncomplete;
@@ -12194,7 +12317,7 @@ namespace CppSharp
                     internal global::System.IntPtr comment;
 
                     [FieldOffset(192)]
-                    internal global::Std.__1.BasicString.__Internal Mangled;
+                    internal global::Std.__1.BasicString.__Internal mangled;
 
                     [FieldOffset(216)]
                     internal global::CppSharp.Parser.AST.QualifiedType.__Internal qualifiedType;
@@ -12396,13 +12519,13 @@ namespace CppSharp
                     internal int lineNumberEnd;
 
                     [FieldOffset(32)]
-                    internal global::Std.__1.BasicString.__Internal Name;
+                    internal global::Std.__1.BasicString.__Internal name;
 
                     [FieldOffset(56)]
                     internal global::Std.__1.BasicString.__Internal USR;
 
                     [FieldOffset(80)]
-                    internal global::Std.__1.BasicString.__Internal DebugText;
+                    internal global::Std.__1.BasicString.__Internal debugText;
 
                     [FieldOffset(104)]
                     internal byte isIncomplete;
@@ -12432,7 +12555,7 @@ namespace CppSharp
                     internal global::System.IntPtr comment;
 
                     [FieldOffset(192)]
-                    internal global::Std.__1.BasicString.__Internal Mangled;
+                    internal global::Std.__1.BasicString.__Internal mangled;
 
                     [FieldOffset(216)]
                     internal global::CppSharp.Parser.AST.QualifiedType.__Internal qualifiedType;
@@ -12554,13 +12677,13 @@ namespace CppSharp
                     internal int lineNumberEnd;
 
                     [FieldOffset(32)]
-                    internal global::Std.__1.BasicString.__Internal Name;
+                    internal global::Std.__1.BasicString.__Internal name;
 
                     [FieldOffset(56)]
                     internal global::Std.__1.BasicString.__Internal USR;
 
                     [FieldOffset(80)]
-                    internal global::Std.__1.BasicString.__Internal DebugText;
+                    internal global::Std.__1.BasicString.__Internal debugText;
 
                     [FieldOffset(104)]
                     internal byte isIncomplete;
@@ -12873,10 +12996,10 @@ namespace CppSharp
                     internal global::CppSharp.Parser.AST.DeclarationKind kind;
 
                     [FieldOffset(24)]
-                    internal global::Std.__1.BasicString.__Internal Name;
+                    internal global::Std.__1.BasicString.__Internal name;
 
                     [FieldOffset(48)]
-                    internal global::Std.__1.BasicString.__Internal Expression;
+                    internal global::Std.__1.BasicString.__Internal expression;
 
                     [FieldOffset(72)]
                     internal int lineNumberStart;
@@ -12898,26 +13021,6 @@ namespace CppSharp
                     [DllImport("CppSharp.CppParser", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
                         EntryPoint="_ZN8CppSharp9CppParser3AST15MacroDefinitionD2Ev")]
                     internal static extern void dtor_0(global::System.IntPtr instance);
-
-                    [SuppressUnmanagedCodeSecurity]
-                    [DllImport("CppSharp.CppParser", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
-                        EntryPoint="_ZN8CppSharp9CppParser3AST15MacroDefinition7getNameEv")]
-                    internal static extern global::System.IntPtr GetName(global::System.IntPtr instance);
-
-                    [SuppressUnmanagedCodeSecurity]
-                    [DllImport("CppSharp.CppParser", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
-                        EntryPoint="_ZN8CppSharp9CppParser3AST15MacroDefinition7setNameEPKc")]
-                    internal static extern void SetName(global::System.IntPtr instance, [MarshalAs(UnmanagedType.LPStr)] string s);
-
-                    [SuppressUnmanagedCodeSecurity]
-                    [DllImport("CppSharp.CppParser", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
-                        EntryPoint="_ZN8CppSharp9CppParser3AST15MacroDefinition13getExpressionEv")]
-                    internal static extern global::System.IntPtr GetExpression(global::System.IntPtr instance);
-
-                    [SuppressUnmanagedCodeSecurity]
-                    [DllImport("CppSharp.CppParser", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
-                        EntryPoint="_ZN8CppSharp9CppParser3AST15MacroDefinition13setExpressionEPKc")]
-                    internal static extern void SetExpression(global::System.IntPtr instance, [MarshalAs(UnmanagedType.LPStr)] string s);
                 }
 
                 internal static new global::CppSharp.Parser.AST.MacroDefinition __CreateInstance(global::System.IntPtr native, bool skipVTables = false)
@@ -12987,6 +13090,36 @@ namespace CppSharp
                     __Instance = IntPtr.Zero;
                 }
 
+                public string Name
+                {
+                    get
+                    {
+                        return global::Std.__1.BasicString.__CreateInstance(((global::CppSharp.Parser.AST.MacroDefinition.__Internal*) __Instance)->name).CStr();
+                    }
+
+                    set
+                    {
+                        var __allocator0 = new global::Std.__1.Allocator();
+                        var __basicString0 = new global::Std.__1.BasicString(value, __allocator0);
+                        ((global::CppSharp.Parser.AST.MacroDefinition.__Internal*) __Instance)->name = *(global::Std.__1.BasicString.__Internal*) __basicString0.__Instance;
+                    }
+                }
+
+                public string Expression
+                {
+                    get
+                    {
+                        return global::Std.__1.BasicString.__CreateInstance(((global::CppSharp.Parser.AST.MacroDefinition.__Internal*) __Instance)->expression).CStr();
+                    }
+
+                    set
+                    {
+                        var __allocator0 = new global::Std.__1.Allocator();
+                        var __basicString0 = new global::Std.__1.BasicString(value, __allocator0);
+                        ((global::CppSharp.Parser.AST.MacroDefinition.__Internal*) __Instance)->expression = *(global::Std.__1.BasicString.__Internal*) __basicString0.__Instance;
+                    }
+                }
+
                 public int LineNumberStart
                 {
                     get
@@ -13012,34 +13145,6 @@ namespace CppSharp
                         ((global::CppSharp.Parser.AST.MacroDefinition.__Internal*) __Instance)->lineNumberEnd = value;
                     }
                 }
-
-                public string Name
-                {
-                    get
-                    {
-                        var __ret = __Internal.GetName((__Instance + __PointerAdjustment));
-                        return Marshal.PtrToStringAnsi(__ret);
-                    }
-
-                    set
-                    {
-                        __Internal.SetName((__Instance + __PointerAdjustment), value);
-                    }
-                }
-
-                public string Expression
-                {
-                    get
-                    {
-                        var __ret = __Internal.GetExpression((__Instance + __PointerAdjustment));
-                        return Marshal.PtrToStringAnsi(__ret);
-                    }
-
-                    set
-                    {
-                        __Internal.SetExpression((__Instance + __PointerAdjustment), value);
-                    }
-                }
             }
 
             public unsafe partial class MacroExpansion : global::CppSharp.Parser.AST.PreprocessedEntity, IDisposable
@@ -13057,10 +13162,10 @@ namespace CppSharp
                     internal global::CppSharp.Parser.AST.DeclarationKind kind;
 
                     [FieldOffset(24)]
-                    internal global::Std.__1.BasicString.__Internal Name;
+                    internal global::Std.__1.BasicString.__Internal name;
 
                     [FieldOffset(48)]
-                    internal global::Std.__1.BasicString.__Internal Text;
+                    internal global::Std.__1.BasicString.__Internal text;
 
                     [FieldOffset(72)]
                     internal global::System.IntPtr definition;
@@ -13079,26 +13184,6 @@ namespace CppSharp
                     [DllImport("CppSharp.CppParser", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
                         EntryPoint="_ZN8CppSharp9CppParser3AST14MacroExpansionD2Ev")]
                     internal static extern void dtor_0(global::System.IntPtr instance);
-
-                    [SuppressUnmanagedCodeSecurity]
-                    [DllImport("CppSharp.CppParser", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
-                        EntryPoint="_ZN8CppSharp9CppParser3AST14MacroExpansion7getNameEv")]
-                    internal static extern global::System.IntPtr GetName(global::System.IntPtr instance);
-
-                    [SuppressUnmanagedCodeSecurity]
-                    [DllImport("CppSharp.CppParser", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
-                        EntryPoint="_ZN8CppSharp9CppParser3AST14MacroExpansion7setNameEPKc")]
-                    internal static extern void SetName(global::System.IntPtr instance, [MarshalAs(UnmanagedType.LPStr)] string s);
-
-                    [SuppressUnmanagedCodeSecurity]
-                    [DllImport("CppSharp.CppParser", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
-                        EntryPoint="_ZN8CppSharp9CppParser3AST14MacroExpansion7getTextEv")]
-                    internal static extern global::System.IntPtr GetText(global::System.IntPtr instance);
-
-                    [SuppressUnmanagedCodeSecurity]
-                    [DllImport("CppSharp.CppParser", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
-                        EntryPoint="_ZN8CppSharp9CppParser3AST14MacroExpansion7setTextEPKc")]
-                    internal static extern void SetText(global::System.IntPtr instance, [MarshalAs(UnmanagedType.LPStr)] string s);
                 }
 
                 internal static new global::CppSharp.Parser.AST.MacroExpansion __CreateInstance(global::System.IntPtr native, bool skipVTables = false)
@@ -13168,6 +13253,36 @@ namespace CppSharp
                     __Instance = IntPtr.Zero;
                 }
 
+                public string Name
+                {
+                    get
+                    {
+                        return global::Std.__1.BasicString.__CreateInstance(((global::CppSharp.Parser.AST.MacroExpansion.__Internal*) __Instance)->name).CStr();
+                    }
+
+                    set
+                    {
+                        var __allocator0 = new global::Std.__1.Allocator();
+                        var __basicString0 = new global::Std.__1.BasicString(value, __allocator0);
+                        ((global::CppSharp.Parser.AST.MacroExpansion.__Internal*) __Instance)->name = *(global::Std.__1.BasicString.__Internal*) __basicString0.__Instance;
+                    }
+                }
+
+                public string Text
+                {
+                    get
+                    {
+                        return global::Std.__1.BasicString.__CreateInstance(((global::CppSharp.Parser.AST.MacroExpansion.__Internal*) __Instance)->text).CStr();
+                    }
+
+                    set
+                    {
+                        var __allocator0 = new global::Std.__1.Allocator();
+                        var __basicString0 = new global::Std.__1.BasicString(value, __allocator0);
+                        ((global::CppSharp.Parser.AST.MacroExpansion.__Internal*) __Instance)->text = *(global::Std.__1.BasicString.__Internal*) __basicString0.__Instance;
+                    }
+                }
+
                 public global::CppSharp.Parser.AST.MacroDefinition Definition
                 {
                     get
@@ -13183,34 +13298,6 @@ namespace CppSharp
                     set
                     {
                         ((global::CppSharp.Parser.AST.MacroExpansion.__Internal*) __Instance)->definition = ReferenceEquals(value, null) ? global::System.IntPtr.Zero : value.__Instance;
-                    }
-                }
-
-                public string Name
-                {
-                    get
-                    {
-                        var __ret = __Internal.GetName((__Instance + __PointerAdjustment));
-                        return Marshal.PtrToStringAnsi(__ret);
-                    }
-
-                    set
-                    {
-                        __Internal.SetName((__Instance + __PointerAdjustment), value);
-                    }
-                }
-
-                public string Text
-                {
-                    get
-                    {
-                        var __ret = __Internal.GetText((__Instance + __PointerAdjustment));
-                        return Marshal.PtrToStringAnsi(__ret);
-                    }
-
-                    set
-                    {
-                        __Internal.SetText((__Instance + __PointerAdjustment), value);
                     }
                 }
             }
@@ -13239,13 +13326,13 @@ namespace CppSharp
                     internal int lineNumberEnd;
 
                     [FieldOffset(32)]
-                    internal global::Std.__1.BasicString.__Internal Name;
+                    internal global::Std.__1.BasicString.__Internal name;
 
                     [FieldOffset(56)]
                     internal global::Std.__1.BasicString.__Internal USR;
 
                     [FieldOffset(80)]
-                    internal global::Std.__1.BasicString.__Internal DebugText;
+                    internal global::Std.__1.BasicString.__Internal debugText;
 
                     [FieldOffset(104)]
                     internal byte isIncomplete;
@@ -13311,7 +13398,7 @@ namespace CppSharp
                     internal byte isInline;
 
                     [FieldOffset(440)]
-                    internal global::Std.__1.BasicString.__Internal FileName;
+                    internal global::Std.__1.BasicString.__Internal fileName;
 
                     [FieldOffset(464)]
                     internal byte isSystemHeader;
@@ -13348,16 +13435,6 @@ namespace CppSharp
                     [DllImport("CppSharp.CppParser", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
                         EntryPoint="_ZN8CppSharp9CppParser3AST15TranslationUnit11clearMacrosEv")]
                     internal static extern void ClearMacros_0(global::System.IntPtr instance);
-
-                    [SuppressUnmanagedCodeSecurity]
-                    [DllImport("CppSharp.CppParser", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
-                        EntryPoint="_ZN8CppSharp9CppParser3AST15TranslationUnit11getFileNameEv")]
-                    internal static extern global::System.IntPtr GetFileName(global::System.IntPtr instance);
-
-                    [SuppressUnmanagedCodeSecurity]
-                    [DllImport("CppSharp.CppParser", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
-                        EntryPoint="_ZN8CppSharp9CppParser3AST15TranslationUnit11setFileNameEPKc")]
-                    internal static extern void SetFileName(global::System.IntPtr instance, [MarshalAs(UnmanagedType.LPStr)] string s);
 
                     [SuppressUnmanagedCodeSecurity]
                     [DllImport("CppSharp.CppParser", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
@@ -13456,6 +13533,21 @@ namespace CppSharp
                     __Internal.ClearMacros_0((__Instance + __PointerAdjustment));
                 }
 
+                public string FileName
+                {
+                    get
+                    {
+                        return global::Std.__1.BasicString.__CreateInstance(((global::CppSharp.Parser.AST.TranslationUnit.__Internal*) __Instance)->fileName).CStr();
+                    }
+
+                    set
+                    {
+                        var __allocator0 = new global::Std.__1.Allocator();
+                        var __basicString0 = new global::Std.__1.BasicString(value, __allocator0);
+                        ((global::CppSharp.Parser.AST.TranslationUnit.__Internal*) __Instance)->fileName = *(global::Std.__1.BasicString.__Internal*) __basicString0.__Instance;
+                    }
+                }
+
                 public bool IsSystemHeader
                 {
                     get
@@ -13466,20 +13558,6 @@ namespace CppSharp
                     set
                     {
                         ((global::CppSharp.Parser.AST.TranslationUnit.__Internal*) __Instance)->isSystemHeader = (byte) (value ? 1 : 0);
-                    }
-                }
-
-                public string FileName
-                {
-                    get
-                    {
-                        var __ret = __Internal.GetFileName((__Instance + __PointerAdjustment));
-                        return Marshal.PtrToStringAnsi(__ret);
-                    }
-
-                    set
-                    {
-                        __Internal.SetFileName((__Instance + __PointerAdjustment), value);
                     }
                 }
 
@@ -13499,7 +13577,7 @@ namespace CppSharp
                 public partial struct __Internal
                 {
                     [FieldOffset(0)]
-                    internal global::Std.__1.BasicString.__Internal FileName;
+                    internal global::Std.__1.BasicString.__Internal fileName;
 
                     [FieldOffset(24)]
                     internal global::CppSharp.Parser.AST.ArchType archType;
@@ -13554,16 +13632,6 @@ namespace CppSharp
                     [DllImport("CppSharp.CppParser", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
                         EntryPoint="_ZN8CppSharp9CppParser3AST13NativeLibrary17clearDependenciesEv")]
                     internal static extern void ClearDependencies_0(global::System.IntPtr instance);
-
-                    [SuppressUnmanagedCodeSecurity]
-                    [DllImport("CppSharp.CppParser", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
-                        EntryPoint="_ZN8CppSharp9CppParser3AST13NativeLibrary11getFileNameEv")]
-                    internal static extern global::System.IntPtr GetFileName(global::System.IntPtr instance);
-
-                    [SuppressUnmanagedCodeSecurity]
-                    [DllImport("CppSharp.CppParser", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
-                        EntryPoint="_ZN8CppSharp9CppParser3AST13NativeLibrary11setFileNameEPKc")]
-                    internal static extern void SetFileName(global::System.IntPtr instance, [MarshalAs(UnmanagedType.LPStr)] string s);
 
                     [SuppressUnmanagedCodeSecurity]
                     [DllImport("CppSharp.CppParser", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
@@ -13684,6 +13752,21 @@ namespace CppSharp
                     __Internal.ClearDependencies_0((__Instance + __PointerAdjustment));
                 }
 
+                public string FileName
+                {
+                    get
+                    {
+                        return global::Std.__1.BasicString.__CreateInstance(((global::CppSharp.Parser.AST.NativeLibrary.__Internal*) __Instance)->fileName).CStr();
+                    }
+
+                    set
+                    {
+                        var __allocator0 = new global::Std.__1.Allocator();
+                        var __basicString0 = new global::Std.__1.BasicString(value, __allocator0);
+                        ((global::CppSharp.Parser.AST.NativeLibrary.__Internal*) __Instance)->fileName = *(global::Std.__1.BasicString.__Internal*) __basicString0.__Instance;
+                    }
+                }
+
                 public global::CppSharp.Parser.AST.ArchType ArchType
                 {
                     get
@@ -13694,20 +13777,6 @@ namespace CppSharp
                     set
                     {
                         ((global::CppSharp.Parser.AST.NativeLibrary.__Internal*) __Instance)->archType = value;
-                    }
-                }
-
-                public string FileName
-                {
-                    get
-                    {
-                        var __ret = __Internal.GetFileName((__Instance + __PointerAdjustment));
-                        return Marshal.PtrToStringAnsi(__ret);
-                    }
-
-                    set
-                    {
-                        __Internal.SetFileName((__Instance + __PointerAdjustment), value);
                     }
                 }
 
@@ -13752,6 +13821,11 @@ namespace CppSharp
                     [DllImport("CppSharp.CppParser", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
                         EntryPoint="_ZN8CppSharp9CppParser3AST10ASTContextD2Ev")]
                     internal static extern void dtor_0(global::System.IntPtr instance);
+
+                    [SuppressUnmanagedCodeSecurity]
+                    [DllImport("CppSharp.CppParser", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
+                        EntryPoint="_ZN8CppSharp9CppParser3AST10ASTContext18FindOrCreateModuleENSt3__112basic_stringIcNS3_11char_traitsIcEENS3_9allocatorIcEEEE")]
+                    internal static extern global::System.IntPtr FindOrCreateModule_0(global::System.IntPtr instance, global::Std.__1.BasicString.__Internal File);
 
                     [SuppressUnmanagedCodeSecurity]
                     [DllImport("CppSharp.CppParser", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
@@ -13848,6 +13922,22 @@ namespace CppSharp
                     if (__ownsNativeInstance)
                         Marshal.FreeHGlobal(__Instance);
                     __Instance = IntPtr.Zero;
+                }
+
+                public global::CppSharp.Parser.AST.TranslationUnit FindOrCreateModule(string File)
+                {
+                    var __allocator0 = new global::Std.__1.Allocator();
+                    var __basicString0 = new global::Std.__1.BasicString(File, __allocator0);
+                    var __arg0 = *(global::Std.__1.BasicString.__Internal*) __basicString0.__Instance;
+                    var __ret = __Internal.FindOrCreateModule_0((__Instance + __PointerAdjustment), __arg0);
+                    __basicString0.Dispose(false);
+                    __allocator0.Dispose();
+                    global::CppSharp.Parser.AST.TranslationUnit __result0;
+                    if (__ret == IntPtr.Zero) __result0 = null;
+                    else if (global::CppSharp.Parser.AST.TranslationUnit.NativeToManagedMap.ContainsKey(__ret))
+                        __result0 = (global::CppSharp.Parser.AST.TranslationUnit) global::CppSharp.Parser.AST.TranslationUnit.NativeToManagedMap[__ret];
+                    else __result0 = global::CppSharp.Parser.AST.TranslationUnit.__CreateInstance(__ret);
+                    return __result0;
                 }
 
                 public global::CppSharp.Parser.AST.TranslationUnit GetTranslationUnits(uint i)
@@ -14565,7 +14655,7 @@ namespace CppSharp
                     public partial struct __Internal
                     {
                         [FieldOffset(0)]
-                        internal global::Std.__1.BasicString.__Internal Text;
+                        internal global::Std.__1.BasicString.__Internal text;
 
                         [SuppressUnmanagedCodeSecurity]
                         [DllImport("CppSharp.CppParser", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
@@ -14581,16 +14671,6 @@ namespace CppSharp
                         [DllImport("CppSharp.CppParser", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
                             EntryPoint="_ZN8CppSharp9CppParser3AST19BlockCommandComment8ArgumentD2Ev")]
                         internal static extern void dtor_0(global::System.IntPtr instance);
-
-                        [SuppressUnmanagedCodeSecurity]
-                        [DllImport("CppSharp.CppParser", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
-                            EntryPoint="_ZN8CppSharp9CppParser3AST19BlockCommandComment8Argument7getTextEv")]
-                        internal static extern global::System.IntPtr GetText(global::System.IntPtr instance);
-
-                        [SuppressUnmanagedCodeSecurity]
-                        [DllImport("CppSharp.CppParser", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
-                            EntryPoint="_ZN8CppSharp9CppParser3AST19BlockCommandComment8Argument7setTextEPKc")]
-                        internal static extern void SetText(global::System.IntPtr instance, [MarshalAs(UnmanagedType.LPStr)] string s);
                     }
 
                     public global::System.IntPtr __Instance { get; protected set; }
@@ -14673,13 +14753,14 @@ namespace CppSharp
                     {
                         get
                         {
-                            var __ret = __Internal.GetText((__Instance + __PointerAdjustment));
-                            return Marshal.PtrToStringAnsi(__ret);
+                            return global::Std.__1.BasicString.__CreateInstance(((global::CppSharp.Parser.AST.BlockCommandComment.Argument.__Internal*) __Instance)->text).CStr();
                         }
 
                         set
                         {
-                            __Internal.SetText((__Instance + __PointerAdjustment), value);
+                            var __allocator0 = new global::Std.__1.Allocator();
+                            var __basicString0 = new global::Std.__1.BasicString(value, __allocator0);
+                            ((global::CppSharp.Parser.AST.BlockCommandComment.Argument.__Internal*) __Instance)->text = *(global::Std.__1.BasicString.__Internal*) __basicString0.__Instance;
                         }
                     }
                 }
@@ -15128,7 +15209,7 @@ namespace CppSharp
                     internal global::CppSharp.Parser.AST.CommentKind kind;
 
                     [FieldOffset(8)]
-                    internal global::Std.__1.BasicString.__Internal Text;
+                    internal global::Std.__1.BasicString.__Internal text;
 
                     [SuppressUnmanagedCodeSecurity]
                     [DllImport("CppSharp.CppParser", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
@@ -15144,16 +15225,6 @@ namespace CppSharp
                     [DllImport("CppSharp.CppParser", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
                         EntryPoint="_ZN8CppSharp9CppParser3AST24VerbatimBlockLineCommentD2Ev")]
                     internal static extern void dtor_0(global::System.IntPtr instance);
-
-                    [SuppressUnmanagedCodeSecurity]
-                    [DllImport("CppSharp.CppParser", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
-                        EntryPoint="_ZN8CppSharp9CppParser3AST24VerbatimBlockLineComment7getTextEv")]
-                    internal static extern global::System.IntPtr GetText(global::System.IntPtr instance);
-
-                    [SuppressUnmanagedCodeSecurity]
-                    [DllImport("CppSharp.CppParser", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
-                        EntryPoint="_ZN8CppSharp9CppParser3AST24VerbatimBlockLineComment7setTextEPKc")]
-                    internal static extern void SetText(global::System.IntPtr instance, [MarshalAs(UnmanagedType.LPStr)] string s);
                 }
 
                 internal static new global::CppSharp.Parser.AST.VerbatimBlockLineComment __CreateInstance(global::System.IntPtr native, bool skipVTables = false)
@@ -15227,13 +15298,14 @@ namespace CppSharp
                 {
                     get
                     {
-                        var __ret = __Internal.GetText((__Instance + __PointerAdjustment));
-                        return Marshal.PtrToStringAnsi(__ret);
+                        return global::Std.__1.BasicString.__CreateInstance(((global::CppSharp.Parser.AST.VerbatimBlockLineComment.__Internal*) __Instance)->text).CStr();
                     }
 
                     set
                     {
-                        __Internal.SetText((__Instance + __PointerAdjustment), value);
+                        var __allocator0 = new global::Std.__1.Allocator();
+                        var __basicString0 = new global::Std.__1.BasicString(value, __allocator0);
+                        ((global::CppSharp.Parser.AST.VerbatimBlockLineComment.__Internal*) __Instance)->text = *(global::Std.__1.BasicString.__Internal*) __basicString0.__Instance;
                     }
                 }
             }
@@ -15413,7 +15485,7 @@ namespace CppSharp
                     internal global::Std.__1.Vector.__Internal Arguments;
 
                     [FieldOffset(40)]
-                    internal global::Std.__1.BasicString.__Internal Text;
+                    internal global::Std.__1.BasicString.__Internal text;
 
                     [SuppressUnmanagedCodeSecurity]
                     [DllImport("CppSharp.CppParser", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
@@ -15429,16 +15501,6 @@ namespace CppSharp
                     [DllImport("CppSharp.CppParser", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
                         EntryPoint="_ZN8CppSharp9CppParser3AST19VerbatimLineCommentD2Ev")]
                     internal static extern void dtor_0(global::System.IntPtr instance);
-
-                    [SuppressUnmanagedCodeSecurity]
-                    [DllImport("CppSharp.CppParser", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
-                        EntryPoint="_ZN8CppSharp9CppParser3AST19VerbatimLineComment7getTextEv")]
-                    internal static extern global::System.IntPtr GetText(global::System.IntPtr instance);
-
-                    [SuppressUnmanagedCodeSecurity]
-                    [DllImport("CppSharp.CppParser", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
-                        EntryPoint="_ZN8CppSharp9CppParser3AST19VerbatimLineComment7setTextEPKc")]
-                    internal static extern void SetText(global::System.IntPtr instance, [MarshalAs(UnmanagedType.LPStr)] string s);
                 }
 
                 internal static new global::CppSharp.Parser.AST.VerbatimLineComment __CreateInstance(global::System.IntPtr native, bool skipVTables = false)
@@ -15512,13 +15574,14 @@ namespace CppSharp
                 {
                     get
                     {
-                        var __ret = __Internal.GetText((__Instance + __PointerAdjustment));
-                        return Marshal.PtrToStringAnsi(__ret);
+                        return global::Std.__1.BasicString.__CreateInstance(((global::CppSharp.Parser.AST.VerbatimLineComment.__Internal*) __Instance)->text).CStr();
                     }
 
                     set
                     {
-                        __Internal.SetText((__Instance + __PointerAdjustment), value);
+                        var __allocator0 = new global::Std.__1.Allocator();
+                        var __basicString0 = new global::Std.__1.BasicString(value, __allocator0);
+                        ((global::CppSharp.Parser.AST.VerbatimLineComment.__Internal*) __Instance)->text = *(global::Std.__1.BasicString.__Internal*) __basicString0.__Instance;
                     }
                 }
             }
@@ -15593,7 +15656,7 @@ namespace CppSharp
                     public partial struct __Internal
                     {
                         [FieldOffset(0)]
-                        internal global::Std.__1.BasicString.__Internal Text;
+                        internal global::Std.__1.BasicString.__Internal text;
 
                         [SuppressUnmanagedCodeSecurity]
                         [DllImport("CppSharp.CppParser", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
@@ -15609,16 +15672,6 @@ namespace CppSharp
                         [DllImport("CppSharp.CppParser", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
                             EntryPoint="_ZN8CppSharp9CppParser3AST20InlineCommandComment8ArgumentD2Ev")]
                         internal static extern void dtor_0(global::System.IntPtr instance);
-
-                        [SuppressUnmanagedCodeSecurity]
-                        [DllImport("CppSharp.CppParser", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
-                            EntryPoint="_ZN8CppSharp9CppParser3AST20InlineCommandComment8Argument7getTextEv")]
-                        internal static extern global::System.IntPtr GetText(global::System.IntPtr instance);
-
-                        [SuppressUnmanagedCodeSecurity]
-                        [DllImport("CppSharp.CppParser", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
-                            EntryPoint="_ZN8CppSharp9CppParser3AST20InlineCommandComment8Argument7setTextEPKc")]
-                        internal static extern void SetText(global::System.IntPtr instance, [MarshalAs(UnmanagedType.LPStr)] string s);
                     }
 
                     public global::System.IntPtr __Instance { get; protected set; }
@@ -15701,13 +15754,14 @@ namespace CppSharp
                     {
                         get
                         {
-                            var __ret = __Internal.GetText((__Instance + __PointerAdjustment));
-                            return Marshal.PtrToStringAnsi(__ret);
+                            return global::Std.__1.BasicString.__CreateInstance(((global::CppSharp.Parser.AST.InlineCommandComment.Argument.__Internal*) __Instance)->text).CStr();
                         }
 
                         set
                         {
-                            __Internal.SetText((__Instance + __PointerAdjustment), value);
+                            var __allocator0 = new global::Std.__1.Allocator();
+                            var __basicString0 = new global::Std.__1.BasicString(value, __allocator0);
+                            ((global::CppSharp.Parser.AST.InlineCommandComment.Argument.__Internal*) __Instance)->text = *(global::Std.__1.BasicString.__Internal*) __basicString0.__Instance;
                         }
                     }
                 }
@@ -15940,7 +15994,7 @@ namespace CppSharp
                     internal byte hasTrailingNewline;
 
                     [FieldOffset(8)]
-                    internal global::Std.__1.BasicString.__Internal TagName;
+                    internal global::Std.__1.BasicString.__Internal tagName;
 
                     [FieldOffset(32)]
                     internal global::Std.__1.Vector.__Internal Attributes;
@@ -15977,16 +16031,6 @@ namespace CppSharp
 
                     [SuppressUnmanagedCodeSecurity]
                     [DllImport("CppSharp.CppParser", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
-                        EntryPoint="_ZN8CppSharp9CppParser3AST19HTMLStartTagComment10getTagNameEv")]
-                    internal static extern global::System.IntPtr GetTagName(global::System.IntPtr instance);
-
-                    [SuppressUnmanagedCodeSecurity]
-                    [DllImport("CppSharp.CppParser", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
-                        EntryPoint="_ZN8CppSharp9CppParser3AST19HTMLStartTagComment10setTagNameEPKc")]
-                    internal static extern void SetTagName(global::System.IntPtr instance, [MarshalAs(UnmanagedType.LPStr)] string s);
-
-                    [SuppressUnmanagedCodeSecurity]
-                    [DllImport("CppSharp.CppParser", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
                         EntryPoint="_ZN8CppSharp9CppParser3AST19HTMLStartTagComment18getAttributesCountEv")]
                     internal static extern uint GetAttributesCount(global::System.IntPtr instance);
                 }
@@ -15997,10 +16041,10 @@ namespace CppSharp
                     public partial struct __Internal
                     {
                         [FieldOffset(0)]
-                        internal global::Std.__1.BasicString.__Internal Name;
+                        internal global::Std.__1.BasicString.__Internal name;
 
                         [FieldOffset(24)]
-                        internal global::Std.__1.BasicString.__Internal Value;
+                        internal global::Std.__1.BasicString.__Internal value;
 
                         [SuppressUnmanagedCodeSecurity]
                         [DllImport("CppSharp.CppParser", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
@@ -16016,26 +16060,6 @@ namespace CppSharp
                         [DllImport("CppSharp.CppParser", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
                             EntryPoint="_ZN8CppSharp9CppParser3AST19HTMLStartTagComment9AttributeD2Ev")]
                         internal static extern void dtor_0(global::System.IntPtr instance);
-
-                        [SuppressUnmanagedCodeSecurity]
-                        [DllImport("CppSharp.CppParser", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
-                            EntryPoint="_ZN8CppSharp9CppParser3AST19HTMLStartTagComment9Attribute7getNameEv")]
-                        internal static extern global::System.IntPtr GetName(global::System.IntPtr instance);
-
-                        [SuppressUnmanagedCodeSecurity]
-                        [DllImport("CppSharp.CppParser", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
-                            EntryPoint="_ZN8CppSharp9CppParser3AST19HTMLStartTagComment9Attribute7setNameEPKc")]
-                        internal static extern void SetName(global::System.IntPtr instance, [MarshalAs(UnmanagedType.LPStr)] string s);
-
-                        [SuppressUnmanagedCodeSecurity]
-                        [DllImport("CppSharp.CppParser", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
-                            EntryPoint="_ZN8CppSharp9CppParser3AST19HTMLStartTagComment9Attribute8getValueEv")]
-                        internal static extern global::System.IntPtr GetValue(global::System.IntPtr instance);
-
-                        [SuppressUnmanagedCodeSecurity]
-                        [DllImport("CppSharp.CppParser", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
-                            EntryPoint="_ZN8CppSharp9CppParser3AST19HTMLStartTagComment9Attribute8setValueEPKc")]
-                        internal static extern void SetValue(global::System.IntPtr instance, [MarshalAs(UnmanagedType.LPStr)] string s);
                     }
 
                     public global::System.IntPtr __Instance { get; protected set; }
@@ -16118,13 +16142,14 @@ namespace CppSharp
                     {
                         get
                         {
-                            var __ret = __Internal.GetName((__Instance + __PointerAdjustment));
-                            return Marshal.PtrToStringAnsi(__ret);
+                            return global::Std.__1.BasicString.__CreateInstance(((global::CppSharp.Parser.AST.HTMLStartTagComment.Attribute.__Internal*) __Instance)->name).CStr();
                         }
 
                         set
                         {
-                            __Internal.SetName((__Instance + __PointerAdjustment), value);
+                            var __allocator0 = new global::Std.__1.Allocator();
+                            var __basicString0 = new global::Std.__1.BasicString(value, __allocator0);
+                            ((global::CppSharp.Parser.AST.HTMLStartTagComment.Attribute.__Internal*) __Instance)->name = *(global::Std.__1.BasicString.__Internal*) __basicString0.__Instance;
                         }
                     }
 
@@ -16132,13 +16157,14 @@ namespace CppSharp
                     {
                         get
                         {
-                            var __ret = __Internal.GetValue((__Instance + __PointerAdjustment));
-                            return Marshal.PtrToStringAnsi(__ret);
+                            return global::Std.__1.BasicString.__CreateInstance(((global::CppSharp.Parser.AST.HTMLStartTagComment.Attribute.__Internal*) __Instance)->value).CStr();
                         }
 
                         set
                         {
-                            __Internal.SetValue((__Instance + __PointerAdjustment), value);
+                            var __allocator0 = new global::Std.__1.Allocator();
+                            var __basicString0 = new global::Std.__1.BasicString(value, __allocator0);
+                            ((global::CppSharp.Parser.AST.HTMLStartTagComment.Attribute.__Internal*) __Instance)->value = *(global::Std.__1.BasicString.__Internal*) __basicString0.__Instance;
                         }
                     }
                 }
@@ -16234,13 +16260,14 @@ namespace CppSharp
                 {
                     get
                     {
-                        var __ret = __Internal.GetTagName((__Instance + __PointerAdjustment));
-                        return Marshal.PtrToStringAnsi(__ret);
+                        return global::Std.__1.BasicString.__CreateInstance(((global::CppSharp.Parser.AST.HTMLStartTagComment.__Internal*) __Instance)->tagName).CStr();
                     }
 
                     set
                     {
-                        __Internal.SetTagName((__Instance + __PointerAdjustment), value);
+                        var __allocator0 = new global::Std.__1.Allocator();
+                        var __basicString0 = new global::Std.__1.BasicString(value, __allocator0);
+                        ((global::CppSharp.Parser.AST.HTMLStartTagComment.__Internal*) __Instance)->tagName = *(global::Std.__1.BasicString.__Internal*) __basicString0.__Instance;
                     }
                 }
 
@@ -16266,7 +16293,7 @@ namespace CppSharp
                     internal byte hasTrailingNewline;
 
                     [FieldOffset(8)]
-                    internal global::Std.__1.BasicString.__Internal TagName;
+                    internal global::Std.__1.BasicString.__Internal tagName;
 
                     [SuppressUnmanagedCodeSecurity]
                     [DllImport("CppSharp.CppParser", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
@@ -16282,16 +16309,6 @@ namespace CppSharp
                     [DllImport("CppSharp.CppParser", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
                         EntryPoint="_ZN8CppSharp9CppParser3AST17HTMLEndTagCommentD2Ev")]
                     internal static extern void dtor_0(global::System.IntPtr instance);
-
-                    [SuppressUnmanagedCodeSecurity]
-                    [DllImport("CppSharp.CppParser", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
-                        EntryPoint="_ZN8CppSharp9CppParser3AST17HTMLEndTagComment10getTagNameEv")]
-                    internal static extern global::System.IntPtr GetTagName(global::System.IntPtr instance);
-
-                    [SuppressUnmanagedCodeSecurity]
-                    [DllImport("CppSharp.CppParser", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
-                        EntryPoint="_ZN8CppSharp9CppParser3AST17HTMLEndTagComment10setTagNameEPKc")]
-                    internal static extern void SetTagName(global::System.IntPtr instance, [MarshalAs(UnmanagedType.LPStr)] string s);
                 }
 
                 internal static new global::CppSharp.Parser.AST.HTMLEndTagComment __CreateInstance(global::System.IntPtr native, bool skipVTables = false)
@@ -16365,13 +16382,14 @@ namespace CppSharp
                 {
                     get
                     {
-                        var __ret = __Internal.GetTagName((__Instance + __PointerAdjustment));
-                        return Marshal.PtrToStringAnsi(__ret);
+                        return global::Std.__1.BasicString.__CreateInstance(((global::CppSharp.Parser.AST.HTMLEndTagComment.__Internal*) __Instance)->tagName).CStr();
                     }
 
                     set
                     {
-                        __Internal.SetTagName((__Instance + __PointerAdjustment), value);
+                        var __allocator0 = new global::Std.__1.Allocator();
+                        var __basicString0 = new global::Std.__1.BasicString(value, __allocator0);
+                        ((global::CppSharp.Parser.AST.HTMLEndTagComment.__Internal*) __Instance)->tagName = *(global::Std.__1.BasicString.__Internal*) __basicString0.__Instance;
                     }
                 }
             }
@@ -16388,7 +16406,7 @@ namespace CppSharp
                     internal byte hasTrailingNewline;
 
                     [FieldOffset(8)]
-                    internal global::Std.__1.BasicString.__Internal Text;
+                    internal global::Std.__1.BasicString.__Internal text;
 
                     [SuppressUnmanagedCodeSecurity]
                     [DllImport("CppSharp.CppParser", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
@@ -16404,16 +16422,6 @@ namespace CppSharp
                     [DllImport("CppSharp.CppParser", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
                         EntryPoint="_ZN8CppSharp9CppParser3AST11TextCommentD2Ev")]
                     internal static extern void dtor_0(global::System.IntPtr instance);
-
-                    [SuppressUnmanagedCodeSecurity]
-                    [DllImport("CppSharp.CppParser", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
-                        EntryPoint="_ZN8CppSharp9CppParser3AST11TextComment7getTextEv")]
-                    internal static extern global::System.IntPtr GetText(global::System.IntPtr instance);
-
-                    [SuppressUnmanagedCodeSecurity]
-                    [DllImport("CppSharp.CppParser", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
-                        EntryPoint="_ZN8CppSharp9CppParser3AST11TextComment7setTextEPKc")]
-                    internal static extern void SetText(global::System.IntPtr instance, [MarshalAs(UnmanagedType.LPStr)] string s);
                 }
 
                 internal static new global::CppSharp.Parser.AST.TextComment __CreateInstance(global::System.IntPtr native, bool skipVTables = false)
@@ -16487,13 +16495,14 @@ namespace CppSharp
                 {
                     get
                     {
-                        var __ret = __Internal.GetText((__Instance + __PointerAdjustment));
-                        return Marshal.PtrToStringAnsi(__ret);
+                        return global::Std.__1.BasicString.__CreateInstance(((global::CppSharp.Parser.AST.TextComment.__Internal*) __Instance)->text).CStr();
                     }
 
                     set
                     {
-                        __Internal.SetText((__Instance + __PointerAdjustment), value);
+                        var __allocator0 = new global::Std.__1.Allocator();
+                        var __basicString0 = new global::Std.__1.BasicString(value, __allocator0);
+                        ((global::CppSharp.Parser.AST.TextComment.__Internal*) __Instance)->text = *(global::Std.__1.BasicString.__Internal*) __basicString0.__Instance;
                     }
                 }
             }
@@ -16507,10 +16516,10 @@ namespace CppSharp
                     internal global::CppSharp.Parser.AST.RawCommentKind kind;
 
                     [FieldOffset(8)]
-                    internal global::Std.__1.BasicString.__Internal Text;
+                    internal global::Std.__1.BasicString.__Internal text;
 
                     [FieldOffset(32)]
-                    internal global::Std.__1.BasicString.__Internal BriefText;
+                    internal global::Std.__1.BasicString.__Internal briefText;
 
                     [FieldOffset(56)]
                     internal global::System.IntPtr fullCommentBlock;
@@ -16529,26 +16538,6 @@ namespace CppSharp
                     [DllImport("CppSharp.CppParser", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
                         EntryPoint="_ZN8CppSharp9CppParser3AST10RawCommentD2Ev")]
                     internal static extern void dtor_0(global::System.IntPtr instance);
-
-                    [SuppressUnmanagedCodeSecurity]
-                    [DllImport("CppSharp.CppParser", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
-                        EntryPoint="_ZN8CppSharp9CppParser3AST10RawComment7getTextEv")]
-                    internal static extern global::System.IntPtr GetText(global::System.IntPtr instance);
-
-                    [SuppressUnmanagedCodeSecurity]
-                    [DllImport("CppSharp.CppParser", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
-                        EntryPoint="_ZN8CppSharp9CppParser3AST10RawComment7setTextEPKc")]
-                    internal static extern void SetText(global::System.IntPtr instance, [MarshalAs(UnmanagedType.LPStr)] string s);
-
-                    [SuppressUnmanagedCodeSecurity]
-                    [DllImport("CppSharp.CppParser", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
-                        EntryPoint="_ZN8CppSharp9CppParser3AST10RawComment12getBriefTextEv")]
-                    internal static extern global::System.IntPtr GetBriefText(global::System.IntPtr instance);
-
-                    [SuppressUnmanagedCodeSecurity]
-                    [DllImport("CppSharp.CppParser", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
-                        EntryPoint="_ZN8CppSharp9CppParser3AST10RawComment12setBriefTextEPKc")]
-                    internal static extern void SetBriefText(global::System.IntPtr instance, [MarshalAs(UnmanagedType.LPStr)] string s);
                 }
 
                 public global::System.IntPtr __Instance { get; protected set; }
@@ -16640,6 +16629,36 @@ namespace CppSharp
                     }
                 }
 
+                public string Text
+                {
+                    get
+                    {
+                        return global::Std.__1.BasicString.__CreateInstance(((global::CppSharp.Parser.AST.RawComment.__Internal*) __Instance)->text).CStr();
+                    }
+
+                    set
+                    {
+                        var __allocator0 = new global::Std.__1.Allocator();
+                        var __basicString0 = new global::Std.__1.BasicString(value, __allocator0);
+                        ((global::CppSharp.Parser.AST.RawComment.__Internal*) __Instance)->text = *(global::Std.__1.BasicString.__Internal*) __basicString0.__Instance;
+                    }
+                }
+
+                public string BriefText
+                {
+                    get
+                    {
+                        return global::Std.__1.BasicString.__CreateInstance(((global::CppSharp.Parser.AST.RawComment.__Internal*) __Instance)->briefText).CStr();
+                    }
+
+                    set
+                    {
+                        var __allocator0 = new global::Std.__1.Allocator();
+                        var __basicString0 = new global::Std.__1.BasicString(value, __allocator0);
+                        ((global::CppSharp.Parser.AST.RawComment.__Internal*) __Instance)->briefText = *(global::Std.__1.BasicString.__Internal*) __basicString0.__Instance;
+                    }
+                }
+
                 public global::CppSharp.Parser.AST.FullComment FullCommentBlock
                 {
                     get
@@ -16655,34 +16674,6 @@ namespace CppSharp
                     set
                     {
                         ((global::CppSharp.Parser.AST.RawComment.__Internal*) __Instance)->fullCommentBlock = ReferenceEquals(value, null) ? global::System.IntPtr.Zero : value.__Instance;
-                    }
-                }
-
-                public string Text
-                {
-                    get
-                    {
-                        var __ret = __Internal.GetText((__Instance + __PointerAdjustment));
-                        return Marshal.PtrToStringAnsi(__ret);
-                    }
-
-                    set
-                    {
-                        __Internal.SetText((__Instance + __PointerAdjustment), value);
-                    }
-                }
-
-                public string BriefText
-                {
-                    get
-                    {
-                        var __ret = __Internal.GetBriefText((__Instance + __PointerAdjustment));
-                        return Marshal.PtrToStringAnsi(__ret);
-                    }
-
-                    set
-                    {
-                        __Internal.SetBriefText((__Instance + __PointerAdjustment), value);
                     }
                 }
             }
@@ -16944,16 +16935,6 @@ namespace CppSharp
                 [DllImport("CppSharp.CppParser", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
                     EntryPoint="_ZN8CppSharp9CppParser16ParserTargetInfoD2Ev")]
                 internal static extern void dtor_0(global::System.IntPtr instance);
-
-                [SuppressUnmanagedCodeSecurity]
-                [DllImport("CppSharp.CppParser", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
-                    EntryPoint="_ZN8CppSharp9CppParser16ParserTargetInfo6getABIEv")]
-                internal static extern global::System.IntPtr GetABI(global::System.IntPtr instance);
-
-                [SuppressUnmanagedCodeSecurity]
-                [DllImport("CppSharp.CppParser", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
-                    EntryPoint="_ZN8CppSharp9CppParser16ParserTargetInfo6setABIEPKc")]
-                internal static extern void SetABI(global::System.IntPtr instance, [MarshalAs(UnmanagedType.LPStr)] string s);
             }
 
             public global::System.IntPtr __Instance { get; protected set; }
@@ -17030,6 +17011,21 @@ namespace CppSharp
                 if (__ownsNativeInstance)
                     Marshal.FreeHGlobal(__Instance);
                 __Instance = IntPtr.Zero;
+            }
+
+            public string ABI
+            {
+                get
+                {
+                    return global::Std.__1.BasicString.__CreateInstance(((global::CppSharp.Parser.ParserTargetInfo.__Internal*) __Instance)->ABI).CStr();
+                }
+
+                set
+                {
+                    var __allocator0 = new global::Std.__1.Allocator();
+                    var __basicString0 = new global::Std.__1.BasicString(value, __allocator0);
+                    ((global::CppSharp.Parser.ParserTargetInfo.__Internal*) __Instance)->ABI = *(global::Std.__1.BasicString.__Internal*) __basicString0.__Instance;
+                }
             }
 
             public global::CppSharp.Parser.ParserIntType Char16Type
@@ -17551,20 +17547,6 @@ namespace CppSharp
                     ((global::CppSharp.Parser.ParserTargetInfo.__Internal*) __Instance)->float128Width = value;
                 }
             }
-
-            public string ABI
-            {
-                get
-                {
-                    var __ret = __Internal.GetABI((__Instance + __PointerAdjustment));
-                    return Marshal.PtrToStringAnsi(__ret);
-                }
-
-                set
-                {
-                    __Internal.SetABI((__Instance + __PointerAdjustment), value);
-                }
-            }
         }
     }
 }
@@ -17670,7 +17652,7 @@ namespace CppSharp
                 internal global::Std.__1.Vector.__Internal Arguments;
 
                 [FieldOffset(24)]
-                internal global::Std.__1.BasicString.__Internal LibraryFile;
+                internal global::Std.__1.BasicString.__Internal libraryFile;
 
                 [FieldOffset(48)]
                 internal global::Std.__1.Vector.__Internal SourceFiles;
@@ -17697,7 +17679,7 @@ namespace CppSharp
                 internal int toolSetToUse;
 
                 [FieldOffset(208)]
-                internal global::Std.__1.BasicString.__Internal TargetTriple;
+                internal global::Std.__1.BasicString.__Internal targetTriple;
 
                 [FieldOffset(232)]
                 internal global::CppSharp.Parser.AST.CppAbi abi;
@@ -17839,26 +17821,6 @@ namespace CppSharp
                 [DllImport("CppSharp.CppParser", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
                     EntryPoint="_ZN8CppSharp9CppParser16CppParserOptions16clearLibraryDirsEv")]
                 internal static extern void ClearLibraryDirs_0(global::System.IntPtr instance);
-
-                [SuppressUnmanagedCodeSecurity]
-                [DllImport("CppSharp.CppParser", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
-                    EntryPoint="_ZN8CppSharp9CppParser16CppParserOptions14getLibraryFileEv")]
-                internal static extern global::System.IntPtr GetLibraryFile(global::System.IntPtr instance);
-
-                [SuppressUnmanagedCodeSecurity]
-                [DllImport("CppSharp.CppParser", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
-                    EntryPoint="_ZN8CppSharp9CppParser16CppParserOptions14setLibraryFileEPKc")]
-                internal static extern void SetLibraryFile(global::System.IntPtr instance, [MarshalAs(UnmanagedType.LPStr)] string s);
-
-                [SuppressUnmanagedCodeSecurity]
-                [DllImport("CppSharp.CppParser", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
-                    EntryPoint="_ZN8CppSharp9CppParser16CppParserOptions15getTargetTripleEv")]
-                internal static extern global::System.IntPtr GetTargetTriple(global::System.IntPtr instance);
-
-                [SuppressUnmanagedCodeSecurity]
-                [DllImport("CppSharp.CppParser", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
-                    EntryPoint="_ZN8CppSharp9CppParser16CppParserOptions15setTargetTripleEPKc")]
-                internal static extern void SetTargetTriple(global::System.IntPtr instance, [MarshalAs(UnmanagedType.LPStr)] string s);
 
                 [SuppressUnmanagedCodeSecurity]
                 [DllImport("CppSharp.CppParser", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
@@ -18084,6 +18046,21 @@ namespace CppSharp
                 __Internal.ClearLibraryDirs_0((__Instance + __PointerAdjustment));
             }
 
+            public string LibraryFile
+            {
+                get
+                {
+                    return global::Std.__1.BasicString.__CreateInstance(((global::CppSharp.Parser.CppParserOptions.__Internal*) __Instance)->libraryFile).CStr();
+                }
+
+                set
+                {
+                    var __allocator0 = new global::Std.__1.Allocator();
+                    var __basicString0 = new global::Std.__1.BasicString(value, __allocator0);
+                    ((global::CppSharp.Parser.CppParserOptions.__Internal*) __Instance)->libraryFile = *(global::Std.__1.BasicString.__Internal*) __basicString0.__Instance;
+                }
+            }
+
             public global::CppSharp.Parser.AST.ASTContext ASTContext
             {
                 get
@@ -18112,6 +18089,21 @@ namespace CppSharp
                 set
                 {
                     ((global::CppSharp.Parser.CppParserOptions.__Internal*) __Instance)->toolSetToUse = value;
+                }
+            }
+
+            public string TargetTriple
+            {
+                get
+                {
+                    return global::Std.__1.BasicString.__CreateInstance(((global::CppSharp.Parser.CppParserOptions.__Internal*) __Instance)->targetTriple).CStr();
+                }
+
+                set
+                {
+                    var __allocator0 = new global::Std.__1.Allocator();
+                    var __basicString0 = new global::Std.__1.BasicString(value, __allocator0);
+                    ((global::CppSharp.Parser.CppParserOptions.__Internal*) __Instance)->targetTriple = *(global::Std.__1.BasicString.__Internal*) __basicString0.__Instance;
                 }
             }
 
@@ -18211,34 +18203,6 @@ namespace CppSharp
                 }
             }
 
-            public string LibraryFile
-            {
-                get
-                {
-                    var __ret = __Internal.GetLibraryFile((__Instance + __PointerAdjustment));
-                    return Marshal.PtrToStringAnsi(__ret);
-                }
-
-                set
-                {
-                    __Internal.SetLibraryFile((__Instance + __PointerAdjustment), value);
-                }
-            }
-
-            public string TargetTriple
-            {
-                get
-                {
-                    var __ret = __Internal.GetTargetTriple((__Instance + __PointerAdjustment));
-                    return Marshal.PtrToStringAnsi(__ret);
-                }
-
-                set
-                {
-                    __Internal.SetTargetTriple((__Instance + __PointerAdjustment), value);
-                }
-            }
-
             public uint ArgumentsCount
             {
                 get
@@ -18309,10 +18273,10 @@ namespace CppSharp
             public partial struct __Internal
             {
                 [FieldOffset(0)]
-                internal global::Std.__1.BasicString.__Internal FileName;
+                internal global::Std.__1.BasicString.__Internal fileName;
 
                 [FieldOffset(24)]
-                internal global::Std.__1.BasicString.__Internal Message;
+                internal global::Std.__1.BasicString.__Internal message;
 
                 [FieldOffset(48)]
                 internal global::CppSharp.Parser.ParserDiagnosticLevel level;
@@ -18337,26 +18301,6 @@ namespace CppSharp
                 [DllImport("CppSharp.CppParser", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
                     EntryPoint="_ZN8CppSharp9CppParser16ParserDiagnosticD2Ev")]
                 internal static extern void dtor_0(global::System.IntPtr instance);
-
-                [SuppressUnmanagedCodeSecurity]
-                [DllImport("CppSharp.CppParser", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
-                    EntryPoint="_ZN8CppSharp9CppParser16ParserDiagnostic11getFileNameEv")]
-                internal static extern global::System.IntPtr GetFileName(global::System.IntPtr instance);
-
-                [SuppressUnmanagedCodeSecurity]
-                [DllImport("CppSharp.CppParser", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
-                    EntryPoint="_ZN8CppSharp9CppParser16ParserDiagnostic11setFileNameEPKc")]
-                internal static extern void SetFileName(global::System.IntPtr instance, [MarshalAs(UnmanagedType.LPStr)] string s);
-
-                [SuppressUnmanagedCodeSecurity]
-                [DllImport("CppSharp.CppParser", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
-                    EntryPoint="_ZN8CppSharp9CppParser16ParserDiagnostic10getMessageEv")]
-                internal static extern global::System.IntPtr GetMessage(global::System.IntPtr instance);
-
-                [SuppressUnmanagedCodeSecurity]
-                [DllImport("CppSharp.CppParser", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
-                    EntryPoint="_ZN8CppSharp9CppParser16ParserDiagnostic10setMessageEPKc")]
-                internal static extern void SetMessage(global::System.IntPtr instance, [MarshalAs(UnmanagedType.LPStr)] string s);
             }
 
             public global::System.IntPtr __Instance { get; protected set; }
@@ -18435,6 +18379,36 @@ namespace CppSharp
                 __Instance = IntPtr.Zero;
             }
 
+            public string FileName
+            {
+                get
+                {
+                    return global::Std.__1.BasicString.__CreateInstance(((global::CppSharp.Parser.ParserDiagnostic.__Internal*) __Instance)->fileName).CStr();
+                }
+
+                set
+                {
+                    var __allocator0 = new global::Std.__1.Allocator();
+                    var __basicString0 = new global::Std.__1.BasicString(value, __allocator0);
+                    ((global::CppSharp.Parser.ParserDiagnostic.__Internal*) __Instance)->fileName = *(global::Std.__1.BasicString.__Internal*) __basicString0.__Instance;
+                }
+            }
+
+            public string Message
+            {
+                get
+                {
+                    return global::Std.__1.BasicString.__CreateInstance(((global::CppSharp.Parser.ParserDiagnostic.__Internal*) __Instance)->message).CStr();
+                }
+
+                set
+                {
+                    var __allocator0 = new global::Std.__1.Allocator();
+                    var __basicString0 = new global::Std.__1.BasicString(value, __allocator0);
+                    ((global::CppSharp.Parser.ParserDiagnostic.__Internal*) __Instance)->message = *(global::Std.__1.BasicString.__Internal*) __basicString0.__Instance;
+                }
+            }
+
             public global::CppSharp.Parser.ParserDiagnosticLevel Level
             {
                 get
@@ -18471,34 +18445,6 @@ namespace CppSharp
                 set
                 {
                     ((global::CppSharp.Parser.ParserDiagnostic.__Internal*) __Instance)->columnNumber = value;
-                }
-            }
-
-            public string FileName
-            {
-                get
-                {
-                    var __ret = __Internal.GetFileName((__Instance + __PointerAdjustment));
-                    return Marshal.PtrToStringAnsi(__ret);
-                }
-
-                set
-                {
-                    __Internal.SetFileName((__Instance + __PointerAdjustment), value);
-                }
-            }
-
-            public string Message
-            {
-                get
-                {
-                    var __ret = __Internal.GetMessage((__Instance + __PointerAdjustment));
-                    return Marshal.PtrToStringAnsi(__ret);
-                }
-
-                set
-                {
-                    __Internal.SetMessage((__Instance + __PointerAdjustment), value);
                 }
             }
         }

--- a/src/CppParser/Bindings/CSharp/x86_64-apple-darwin12.4.0/Std.cs
+++ b/src/CppParser/Bindings/CSharp/x86_64-apple-darwin12.4.0/Std.cs
@@ -1256,69 +1256,6 @@ namespace Std
 {
     namespace __1
     {
-        public unsafe partial class CharTraits : IDisposable
-        {
-            [StructLayout(LayoutKind.Explicit, Size = 0)]
-            public unsafe partial struct __Internal
-            {
-            }
-
-            public global::System.IntPtr __Instance { get; protected set; }
-
-            protected int __PointerAdjustment;
-            internal static readonly global::System.Collections.Concurrent.ConcurrentDictionary<IntPtr, global::Std.__1.CharTraits> NativeToManagedMap = new global::System.Collections.Concurrent.ConcurrentDictionary<IntPtr, global::Std.__1.CharTraits>();
-            protected void*[] __OriginalVTables;
-
-            protected bool __ownsNativeInstance;
-
-            internal static global::Std.__1.CharTraits __CreateInstance(global::System.IntPtr native, bool skipVTables = false)
-            {
-                return new global::Std.__1.CharTraits(native.ToPointer(), skipVTables);
-            }
-
-            internal static global::Std.__1.CharTraits __CreateInstance(global::Std.__1.CharTraits.__Internal native, bool skipVTables = false)
-            {
-                return new global::Std.__1.CharTraits(native, skipVTables);
-            }
-
-            private static void* __CopyValue(global::Std.__1.CharTraits.__Internal native)
-            {
-                var ret = Marshal.AllocHGlobal(sizeof(global::Std.__1.CharTraits.__Internal));
-                *(global::Std.__1.CharTraits.__Internal*) ret = native;
-                return ret.ToPointer();
-            }
-
-            private CharTraits(global::Std.__1.CharTraits.__Internal native, bool skipVTables = false)
-                : this(__CopyValue(native), skipVTables)
-            {
-                __ownsNativeInstance = true;
-                NativeToManagedMap[__Instance] = this;
-            }
-
-            protected CharTraits(void* native, bool skipVTables = false)
-            {
-                if (native == null)
-                    return;
-                __Instance = new global::System.IntPtr(native);
-            }
-
-            public void Dispose()
-            {
-                Dispose(disposing: true);
-            }
-
-            public virtual void Dispose(bool disposing)
-            {
-                if (__Instance == IntPtr.Zero)
-                    return;
-                global::Std.__1.CharTraits __dummy;
-                NativeToManagedMap.TryRemove(__Instance, out __dummy);
-                if (__ownsNativeInstance)
-                    Marshal.FreeHGlobal(__Instance);
-                __Instance = IntPtr.Zero;
-            }
-        }
-
         public unsafe partial class BasicString : IDisposable
         {
             [StructLayout(LayoutKind.Explicit, Size = 24)]
@@ -1326,6 +1263,11 @@ namespace Std
             {
                 [FieldOffset(0)]
                 internal global::Std.__1.CompressedPair.__Internal __r_;
+
+                [SuppressUnmanagedCodeSecurity]
+                [DllImport("Std-symbols", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
+                    EntryPoint="_ZNSt3__112basic_stringIcNS_11char_traitsIcEENS_9allocatorIcEEEC2EPKcRKS4_")]
+                internal static extern void ctorc__N_std_N___1_S_basic_string__C___N_std_N___1_S_char_traits__C___N_std_N___1_S_allocator__C_0(global::System.IntPtr instance, [MarshalAs(UnmanagedType.LPStr)] string __s, global::System.IntPtr __a);
 
                 [SuppressUnmanagedCodeSecurity]
                 [DllImport("Std-symbols", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
@@ -1492,6 +1434,17 @@ namespace Std
                 if (native == null)
                     return;
                 __Instance = new global::System.IntPtr(native);
+            }
+
+            public BasicString(string __s, global::Std.__1.Allocator __a)
+            {
+                __Instance = Marshal.AllocHGlobal(sizeof(global::Std.__1.BasicString.__Internal));
+                __ownsNativeInstance = true;
+                NativeToManagedMap[__Instance] = this;
+                if (ReferenceEquals(__a, null))
+                    throw new global::System.ArgumentNullException("__a", "Cannot be null because it is a C++ reference (&).");
+                var __arg1 = __a.__Instance;
+                global::Std.__1.BasicString.__Internal.ctorc__N_std_N___1_S_basic_string__C___N_std_N___1_S_char_traits__C___N_std_N___1_S_allocator__C_0((__Instance + __PointerAdjustment), __s, __arg1);
             }
 
             public void Dispose()

--- a/src/CppParser/Bindings/CSharp/x86_64-linux-gnu-cxx11abi/CppSharp.CppParser.cs
+++ b/src/CppParser/Bindings/CSharp/x86_64-linux-gnu-cxx11abi/CppSharp.CppParser.cs
@@ -2589,7 +2589,7 @@ namespace CppSharp
                     internal global::CppSharp.Parser.AST.QualifiedType.__Internal qualifier;
 
                     [FieldOffset(24)]
-                    internal global::Std.Cxx11.BasicString.__Internal Identifier;
+                    internal global::Std.Cxx11.BasicString.__Internal identifier;
 
                     [SuppressUnmanagedCodeSecurity]
                     [DllImport("CppSharp.CppParser", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
@@ -2605,16 +2605,6 @@ namespace CppSharp
                     [DllImport("CppSharp.CppParser", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
                         EntryPoint="_ZN8CppSharp9CppParser3AST17DependentNameTypeD2Ev")]
                     internal static extern void dtor_0(global::System.IntPtr instance);
-
-                    [SuppressUnmanagedCodeSecurity]
-                    [DllImport("CppSharp.CppParser", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
-                        EntryPoint="_ZN8CppSharp9CppParser3AST17DependentNameType13getIdentifierEv")]
-                    internal static extern global::System.IntPtr GetIdentifier(global::System.IntPtr instance);
-
-                    [SuppressUnmanagedCodeSecurity]
-                    [DllImport("CppSharp.CppParser", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
-                        EntryPoint="_ZN8CppSharp9CppParser3AST17DependentNameType13setIdentifierEPKc")]
-                    internal static extern void SetIdentifier(global::System.IntPtr instance, [MarshalAs(UnmanagedType.LPStr)] string s);
                 }
 
                 internal static new global::CppSharp.Parser.AST.DependentNameType __CreateInstance(global::System.IntPtr native, bool skipVTables = false)
@@ -2701,13 +2691,14 @@ namespace CppSharp
                 {
                     get
                     {
-                        var __ret = __Internal.GetIdentifier((__Instance + __PointerAdjustment));
-                        return Marshal.PtrToStringAnsi(__ret);
+                        return global::Std.Cxx11.BasicString.__CreateInstance(((global::CppSharp.Parser.AST.DependentNameType.__Internal*) __Instance)->identifier).CStr();
                     }
 
                     set
                     {
-                        __Internal.SetIdentifier((__Instance + __PointerAdjustment), value);
+                        var __allocator0 = new global::Std.Allocator();
+                        var __basicString0 = new global::Std.Cxx11.BasicString(value, __allocator0);
+                        ((global::CppSharp.Parser.AST.DependentNameType.__Internal*) __Instance)->identifier = *(global::Std.Cxx11.BasicString.__Internal*) __basicString0.__Instance;
                     }
                 }
             }
@@ -3561,7 +3552,7 @@ namespace CppSharp
                     internal uint offset;
 
                     [FieldOffset(8)]
-                    internal global::Std.Cxx11.BasicString.__Internal Name;
+                    internal global::Std.Cxx11.BasicString.__Internal name;
 
                     [FieldOffset(40)]
                     internal global::CppSharp.Parser.AST.QualifiedType.__Internal qualifiedType;
@@ -3583,16 +3574,6 @@ namespace CppSharp
                     [DllImport("CppSharp.CppParser", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
                         EntryPoint="_ZN8CppSharp9CppParser3AST11LayoutFieldD2Ev")]
                     internal static extern void dtor_0(global::System.IntPtr instance);
-
-                    [SuppressUnmanagedCodeSecurity]
-                    [DllImport("CppSharp.CppParser", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
-                        EntryPoint="_ZN8CppSharp9CppParser3AST11LayoutField7getNameEv")]
-                    internal static extern global::System.IntPtr GetName(global::System.IntPtr instance);
-
-                    [SuppressUnmanagedCodeSecurity]
-                    [DllImport("CppSharp.CppParser", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
-                        EntryPoint="_ZN8CppSharp9CppParser3AST11LayoutField7setNameEPKc")]
-                    internal static extern void SetName(global::System.IntPtr instance, [MarshalAs(UnmanagedType.LPStr)] string s);
                 }
 
                 public global::System.IntPtr __Instance { get; protected set; }
@@ -3684,6 +3665,21 @@ namespace CppSharp
                     }
                 }
 
+                public string Name
+                {
+                    get
+                    {
+                        return global::Std.Cxx11.BasicString.__CreateInstance(((global::CppSharp.Parser.AST.LayoutField.__Internal*) __Instance)->name).CStr();
+                    }
+
+                    set
+                    {
+                        var __allocator0 = new global::Std.Allocator();
+                        var __basicString0 = new global::Std.Cxx11.BasicString(value, __allocator0);
+                        ((global::CppSharp.Parser.AST.LayoutField.__Internal*) __Instance)->name = *(global::Std.Cxx11.BasicString.__Internal*) __basicString0.__Instance;
+                    }
+                }
+
                 public global::CppSharp.Parser.AST.QualifiedType QualifiedType
                 {
                     get
@@ -3707,20 +3703,6 @@ namespace CppSharp
                     set
                     {
                         ((global::CppSharp.Parser.AST.LayoutField.__Internal*) __Instance)->fieldPtr = (global::System.IntPtr) value;
-                    }
-                }
-
-                public string Name
-                {
-                    get
-                    {
-                        var __ret = __Internal.GetName((__Instance + __PointerAdjustment));
-                        return Marshal.PtrToStringAnsi(__ret);
-                    }
-
-                    set
-                    {
-                        __Internal.SetName((__Instance + __PointerAdjustment), value);
                     }
                 }
             }
@@ -4250,13 +4232,13 @@ namespace CppSharp
                     internal int lineNumberEnd;
 
                     [FieldOffset(32)]
-                    internal global::Std.Cxx11.BasicString.__Internal Name;
+                    internal global::Std.Cxx11.BasicString.__Internal name;
 
                     [FieldOffset(64)]
                     internal global::Std.Cxx11.BasicString.__Internal USR;
 
                     [FieldOffset(96)]
-                    internal global::Std.Cxx11.BasicString.__Internal DebugText;
+                    internal global::Std.Cxx11.BasicString.__Internal debugText;
 
                     [FieldOffset(128)]
                     internal byte isIncomplete;
@@ -4329,36 +4311,6 @@ namespace CppSharp
                     [DllImport("CppSharp.CppParser", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
                         EntryPoint="_ZN8CppSharp9CppParser3AST11Declaration19clearRedeclarationsEv")]
                     internal static extern void ClearRedeclarations_0(global::System.IntPtr instance);
-
-                    [SuppressUnmanagedCodeSecurity]
-                    [DllImport("CppSharp.CppParser", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
-                        EntryPoint="_ZN8CppSharp9CppParser3AST11Declaration7getNameEv")]
-                    internal static extern global::System.IntPtr GetName(global::System.IntPtr instance);
-
-                    [SuppressUnmanagedCodeSecurity]
-                    [DllImport("CppSharp.CppParser", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
-                        EntryPoint="_ZN8CppSharp9CppParser3AST11Declaration7setNameEPKc")]
-                    internal static extern void SetName(global::System.IntPtr instance, [MarshalAs(UnmanagedType.LPStr)] string s);
-
-                    [SuppressUnmanagedCodeSecurity]
-                    [DllImport("CppSharp.CppParser", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
-                        EntryPoint="_ZN8CppSharp9CppParser3AST11Declaration6getUSREv")]
-                    internal static extern global::System.IntPtr GetUSR(global::System.IntPtr instance);
-
-                    [SuppressUnmanagedCodeSecurity]
-                    [DllImport("CppSharp.CppParser", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
-                        EntryPoint="_ZN8CppSharp9CppParser3AST11Declaration6setUSREPKc")]
-                    internal static extern void SetUSR(global::System.IntPtr instance, [MarshalAs(UnmanagedType.LPStr)] string s);
-
-                    [SuppressUnmanagedCodeSecurity]
-                    [DllImport("CppSharp.CppParser", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
-                        EntryPoint="_ZN8CppSharp9CppParser3AST11Declaration12getDebugTextEv")]
-                    internal static extern global::System.IntPtr GetDebugText(global::System.IntPtr instance);
-
-                    [SuppressUnmanagedCodeSecurity]
-                    [DllImport("CppSharp.CppParser", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
-                        EntryPoint="_ZN8CppSharp9CppParser3AST11Declaration12setDebugTextEPKc")]
-                    internal static extern void SetDebugText(global::System.IntPtr instance, [MarshalAs(UnmanagedType.LPStr)] string s);
 
                     [SuppressUnmanagedCodeSecurity]
                     [DllImport("CppSharp.CppParser", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
@@ -4583,6 +4535,51 @@ namespace CppSharp
                     }
                 }
 
+                public string Name
+                {
+                    get
+                    {
+                        return global::Std.Cxx11.BasicString.__CreateInstance(((global::CppSharp.Parser.AST.Declaration.__Internal*) __Instance)->name).CStr();
+                    }
+
+                    set
+                    {
+                        var __allocator0 = new global::Std.Allocator();
+                        var __basicString0 = new global::Std.Cxx11.BasicString(value, __allocator0);
+                        ((global::CppSharp.Parser.AST.Declaration.__Internal*) __Instance)->name = *(global::Std.Cxx11.BasicString.__Internal*) __basicString0.__Instance;
+                    }
+                }
+
+                public string USR
+                {
+                    get
+                    {
+                        return global::Std.Cxx11.BasicString.__CreateInstance(((global::CppSharp.Parser.AST.Declaration.__Internal*) __Instance)->USR).CStr();
+                    }
+
+                    set
+                    {
+                        var __allocator0 = new global::Std.Allocator();
+                        var __basicString0 = new global::Std.Cxx11.BasicString(value, __allocator0);
+                        ((global::CppSharp.Parser.AST.Declaration.__Internal*) __Instance)->USR = *(global::Std.Cxx11.BasicString.__Internal*) __basicString0.__Instance;
+                    }
+                }
+
+                public string DebugText
+                {
+                    get
+                    {
+                        return global::Std.Cxx11.BasicString.__CreateInstance(((global::CppSharp.Parser.AST.Declaration.__Internal*) __Instance)->debugText).CStr();
+                    }
+
+                    set
+                    {
+                        var __allocator0 = new global::Std.Allocator();
+                        var __basicString0 = new global::Std.Cxx11.BasicString(value, __allocator0);
+                        ((global::CppSharp.Parser.AST.Declaration.__Internal*) __Instance)->debugText = *(global::Std.Cxx11.BasicString.__Internal*) __basicString0.__Instance;
+                    }
+                }
+
                 public bool IsIncomplete
                 {
                     get
@@ -4684,48 +4681,6 @@ namespace CppSharp
                     }
                 }
 
-                public string Name
-                {
-                    get
-                    {
-                        var __ret = __Internal.GetName((__Instance + __PointerAdjustment));
-                        return Marshal.PtrToStringAnsi(__ret);
-                    }
-
-                    set
-                    {
-                        __Internal.SetName((__Instance + __PointerAdjustment), value);
-                    }
-                }
-
-                public string USR
-                {
-                    get
-                    {
-                        var __ret = __Internal.GetUSR((__Instance + __PointerAdjustment));
-                        return Marshal.PtrToStringAnsi(__ret);
-                    }
-
-                    set
-                    {
-                        __Internal.SetUSR((__Instance + __PointerAdjustment), value);
-                    }
-                }
-
-                public string DebugText
-                {
-                    get
-                    {
-                        var __ret = __Internal.GetDebugText((__Instance + __PointerAdjustment));
-                        return Marshal.PtrToStringAnsi(__ret);
-                    }
-
-                    set
-                    {
-                        __Internal.SetDebugText((__Instance + __PointerAdjustment), value);
-                    }
-                }
-
                 public uint PreprocessedEntitiesCount
                 {
                     get
@@ -4769,13 +4724,13 @@ namespace CppSharp
                     internal int lineNumberEnd;
 
                     [FieldOffset(32)]
-                    internal global::Std.Cxx11.BasicString.__Internal Name;
+                    internal global::Std.Cxx11.BasicString.__Internal name;
 
                     [FieldOffset(64)]
                     internal global::Std.Cxx11.BasicString.__Internal USR;
 
                     [FieldOffset(96)]
-                    internal global::Std.Cxx11.BasicString.__Internal DebugText;
+                    internal global::Std.Cxx11.BasicString.__Internal debugText;
 
                     [FieldOffset(128)]
                     internal byte isIncomplete;
@@ -5440,13 +5395,13 @@ namespace CppSharp
                     internal int lineNumberEnd;
 
                     [FieldOffset(32)]
-                    internal global::Std.Cxx11.BasicString.__Internal Name;
+                    internal global::Std.Cxx11.BasicString.__Internal name;
 
                     [FieldOffset(64)]
                     internal global::Std.Cxx11.BasicString.__Internal USR;
 
                     [FieldOffset(96)]
-                    internal global::Std.Cxx11.BasicString.__Internal DebugText;
+                    internal global::Std.Cxx11.BasicString.__Internal debugText;
 
                     [FieldOffset(128)]
                     internal byte isIncomplete;
@@ -5604,13 +5559,13 @@ namespace CppSharp
                     internal int lineNumberEnd;
 
                     [FieldOffset(32)]
-                    internal global::Std.Cxx11.BasicString.__Internal Name;
+                    internal global::Std.Cxx11.BasicString.__Internal name;
 
                     [FieldOffset(64)]
                     internal global::Std.Cxx11.BasicString.__Internal USR;
 
                     [FieldOffset(96)]
-                    internal global::Std.Cxx11.BasicString.__Internal DebugText;
+                    internal global::Std.Cxx11.BasicString.__Internal debugText;
 
                     [FieldOffset(128)]
                     internal byte isIncomplete;
@@ -5750,13 +5705,13 @@ namespace CppSharp
                     internal int lineNumberEnd;
 
                     [FieldOffset(32)]
-                    internal global::Std.Cxx11.BasicString.__Internal Name;
+                    internal global::Std.Cxx11.BasicString.__Internal name;
 
                     [FieldOffset(64)]
                     internal global::Std.Cxx11.BasicString.__Internal USR;
 
                     [FieldOffset(96)]
-                    internal global::Std.Cxx11.BasicString.__Internal DebugText;
+                    internal global::Std.Cxx11.BasicString.__Internal debugText;
 
                     [FieldOffset(128)]
                     internal byte isIncomplete;
@@ -5917,13 +5872,13 @@ namespace CppSharp
                     internal int lineNumberEnd;
 
                     [FieldOffset(32)]
-                    internal global::Std.Cxx11.BasicString.__Internal Name;
+                    internal global::Std.Cxx11.BasicString.__Internal name;
 
                     [FieldOffset(64)]
                     internal global::Std.Cxx11.BasicString.__Internal USR;
 
                     [FieldOffset(96)]
-                    internal global::Std.Cxx11.BasicString.__Internal DebugText;
+                    internal global::Std.Cxx11.BasicString.__Internal debugText;
 
                     [FieldOffset(128)]
                     internal byte isIncomplete;
@@ -6069,27 +6024,22 @@ namespace CppSharp
                     internal global::System.IntPtr decl;
 
                     [FieldOffset(16)]
-                    internal global::Std.Cxx11.BasicString.__Internal String;
+                    internal global::Std.Cxx11.BasicString.__Internal @string;
+
+                    [SuppressUnmanagedCodeSecurity]
+                    [DllImport("CppSharp.CppParser", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
+                        EntryPoint="_ZN8CppSharp9CppParser3AST9StatementC2ERKNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEENS1_14StatementClassEPNS1_11DeclarationE")]
+                    internal static extern void ctor_0(global::System.IntPtr instance, global::System.IntPtr str, global::CppSharp.Parser.AST.StatementClass Class, global::System.IntPtr decl);
 
                     [SuppressUnmanagedCodeSecurity]
                     [DllImport("CppSharp.CppParser", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
                         EntryPoint="_ZN8CppSharp9CppParser3AST9StatementC2ERKS2_")]
-                    internal static extern void cctor_0(global::System.IntPtr instance, global::System.IntPtr _0);
+                    internal static extern void cctor_1(global::System.IntPtr instance, global::System.IntPtr _0);
 
                     [SuppressUnmanagedCodeSecurity]
                     [DllImport("CppSharp.CppParser", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
                         EntryPoint="_ZN8CppSharp9CppParser3AST9StatementD2Ev")]
                     internal static extern void dtor_0(global::System.IntPtr instance);
-
-                    [SuppressUnmanagedCodeSecurity]
-                    [DllImport("CppSharp.CppParser", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
-                        EntryPoint="_ZN8CppSharp9CppParser3AST9Statement9getStringEv")]
-                    internal static extern global::System.IntPtr GetString(global::System.IntPtr instance);
-
-                    [SuppressUnmanagedCodeSecurity]
-                    [DllImport("CppSharp.CppParser", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
-                        EntryPoint="_ZN8CppSharp9CppParser3AST9Statement9setStringEPKc")]
-                    internal static extern void SetString(global::System.IntPtr instance, [MarshalAs(UnmanagedType.LPStr)] string s);
                 }
 
                 public global::System.IntPtr __Instance { get; protected set; }
@@ -6113,7 +6063,7 @@ namespace CppSharp
                 private static void* __CopyValue(global::CppSharp.Parser.AST.Statement.__Internal native)
                 {
                     var ret = Marshal.AllocHGlobal(sizeof(global::CppSharp.Parser.AST.Statement.__Internal));
-                    global::CppSharp.Parser.AST.Statement.__Internal.cctor_0(ret, new global::System.IntPtr(&native));
+                    global::CppSharp.Parser.AST.Statement.__Internal.cctor_1(ret, new global::System.IntPtr(&native));
                     return ret.ToPointer();
                 }
 
@@ -6131,6 +6081,20 @@ namespace CppSharp
                     __Instance = new global::System.IntPtr(native);
                 }
 
+                public Statement(string str, global::CppSharp.Parser.AST.StatementClass Class, global::CppSharp.Parser.AST.Declaration decl)
+                {
+                    __Instance = Marshal.AllocHGlobal(sizeof(global::CppSharp.Parser.AST.Statement.__Internal));
+                    __ownsNativeInstance = true;
+                    NativeToManagedMap[__Instance] = this;
+                    var __allocator0 = new global::Std.Allocator();
+                    var __basicString0 = new global::Std.Cxx11.BasicString(str, __allocator0);
+                    var __arg0 = __basicString0.__Instance;
+                    var __arg2 = ReferenceEquals(decl, null) ? global::System.IntPtr.Zero : decl.__Instance;
+                    __Internal.ctor_0((__Instance + __PointerAdjustment), __arg0, Class, __arg2);
+                    __basicString0.Dispose(false);
+                    __allocator0.Dispose();
+                }
+
                 public Statement(global::CppSharp.Parser.AST.Statement _0)
                 {
                     __Instance = Marshal.AllocHGlobal(sizeof(global::CppSharp.Parser.AST.Statement.__Internal));
@@ -6139,7 +6103,7 @@ namespace CppSharp
                     if (ReferenceEquals(_0, null))
                         throw new global::System.ArgumentNullException("_0", "Cannot be null because it is a C++ reference (&).");
                     var __arg0 = _0.__Instance;
-                    __Internal.cctor_0((__Instance + __PointerAdjustment), __arg0);
+                    __Internal.cctor_1((__Instance + __PointerAdjustment), __arg0);
                 }
 
                 public void Dispose()
@@ -6195,13 +6159,14 @@ namespace CppSharp
                 {
                     get
                     {
-                        var __ret = __Internal.GetString((__Instance + __PointerAdjustment));
-                        return Marshal.PtrToStringAnsi(__ret);
+                        return global::Std.Cxx11.BasicString.__CreateInstance(((global::CppSharp.Parser.AST.Statement.__Internal*) __Instance)->@string).CStr();
                     }
 
                     set
                     {
-                        __Internal.SetString((__Instance + __PointerAdjustment), value);
+                        var __allocator0 = new global::Std.Allocator();
+                        var __basicString0 = new global::Std.Cxx11.BasicString(value, __allocator0);
+                        ((global::CppSharp.Parser.AST.Statement.__Internal*) __Instance)->@string = *(global::Std.Cxx11.BasicString.__Internal*) __basicString0.__Instance;
                     }
                 }
             }
@@ -6218,12 +6183,17 @@ namespace CppSharp
                     internal global::System.IntPtr decl;
 
                     [FieldOffset(16)]
-                    internal global::Std.Cxx11.BasicString.__Internal String;
+                    internal global::Std.Cxx11.BasicString.__Internal @string;
+
+                    [SuppressUnmanagedCodeSecurity]
+                    [DllImport("CppSharp.CppParser", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
+                        EntryPoint="_ZN8CppSharp9CppParser3AST10ExpressionC2ERKNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEENS1_14StatementClassEPNS1_11DeclarationE")]
+                    internal static extern void ctor_0(global::System.IntPtr instance, global::System.IntPtr str, global::CppSharp.Parser.AST.StatementClass Class, global::System.IntPtr decl);
 
                     [SuppressUnmanagedCodeSecurity]
                     [DllImport("CppSharp.CppParser", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
                         EntryPoint="_ZN8CppSharp9CppParser3AST10ExpressionC2ERKS2_")]
-                    internal static extern void cctor_0(global::System.IntPtr instance, global::System.IntPtr _0);
+                    internal static extern void cctor_1(global::System.IntPtr instance, global::System.IntPtr _0);
 
                     [SuppressUnmanagedCodeSecurity]
                     [DllImport("CppSharp.CppParser", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
@@ -6244,7 +6214,7 @@ namespace CppSharp
                 private static void* __CopyValue(global::CppSharp.Parser.AST.Expression.__Internal native)
                 {
                     var ret = Marshal.AllocHGlobal(sizeof(global::CppSharp.Parser.AST.Expression.__Internal));
-                    global::CppSharp.Parser.AST.Expression.__Internal.cctor_0(ret, new global::System.IntPtr(&native));
+                    global::CppSharp.Parser.AST.Expression.__Internal.cctor_1(ret, new global::System.IntPtr(&native));
                     return ret.ToPointer();
                 }
 
@@ -6264,6 +6234,21 @@ namespace CppSharp
                     __Instance = new global::System.IntPtr(native);
                 }
 
+                public Expression(string str, global::CppSharp.Parser.AST.StatementClass Class, global::CppSharp.Parser.AST.Declaration decl)
+                    : this((void*) null)
+                {
+                    __Instance = Marshal.AllocHGlobal(sizeof(global::CppSharp.Parser.AST.Expression.__Internal));
+                    __ownsNativeInstance = true;
+                    NativeToManagedMap[__Instance] = this;
+                    var __allocator0 = new global::Std.Allocator();
+                    var __basicString0 = new global::Std.Cxx11.BasicString(str, __allocator0);
+                    var __arg0 = __basicString0.__Instance;
+                    var __arg2 = ReferenceEquals(decl, null) ? global::System.IntPtr.Zero : decl.__Instance;
+                    __Internal.ctor_0((__Instance + __PointerAdjustment), __arg0, Class, __arg2);
+                    __basicString0.Dispose(false);
+                    __allocator0.Dispose();
+                }
+
                 public Expression(global::CppSharp.Parser.AST.Expression _0)
                     : this((void*) null)
                 {
@@ -6273,7 +6258,7 @@ namespace CppSharp
                     if (ReferenceEquals(_0, null))
                         throw new global::System.ArgumentNullException("_0", "Cannot be null because it is a C++ reference (&).");
                     var __arg0 = _0.__Instance;
-                    __Internal.cctor_0((__Instance + __PointerAdjustment), __arg0);
+                    __Internal.cctor_1((__Instance + __PointerAdjustment), __arg0);
                 }
 
                 public override void Dispose(bool disposing)
@@ -6302,7 +6287,7 @@ namespace CppSharp
                     internal global::System.IntPtr decl;
 
                     [FieldOffset(16)]
-                    internal global::Std.Cxx11.BasicString.__Internal String;
+                    internal global::Std.Cxx11.BasicString.__Internal @string;
 
                     [FieldOffset(48)]
                     internal global::System.IntPtr LHS;
@@ -6311,27 +6296,22 @@ namespace CppSharp
                     internal global::System.IntPtr RHS;
 
                     [FieldOffset(64)]
-                    internal global::Std.Cxx11.BasicString.__Internal OpcodeStr;
+                    internal global::Std.Cxx11.BasicString.__Internal opcodeStr;
+
+                    [SuppressUnmanagedCodeSecurity]
+                    [DllImport("CppSharp.CppParser", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
+                        EntryPoint="_ZN8CppSharp9CppParser3AST14BinaryOperatorC2ERKNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEPNS1_10ExpressionESC_SA_")]
+                    internal static extern void ctor_0(global::System.IntPtr instance, global::System.IntPtr str, global::System.IntPtr lhs, global::System.IntPtr rhs, global::System.IntPtr opcodeStr);
 
                     [SuppressUnmanagedCodeSecurity]
                     [DllImport("CppSharp.CppParser", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
                         EntryPoint="_ZN8CppSharp9CppParser3AST14BinaryOperatorC2ERKS2_")]
-                    internal static extern void cctor_0(global::System.IntPtr instance, global::System.IntPtr _0);
+                    internal static extern void cctor_1(global::System.IntPtr instance, global::System.IntPtr _0);
 
                     [SuppressUnmanagedCodeSecurity]
                     [DllImport("CppSharp.CppParser", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
                         EntryPoint="_ZN8CppSharp9CppParser3AST14BinaryOperatorD2Ev")]
                     internal static extern void dtor_0(global::System.IntPtr instance);
-
-                    [SuppressUnmanagedCodeSecurity]
-                    [DllImport("CppSharp.CppParser", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
-                        EntryPoint="_ZN8CppSharp9CppParser3AST14BinaryOperator12getOpcodeStrEv")]
-                    internal static extern global::System.IntPtr GetOpcodeStr(global::System.IntPtr instance);
-
-                    [SuppressUnmanagedCodeSecurity]
-                    [DllImport("CppSharp.CppParser", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
-                        EntryPoint="_ZN8CppSharp9CppParser3AST14BinaryOperator12setOpcodeStrEPKc")]
-                    internal static extern void SetOpcodeStr(global::System.IntPtr instance, [MarshalAs(UnmanagedType.LPStr)] string s);
                 }
 
                 internal static new global::CppSharp.Parser.AST.BinaryOperator __CreateInstance(global::System.IntPtr native, bool skipVTables = false)
@@ -6347,7 +6327,7 @@ namespace CppSharp
                 private static void* __CopyValue(global::CppSharp.Parser.AST.BinaryOperator.__Internal native)
                 {
                     var ret = Marshal.AllocHGlobal(sizeof(global::CppSharp.Parser.AST.BinaryOperator.__Internal));
-                    global::CppSharp.Parser.AST.BinaryOperator.__Internal.cctor_0(ret, new global::System.IntPtr(&native));
+                    global::CppSharp.Parser.AST.BinaryOperator.__Internal.cctor_1(ret, new global::System.IntPtr(&native));
                     return ret.ToPointer();
                 }
 
@@ -6367,6 +6347,27 @@ namespace CppSharp
                     __Instance = new global::System.IntPtr(native);
                 }
 
+                public BinaryOperator(string str, global::CppSharp.Parser.AST.Expression lhs, global::CppSharp.Parser.AST.Expression rhs, string opcodeStr)
+                    : this((void*) null)
+                {
+                    __Instance = Marshal.AllocHGlobal(sizeof(global::CppSharp.Parser.AST.BinaryOperator.__Internal));
+                    __ownsNativeInstance = true;
+                    NativeToManagedMap[__Instance] = this;
+                    var __allocator0 = new global::Std.Allocator();
+                    var __basicString0 = new global::Std.Cxx11.BasicString(str, __allocator0);
+                    var __arg0 = __basicString0.__Instance;
+                    var __arg1 = ReferenceEquals(lhs, null) ? global::System.IntPtr.Zero : lhs.__Instance;
+                    var __arg2 = ReferenceEquals(rhs, null) ? global::System.IntPtr.Zero : rhs.__Instance;
+                    var __allocator3 = new global::Std.Allocator();
+                    var __basicString3 = new global::Std.Cxx11.BasicString(opcodeStr, __allocator3);
+                    var __arg3 = __basicString3.__Instance;
+                    __Internal.ctor_0((__Instance + __PointerAdjustment), __arg0, __arg1, __arg2, __arg3);
+                    __basicString0.Dispose(false);
+                    __allocator0.Dispose();
+                    __basicString3.Dispose(false);
+                    __allocator3.Dispose();
+                }
+
                 public BinaryOperator(global::CppSharp.Parser.AST.BinaryOperator _0)
                     : this((void*) null)
                 {
@@ -6376,7 +6377,7 @@ namespace CppSharp
                     if (ReferenceEquals(_0, null))
                         throw new global::System.ArgumentNullException("_0", "Cannot be null because it is a C++ reference (&).");
                     var __arg0 = _0.__Instance;
-                    __Internal.cctor_0((__Instance + __PointerAdjustment), __arg0);
+                    __Internal.cctor_1((__Instance + __PointerAdjustment), __arg0);
                 }
 
                 public override void Dispose(bool disposing)
@@ -6432,13 +6433,14 @@ namespace CppSharp
                 {
                     get
                     {
-                        var __ret = __Internal.GetOpcodeStr((__Instance + __PointerAdjustment));
-                        return Marshal.PtrToStringAnsi(__ret);
+                        return global::Std.Cxx11.BasicString.__CreateInstance(((global::CppSharp.Parser.AST.BinaryOperator.__Internal*) __Instance)->opcodeStr).CStr();
                     }
 
                     set
                     {
-                        __Internal.SetOpcodeStr((__Instance + __PointerAdjustment), value);
+                        var __allocator0 = new global::Std.Allocator();
+                        var __basicString0 = new global::Std.Cxx11.BasicString(value, __allocator0);
+                        ((global::CppSharp.Parser.AST.BinaryOperator.__Internal*) __Instance)->opcodeStr = *(global::Std.Cxx11.BasicString.__Internal*) __basicString0.__Instance;
                     }
                 }
             }
@@ -6455,15 +6457,20 @@ namespace CppSharp
                     internal global::System.IntPtr decl;
 
                     [FieldOffset(16)]
-                    internal global::Std.Cxx11.BasicString.__Internal String;
+                    internal global::Std.Cxx11.BasicString.__Internal @string;
 
                     [FieldOffset(48)]
                     internal global::Std.Vector.__Internal Arguments;
 
                     [SuppressUnmanagedCodeSecurity]
                     [DllImport("CppSharp.CppParser", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
+                        EntryPoint="_ZN8CppSharp9CppParser3AST8CallExprC2ERKNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEPNS1_11DeclarationE")]
+                    internal static extern void ctor_0(global::System.IntPtr instance, global::System.IntPtr str, global::System.IntPtr decl);
+
+                    [SuppressUnmanagedCodeSecurity]
+                    [DllImport("CppSharp.CppParser", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
                         EntryPoint="_ZN8CppSharp9CppParser3AST8CallExprC2ERKS2_")]
-                    internal static extern void cctor_0(global::System.IntPtr instance, global::System.IntPtr _0);
+                    internal static extern void cctor_1(global::System.IntPtr instance, global::System.IntPtr _0);
 
                     [SuppressUnmanagedCodeSecurity]
                     [DllImport("CppSharp.CppParser", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
@@ -6504,7 +6511,7 @@ namespace CppSharp
                 private static void* __CopyValue(global::CppSharp.Parser.AST.CallExpr.__Internal native)
                 {
                     var ret = Marshal.AllocHGlobal(sizeof(global::CppSharp.Parser.AST.CallExpr.__Internal));
-                    global::CppSharp.Parser.AST.CallExpr.__Internal.cctor_0(ret, new global::System.IntPtr(&native));
+                    global::CppSharp.Parser.AST.CallExpr.__Internal.cctor_1(ret, new global::System.IntPtr(&native));
                     return ret.ToPointer();
                 }
 
@@ -6524,6 +6531,21 @@ namespace CppSharp
                     __Instance = new global::System.IntPtr(native);
                 }
 
+                public CallExpr(string str, global::CppSharp.Parser.AST.Declaration decl)
+                    : this((void*) null)
+                {
+                    __Instance = Marshal.AllocHGlobal(sizeof(global::CppSharp.Parser.AST.CallExpr.__Internal));
+                    __ownsNativeInstance = true;
+                    NativeToManagedMap[__Instance] = this;
+                    var __allocator0 = new global::Std.Allocator();
+                    var __basicString0 = new global::Std.Cxx11.BasicString(str, __allocator0);
+                    var __arg0 = __basicString0.__Instance;
+                    var __arg1 = ReferenceEquals(decl, null) ? global::System.IntPtr.Zero : decl.__Instance;
+                    __Internal.ctor_0((__Instance + __PointerAdjustment), __arg0, __arg1);
+                    __basicString0.Dispose(false);
+                    __allocator0.Dispose();
+                }
+
                 public CallExpr(global::CppSharp.Parser.AST.CallExpr _0)
                     : this((void*) null)
                 {
@@ -6533,7 +6555,7 @@ namespace CppSharp
                     if (ReferenceEquals(_0, null))
                         throw new global::System.ArgumentNullException("_0", "Cannot be null because it is a C++ reference (&).");
                     var __arg0 = _0.__Instance;
-                    __Internal.cctor_0((__Instance + __PointerAdjustment), __arg0);
+                    __Internal.cctor_1((__Instance + __PointerAdjustment), __arg0);
                 }
 
                 public override void Dispose(bool disposing)
@@ -6595,15 +6617,20 @@ namespace CppSharp
                     internal global::System.IntPtr decl;
 
                     [FieldOffset(16)]
-                    internal global::Std.Cxx11.BasicString.__Internal String;
+                    internal global::Std.Cxx11.BasicString.__Internal @string;
 
                     [FieldOffset(48)]
                     internal global::Std.Vector.__Internal Arguments;
 
                     [SuppressUnmanagedCodeSecurity]
                     [DllImport("CppSharp.CppParser", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
+                        EntryPoint="_ZN8CppSharp9CppParser3AST16CXXConstructExprC2ERKNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEPNS1_11DeclarationE")]
+                    internal static extern void ctor_0(global::System.IntPtr instance, global::System.IntPtr str, global::System.IntPtr decl);
+
+                    [SuppressUnmanagedCodeSecurity]
+                    [DllImport("CppSharp.CppParser", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
                         EntryPoint="_ZN8CppSharp9CppParser3AST16CXXConstructExprC2ERKS2_")]
-                    internal static extern void cctor_0(global::System.IntPtr instance, global::System.IntPtr _0);
+                    internal static extern void cctor_1(global::System.IntPtr instance, global::System.IntPtr _0);
 
                     [SuppressUnmanagedCodeSecurity]
                     [DllImport("CppSharp.CppParser", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
@@ -6644,7 +6671,7 @@ namespace CppSharp
                 private static void* __CopyValue(global::CppSharp.Parser.AST.CXXConstructExpr.__Internal native)
                 {
                     var ret = Marshal.AllocHGlobal(sizeof(global::CppSharp.Parser.AST.CXXConstructExpr.__Internal));
-                    global::CppSharp.Parser.AST.CXXConstructExpr.__Internal.cctor_0(ret, new global::System.IntPtr(&native));
+                    global::CppSharp.Parser.AST.CXXConstructExpr.__Internal.cctor_1(ret, new global::System.IntPtr(&native));
                     return ret.ToPointer();
                 }
 
@@ -6664,6 +6691,21 @@ namespace CppSharp
                     __Instance = new global::System.IntPtr(native);
                 }
 
+                public CXXConstructExpr(string str, global::CppSharp.Parser.AST.Declaration decl)
+                    : this((void*) null)
+                {
+                    __Instance = Marshal.AllocHGlobal(sizeof(global::CppSharp.Parser.AST.CXXConstructExpr.__Internal));
+                    __ownsNativeInstance = true;
+                    NativeToManagedMap[__Instance] = this;
+                    var __allocator0 = new global::Std.Allocator();
+                    var __basicString0 = new global::Std.Cxx11.BasicString(str, __allocator0);
+                    var __arg0 = __basicString0.__Instance;
+                    var __arg1 = ReferenceEquals(decl, null) ? global::System.IntPtr.Zero : decl.__Instance;
+                    __Internal.ctor_0((__Instance + __PointerAdjustment), __arg0, __arg1);
+                    __basicString0.Dispose(false);
+                    __allocator0.Dispose();
+                }
+
                 public CXXConstructExpr(global::CppSharp.Parser.AST.CXXConstructExpr _0)
                     : this((void*) null)
                 {
@@ -6673,7 +6715,7 @@ namespace CppSharp
                     if (ReferenceEquals(_0, null))
                         throw new global::System.ArgumentNullException("_0", "Cannot be null because it is a C++ reference (&).");
                     var __arg0 = _0.__Instance;
-                    __Internal.cctor_0((__Instance + __PointerAdjustment), __arg0);
+                    __Internal.cctor_1((__Instance + __PointerAdjustment), __arg0);
                 }
 
                 public override void Dispose(bool disposing)
@@ -6747,13 +6789,13 @@ namespace CppSharp
                     internal int lineNumberEnd;
 
                     [FieldOffset(32)]
-                    internal global::Std.Cxx11.BasicString.__Internal Name;
+                    internal global::Std.Cxx11.BasicString.__Internal name;
 
                     [FieldOffset(64)]
                     internal global::Std.Cxx11.BasicString.__Internal USR;
 
                     [FieldOffset(96)]
-                    internal global::Std.Cxx11.BasicString.__Internal DebugText;
+                    internal global::Std.Cxx11.BasicString.__Internal debugText;
 
                     [FieldOffset(128)]
                     internal byte isIncomplete;
@@ -6975,13 +7017,13 @@ namespace CppSharp
                     internal int lineNumberEnd;
 
                     [FieldOffset(32)]
-                    internal global::Std.Cxx11.BasicString.__Internal Name;
+                    internal global::Std.Cxx11.BasicString.__Internal name;
 
                     [FieldOffset(64)]
                     internal global::Std.Cxx11.BasicString.__Internal USR;
 
                     [FieldOffset(96)]
-                    internal global::Std.Cxx11.BasicString.__Internal DebugText;
+                    internal global::Std.Cxx11.BasicString.__Internal debugText;
 
                     [FieldOffset(128)]
                     internal byte isIncomplete;
@@ -7041,13 +7083,13 @@ namespace CppSharp
                     internal global::CppSharp.Parser.AST.CXXOperatorKind operatorKind;
 
                     [FieldOffset(248)]
-                    internal global::Std.Cxx11.BasicString.__Internal Mangled;
+                    internal global::Std.Cxx11.BasicString.__Internal mangled;
 
                     [FieldOffset(280)]
-                    internal global::Std.Cxx11.BasicString.__Internal Signature;
+                    internal global::Std.Cxx11.BasicString.__Internal signature;
 
                     [FieldOffset(312)]
-                    internal global::Std.Cxx11.BasicString.__Internal Body;
+                    internal global::Std.Cxx11.BasicString.__Internal body;
 
                     [FieldOffset(344)]
                     internal global::CppSharp.Parser.AST.CallingConvention callingConvention;
@@ -7093,36 +7135,6 @@ namespace CppSharp
                     [DllImport("CppSharp.CppParser", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
                         EntryPoint="_ZN8CppSharp9CppParser3AST8Function15clearParametersEv")]
                     internal static extern void ClearParameters_0(global::System.IntPtr instance);
-
-                    [SuppressUnmanagedCodeSecurity]
-                    [DllImport("CppSharp.CppParser", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
-                        EntryPoint="_ZN8CppSharp9CppParser3AST8Function10getMangledEv")]
-                    internal static extern global::System.IntPtr GetMangled(global::System.IntPtr instance);
-
-                    [SuppressUnmanagedCodeSecurity]
-                    [DllImport("CppSharp.CppParser", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
-                        EntryPoint="_ZN8CppSharp9CppParser3AST8Function10setMangledEPKc")]
-                    internal static extern void SetMangled(global::System.IntPtr instance, [MarshalAs(UnmanagedType.LPStr)] string s);
-
-                    [SuppressUnmanagedCodeSecurity]
-                    [DllImport("CppSharp.CppParser", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
-                        EntryPoint="_ZN8CppSharp9CppParser3AST8Function12getSignatureEv")]
-                    internal static extern global::System.IntPtr GetSignature(global::System.IntPtr instance);
-
-                    [SuppressUnmanagedCodeSecurity]
-                    [DllImport("CppSharp.CppParser", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
-                        EntryPoint="_ZN8CppSharp9CppParser3AST8Function12setSignatureEPKc")]
-                    internal static extern void SetSignature(global::System.IntPtr instance, [MarshalAs(UnmanagedType.LPStr)] string s);
-
-                    [SuppressUnmanagedCodeSecurity]
-                    [DllImport("CppSharp.CppParser", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
-                        EntryPoint="_ZN8CppSharp9CppParser3AST8Function7getBodyEv")]
-                    internal static extern global::System.IntPtr GetBody(global::System.IntPtr instance);
-
-                    [SuppressUnmanagedCodeSecurity]
-                    [DllImport("CppSharp.CppParser", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
-                        EntryPoint="_ZN8CppSharp9CppParser3AST8Function7setBodyEPKc")]
-                    internal static extern void SetBody(global::System.IntPtr instance, [MarshalAs(UnmanagedType.LPStr)] string s);
 
                     [SuppressUnmanagedCodeSecurity]
                     [DllImport("CppSharp.CppParser", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
@@ -7351,6 +7363,51 @@ namespace CppSharp
                     }
                 }
 
+                public string Mangled
+                {
+                    get
+                    {
+                        return global::Std.Cxx11.BasicString.__CreateInstance(((global::CppSharp.Parser.AST.Function.__Internal*) __Instance)->mangled).CStr();
+                    }
+
+                    set
+                    {
+                        var __allocator0 = new global::Std.Allocator();
+                        var __basicString0 = new global::Std.Cxx11.BasicString(value, __allocator0);
+                        ((global::CppSharp.Parser.AST.Function.__Internal*) __Instance)->mangled = *(global::Std.Cxx11.BasicString.__Internal*) __basicString0.__Instance;
+                    }
+                }
+
+                public string Signature
+                {
+                    get
+                    {
+                        return global::Std.Cxx11.BasicString.__CreateInstance(((global::CppSharp.Parser.AST.Function.__Internal*) __Instance)->signature).CStr();
+                    }
+
+                    set
+                    {
+                        var __allocator0 = new global::Std.Allocator();
+                        var __basicString0 = new global::Std.Cxx11.BasicString(value, __allocator0);
+                        ((global::CppSharp.Parser.AST.Function.__Internal*) __Instance)->signature = *(global::Std.Cxx11.BasicString.__Internal*) __basicString0.__Instance;
+                    }
+                }
+
+                public string Body
+                {
+                    get
+                    {
+                        return global::Std.Cxx11.BasicString.__CreateInstance(((global::CppSharp.Parser.AST.Function.__Internal*) __Instance)->body).CStr();
+                    }
+
+                    set
+                    {
+                        var __allocator0 = new global::Std.Allocator();
+                        var __basicString0 = new global::Std.Cxx11.BasicString(value, __allocator0);
+                        ((global::CppSharp.Parser.AST.Function.__Internal*) __Instance)->body = *(global::Std.Cxx11.BasicString.__Internal*) __basicString0.__Instance;
+                    }
+                }
+
                 public global::CppSharp.Parser.AST.CallingConvention CallingConvention
                 {
                     get
@@ -7413,48 +7470,6 @@ namespace CppSharp
                     }
                 }
 
-                public string Mangled
-                {
-                    get
-                    {
-                        var __ret = __Internal.GetMangled((__Instance + __PointerAdjustment));
-                        return Marshal.PtrToStringAnsi(__ret);
-                    }
-
-                    set
-                    {
-                        __Internal.SetMangled((__Instance + __PointerAdjustment), value);
-                    }
-                }
-
-                public string Signature
-                {
-                    get
-                    {
-                        var __ret = __Internal.GetSignature((__Instance + __PointerAdjustment));
-                        return Marshal.PtrToStringAnsi(__ret);
-                    }
-
-                    set
-                    {
-                        __Internal.SetSignature((__Instance + __PointerAdjustment), value);
-                    }
-                }
-
-                public string Body
-                {
-                    get
-                    {
-                        var __ret = __Internal.GetBody((__Instance + __PointerAdjustment));
-                        return Marshal.PtrToStringAnsi(__ret);
-                    }
-
-                    set
-                    {
-                        __Internal.SetBody((__Instance + __PointerAdjustment), value);
-                    }
-                }
-
                 public uint ParametersCount
                 {
                     get
@@ -7489,13 +7504,13 @@ namespace CppSharp
                     internal int lineNumberEnd;
 
                     [FieldOffset(32)]
-                    internal global::Std.Cxx11.BasicString.__Internal Name;
+                    internal global::Std.Cxx11.BasicString.__Internal name;
 
                     [FieldOffset(64)]
                     internal global::Std.Cxx11.BasicString.__Internal USR;
 
                     [FieldOffset(96)]
-                    internal global::Std.Cxx11.BasicString.__Internal DebugText;
+                    internal global::Std.Cxx11.BasicString.__Internal debugText;
 
                     [FieldOffset(128)]
                     internal byte isIncomplete;
@@ -7555,13 +7570,13 @@ namespace CppSharp
                     internal global::CppSharp.Parser.AST.CXXOperatorKind operatorKind;
 
                     [FieldOffset(248)]
-                    internal global::Std.Cxx11.BasicString.__Internal Mangled;
+                    internal global::Std.Cxx11.BasicString.__Internal mangled;
 
                     [FieldOffset(280)]
-                    internal global::Std.Cxx11.BasicString.__Internal Signature;
+                    internal global::Std.Cxx11.BasicString.__Internal signature;
 
                     [FieldOffset(312)]
-                    internal global::Std.Cxx11.BasicString.__Internal Body;
+                    internal global::Std.Cxx11.BasicString.__Internal body;
 
                     [FieldOffset(344)]
                     internal global::CppSharp.Parser.AST.CallingConvention callingConvention;
@@ -7862,13 +7877,13 @@ namespace CppSharp
                     internal int lineNumberEnd;
 
                     [FieldOffset(32)]
-                    internal global::Std.Cxx11.BasicString.__Internal Name;
+                    internal global::Std.Cxx11.BasicString.__Internal name;
 
                     [FieldOffset(64)]
                     internal global::Std.Cxx11.BasicString.__Internal USR;
 
                     [FieldOffset(96)]
-                    internal global::Std.Cxx11.BasicString.__Internal DebugText;
+                    internal global::Std.Cxx11.BasicString.__Internal debugText;
 
                     [FieldOffset(128)]
                     internal byte isIncomplete;
@@ -7974,6 +7989,11 @@ namespace CppSharp
 
                     [SuppressUnmanagedCodeSecurity]
                     [DllImport("CppSharp.CppParser", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
+                        EntryPoint="_ZN8CppSharp9CppParser3AST11Enumeration14FindItemByNameERKNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEE")]
+                    internal static extern global::System.IntPtr FindItemByName_0(global::System.IntPtr instance, global::System.IntPtr Name);
+
+                    [SuppressUnmanagedCodeSecurity]
+                    [DllImport("CppSharp.CppParser", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
                         EntryPoint="_ZN8CppSharp9CppParser3AST11Enumeration13getItemsCountEv")]
                     internal static extern uint GetItemsCount(global::System.IntPtr instance);
                 }
@@ -8010,13 +8030,13 @@ namespace CppSharp
                         internal int lineNumberEnd;
 
                         [FieldOffset(32)]
-                        internal global::Std.Cxx11.BasicString.__Internal Name;
+                        internal global::Std.Cxx11.BasicString.__Internal name;
 
                         [FieldOffset(64)]
                         internal global::Std.Cxx11.BasicString.__Internal USR;
 
                         [FieldOffset(96)]
-                        internal global::Std.Cxx11.BasicString.__Internal DebugText;
+                        internal global::Std.Cxx11.BasicString.__Internal debugText;
 
                         [FieldOffset(128)]
                         internal byte isIncomplete;
@@ -8046,7 +8066,7 @@ namespace CppSharp
                         internal global::System.IntPtr comment;
 
                         [FieldOffset(216)]
-                        internal global::Std.Cxx11.BasicString.__Internal Expression;
+                        internal global::Std.Cxx11.BasicString.__Internal expression;
 
                         [FieldOffset(248)]
                         internal ulong value;
@@ -8065,16 +8085,6 @@ namespace CppSharp
                         [DllImport("CppSharp.CppParser", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
                             EntryPoint="_ZN8CppSharp9CppParser3AST11Enumeration4ItemD2Ev")]
                         internal static extern void dtor_0(global::System.IntPtr instance);
-
-                        [SuppressUnmanagedCodeSecurity]
-                        [DllImport("CppSharp.CppParser", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
-                            EntryPoint="_ZN8CppSharp9CppParser3AST11Enumeration4Item13getExpressionEv")]
-                        internal static extern global::System.IntPtr GetExpression(global::System.IntPtr instance);
-
-                        [SuppressUnmanagedCodeSecurity]
-                        [DllImport("CppSharp.CppParser", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
-                            EntryPoint="_ZN8CppSharp9CppParser3AST11Enumeration4Item13setExpressionEPKc")]
-                        internal static extern void SetExpression(global::System.IntPtr instance, [MarshalAs(UnmanagedType.LPStr)] string s);
                     }
 
                     internal static new global::CppSharp.Parser.AST.Enumeration.Item __CreateInstance(global::System.IntPtr native, bool skipVTables = false)
@@ -8144,6 +8154,21 @@ namespace CppSharp
                         __Instance = IntPtr.Zero;
                     }
 
+                    public string Expression
+                    {
+                        get
+                        {
+                            return global::Std.Cxx11.BasicString.__CreateInstance(((global::CppSharp.Parser.AST.Enumeration.Item.__Internal*) __Instance)->expression).CStr();
+                        }
+
+                        set
+                        {
+                            var __allocator0 = new global::Std.Allocator();
+                            var __basicString0 = new global::Std.Cxx11.BasicString(value, __allocator0);
+                            ((global::CppSharp.Parser.AST.Enumeration.Item.__Internal*) __Instance)->expression = *(global::Std.Cxx11.BasicString.__Internal*) __basicString0.__Instance;
+                        }
+                    }
+
                     public ulong Value
                     {
                         get
@@ -8154,20 +8179,6 @@ namespace CppSharp
                         set
                         {
                             ((global::CppSharp.Parser.AST.Enumeration.Item.__Internal*) __Instance)->value = value;
-                        }
-                    }
-
-                    public string Expression
-                    {
-                        get
-                        {
-                            var __ret = __Internal.GetExpression((__Instance + __PointerAdjustment));
-                            return Marshal.PtrToStringAnsi(__ret);
-                        }
-
-                        set
-                        {
-                            __Internal.SetExpression((__Instance + __PointerAdjustment), value);
                         }
                     }
                 }
@@ -8263,6 +8274,22 @@ namespace CppSharp
                     __Internal.ClearItems_0((__Instance + __PointerAdjustment));
                 }
 
+                public global::CppSharp.Parser.AST.Enumeration.Item FindItemByName(string Name)
+                {
+                    var __allocator0 = new global::Std.Allocator();
+                    var __basicString0 = new global::Std.Cxx11.BasicString(Name, __allocator0);
+                    var __arg0 = __basicString0.__Instance;
+                    var __ret = __Internal.FindItemByName_0((__Instance + __PointerAdjustment), __arg0);
+                    __basicString0.Dispose(false);
+                    __allocator0.Dispose();
+                    global::CppSharp.Parser.AST.Enumeration.Item __result0;
+                    if (__ret == IntPtr.Zero) __result0 = null;
+                    else if (global::CppSharp.Parser.AST.Enumeration.Item.NativeToManagedMap.ContainsKey(__ret))
+                        __result0 = (global::CppSharp.Parser.AST.Enumeration.Item) global::CppSharp.Parser.AST.Enumeration.Item.NativeToManagedMap[__ret];
+                    else __result0 = global::CppSharp.Parser.AST.Enumeration.Item.__CreateInstance(__ret);
+                    return __result0;
+                }
+
                 public global::CppSharp.Parser.AST.Enumeration.EnumModifiers Modifiers
                 {
                     get
@@ -8346,13 +8373,13 @@ namespace CppSharp
                     internal int lineNumberEnd;
 
                     [FieldOffset(32)]
-                    internal global::Std.Cxx11.BasicString.__Internal Name;
+                    internal global::Std.Cxx11.BasicString.__Internal name;
 
                     [FieldOffset(64)]
                     internal global::Std.Cxx11.BasicString.__Internal USR;
 
                     [FieldOffset(96)]
-                    internal global::Std.Cxx11.BasicString.__Internal DebugText;
+                    internal global::Std.Cxx11.BasicString.__Internal debugText;
 
                     [FieldOffset(128)]
                     internal byte isIncomplete;
@@ -8382,7 +8409,7 @@ namespace CppSharp
                     internal global::System.IntPtr comment;
 
                     [FieldOffset(216)]
-                    internal global::Std.Cxx11.BasicString.__Internal Mangled;
+                    internal global::Std.Cxx11.BasicString.__Internal mangled;
 
                     [FieldOffset(248)]
                     internal global::CppSharp.Parser.AST.QualifiedType.__Internal qualifiedType;
@@ -8401,16 +8428,6 @@ namespace CppSharp
                     [DllImport("CppSharp.CppParser", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
                         EntryPoint="_ZN8CppSharp9CppParser3AST8VariableD2Ev")]
                     internal static extern void dtor_0(global::System.IntPtr instance);
-
-                    [SuppressUnmanagedCodeSecurity]
-                    [DllImport("CppSharp.CppParser", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
-                        EntryPoint="_ZN8CppSharp9CppParser3AST8Variable10getMangledEv")]
-                    internal static extern global::System.IntPtr GetMangled(global::System.IntPtr instance);
-
-                    [SuppressUnmanagedCodeSecurity]
-                    [DllImport("CppSharp.CppParser", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
-                        EntryPoint="_ZN8CppSharp9CppParser3AST8Variable10setMangledEPKc")]
-                    internal static extern void SetMangled(global::System.IntPtr instance, [MarshalAs(UnmanagedType.LPStr)] string s);
                 }
 
                 internal static new global::CppSharp.Parser.AST.Variable __CreateInstance(global::System.IntPtr native, bool skipVTables = false)
@@ -8480,6 +8497,21 @@ namespace CppSharp
                     __Instance = IntPtr.Zero;
                 }
 
+                public string Mangled
+                {
+                    get
+                    {
+                        return global::Std.Cxx11.BasicString.__CreateInstance(((global::CppSharp.Parser.AST.Variable.__Internal*) __Instance)->mangled).CStr();
+                    }
+
+                    set
+                    {
+                        var __allocator0 = new global::Std.Allocator();
+                        var __basicString0 = new global::Std.Cxx11.BasicString(value, __allocator0);
+                        ((global::CppSharp.Parser.AST.Variable.__Internal*) __Instance)->mangled = *(global::Std.Cxx11.BasicString.__Internal*) __basicString0.__Instance;
+                    }
+                }
+
                 public global::CppSharp.Parser.AST.QualifiedType QualifiedType
                 {
                     get
@@ -8490,20 +8522,6 @@ namespace CppSharp
                     set
                     {
                         ((global::CppSharp.Parser.AST.Variable.__Internal*) __Instance)->qualifiedType = ReferenceEquals(value, null) ? new global::CppSharp.Parser.AST.QualifiedType.__Internal() : *(global::CppSharp.Parser.AST.QualifiedType.__Internal*) value.__Instance;
-                    }
-                }
-
-                public string Mangled
-                {
-                    get
-                    {
-                        var __ret = __Internal.GetMangled((__Instance + __PointerAdjustment));
-                        return Marshal.PtrToStringAnsi(__ret);
-                    }
-
-                    set
-                    {
-                        __Internal.SetMangled((__Instance + __PointerAdjustment), value);
                     }
                 }
             }
@@ -8689,13 +8707,13 @@ namespace CppSharp
                     internal int lineNumberEnd;
 
                     [FieldOffset(32)]
-                    internal global::Std.Cxx11.BasicString.__Internal Name;
+                    internal global::Std.Cxx11.BasicString.__Internal name;
 
                     [FieldOffset(64)]
                     internal global::Std.Cxx11.BasicString.__Internal USR;
 
                     [FieldOffset(96)]
-                    internal global::Std.Cxx11.BasicString.__Internal DebugText;
+                    internal global::Std.Cxx11.BasicString.__Internal debugText;
 
                     [FieldOffset(128)]
                     internal byte isIncomplete;
@@ -8901,13 +8919,13 @@ namespace CppSharp
                     internal int lineNumberEnd;
 
                     [FieldOffset(32)]
-                    internal global::Std.Cxx11.BasicString.__Internal Name;
+                    internal global::Std.Cxx11.BasicString.__Internal name;
 
                     [FieldOffset(64)]
                     internal global::Std.Cxx11.BasicString.__Internal USR;
 
                     [FieldOffset(96)]
-                    internal global::Std.Cxx11.BasicString.__Internal DebugText;
+                    internal global::Std.Cxx11.BasicString.__Internal debugText;
 
                     [FieldOffset(128)]
                     internal byte isIncomplete;
@@ -9044,13 +9062,13 @@ namespace CppSharp
                     internal int lineNumberEnd;
 
                     [FieldOffset(32)]
-                    internal global::Std.Cxx11.BasicString.__Internal Name;
+                    internal global::Std.Cxx11.BasicString.__Internal name;
 
                     [FieldOffset(64)]
                     internal global::Std.Cxx11.BasicString.__Internal USR;
 
                     [FieldOffset(96)]
-                    internal global::Std.Cxx11.BasicString.__Internal DebugText;
+                    internal global::Std.Cxx11.BasicString.__Internal debugText;
 
                     [FieldOffset(128)]
                     internal byte isIncomplete;
@@ -9625,13 +9643,13 @@ namespace CppSharp
                     internal int lineNumberEnd;
 
                     [FieldOffset(32)]
-                    internal global::Std.Cxx11.BasicString.__Internal Name;
+                    internal global::Std.Cxx11.BasicString.__Internal name;
 
                     [FieldOffset(64)]
                     internal global::Std.Cxx11.BasicString.__Internal USR;
 
                     [FieldOffset(96)]
-                    internal global::Std.Cxx11.BasicString.__Internal DebugText;
+                    internal global::Std.Cxx11.BasicString.__Internal debugText;
 
                     [FieldOffset(128)]
                     internal byte isIncomplete;
@@ -9864,13 +9882,13 @@ namespace CppSharp
                     internal int lineNumberEnd;
 
                     [FieldOffset(32)]
-                    internal global::Std.Cxx11.BasicString.__Internal Name;
+                    internal global::Std.Cxx11.BasicString.__Internal name;
 
                     [FieldOffset(64)]
                     internal global::Std.Cxx11.BasicString.__Internal USR;
 
                     [FieldOffset(96)]
-                    internal global::Std.Cxx11.BasicString.__Internal DebugText;
+                    internal global::Std.Cxx11.BasicString.__Internal debugText;
 
                     [FieldOffset(128)]
                     internal byte isIncomplete;
@@ -10013,13 +10031,13 @@ namespace CppSharp
                     internal int lineNumberEnd;
 
                     [FieldOffset(32)]
-                    internal global::Std.Cxx11.BasicString.__Internal Name;
+                    internal global::Std.Cxx11.BasicString.__Internal name;
 
                     [FieldOffset(64)]
                     internal global::Std.Cxx11.BasicString.__Internal USR;
 
                     [FieldOffset(96)]
-                    internal global::Std.Cxx11.BasicString.__Internal DebugText;
+                    internal global::Std.Cxx11.BasicString.__Internal debugText;
 
                     [FieldOffset(128)]
                     internal byte isIncomplete;
@@ -10209,13 +10227,13 @@ namespace CppSharp
                     internal int lineNumberEnd;
 
                     [FieldOffset(32)]
-                    internal global::Std.Cxx11.BasicString.__Internal Name;
+                    internal global::Std.Cxx11.BasicString.__Internal name;
 
                     [FieldOffset(64)]
                     internal global::Std.Cxx11.BasicString.__Internal USR;
 
                     [FieldOffset(96)]
-                    internal global::Std.Cxx11.BasicString.__Internal DebugText;
+                    internal global::Std.Cxx11.BasicString.__Internal debugText;
 
                     [FieldOffset(128)]
                     internal byte isIncomplete;
@@ -10406,13 +10424,13 @@ namespace CppSharp
                     internal int lineNumberEnd;
 
                     [FieldOffset(32)]
-                    internal global::Std.Cxx11.BasicString.__Internal Name;
+                    internal global::Std.Cxx11.BasicString.__Internal name;
 
                     [FieldOffset(64)]
                     internal global::Std.Cxx11.BasicString.__Internal USR;
 
                     [FieldOffset(96)]
-                    internal global::Std.Cxx11.BasicString.__Internal DebugText;
+                    internal global::Std.Cxx11.BasicString.__Internal debugText;
 
                     [FieldOffset(128)]
                     internal byte isIncomplete;
@@ -10574,13 +10592,13 @@ namespace CppSharp
                     internal int lineNumberEnd;
 
                     [FieldOffset(32)]
-                    internal global::Std.Cxx11.BasicString.__Internal Name;
+                    internal global::Std.Cxx11.BasicString.__Internal name;
 
                     [FieldOffset(64)]
                     internal global::Std.Cxx11.BasicString.__Internal USR;
 
                     [FieldOffset(96)]
-                    internal global::Std.Cxx11.BasicString.__Internal DebugText;
+                    internal global::Std.Cxx11.BasicString.__Internal debugText;
 
                     [FieldOffset(128)]
                     internal byte isIncomplete;
@@ -10795,13 +10813,13 @@ namespace CppSharp
                     internal int lineNumberEnd;
 
                     [FieldOffset(32)]
-                    internal global::Std.Cxx11.BasicString.__Internal Name;
+                    internal global::Std.Cxx11.BasicString.__Internal name;
 
                     [FieldOffset(64)]
                     internal global::Std.Cxx11.BasicString.__Internal USR;
 
                     [FieldOffset(96)]
-                    internal global::Std.Cxx11.BasicString.__Internal DebugText;
+                    internal global::Std.Cxx11.BasicString.__Internal debugText;
 
                     [FieldOffset(128)]
                     internal byte isIncomplete;
@@ -10868,6 +10886,16 @@ namespace CppSharp
                     [DllImport("CppSharp.CppParser", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
                         EntryPoint="_ZN8CppSharp9CppParser3AST13ClassTemplate20clearSpecializationsEv")]
                     internal static extern void ClearSpecializations_0(global::System.IntPtr instance);
+
+                    [SuppressUnmanagedCodeSecurity]
+                    [DllImport("CppSharp.CppParser", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
+                        EntryPoint="_ZN8CppSharp9CppParser3AST13ClassTemplate18FindSpecializationERKNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEE")]
+                    internal static extern global::System.IntPtr FindSpecialization_0(global::System.IntPtr instance, global::System.IntPtr usr);
+
+                    [SuppressUnmanagedCodeSecurity]
+                    [DllImport("CppSharp.CppParser", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
+                        EntryPoint="_ZN8CppSharp9CppParser3AST13ClassTemplate25FindPartialSpecializationERKNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEE")]
+                    internal static extern global::System.IntPtr FindPartialSpecialization_0(global::System.IntPtr instance, global::System.IntPtr usr);
 
                     [SuppressUnmanagedCodeSecurity]
                     [DllImport("CppSharp.CppParser", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
@@ -10966,6 +10994,38 @@ namespace CppSharp
                     __Internal.ClearSpecializations_0((__Instance + __PointerAdjustment));
                 }
 
+                public global::CppSharp.Parser.AST.ClassTemplateSpecialization FindSpecialization(string usr)
+                {
+                    var __allocator0 = new global::Std.Allocator();
+                    var __basicString0 = new global::Std.Cxx11.BasicString(usr, __allocator0);
+                    var __arg0 = __basicString0.__Instance;
+                    var __ret = __Internal.FindSpecialization_0((__Instance + __PointerAdjustment), __arg0);
+                    __basicString0.Dispose(false);
+                    __allocator0.Dispose();
+                    global::CppSharp.Parser.AST.ClassTemplateSpecialization __result0;
+                    if (__ret == IntPtr.Zero) __result0 = null;
+                    else if (global::CppSharp.Parser.AST.ClassTemplateSpecialization.NativeToManagedMap.ContainsKey(__ret))
+                        __result0 = (global::CppSharp.Parser.AST.ClassTemplateSpecialization) global::CppSharp.Parser.AST.ClassTemplateSpecialization.NativeToManagedMap[__ret];
+                    else __result0 = global::CppSharp.Parser.AST.ClassTemplateSpecialization.__CreateInstance(__ret);
+                    return __result0;
+                }
+
+                public global::CppSharp.Parser.AST.ClassTemplatePartialSpecialization FindPartialSpecialization(string usr)
+                {
+                    var __allocator0 = new global::Std.Allocator();
+                    var __basicString0 = new global::Std.Cxx11.BasicString(usr, __allocator0);
+                    var __arg0 = __basicString0.__Instance;
+                    var __ret = __Internal.FindPartialSpecialization_0((__Instance + __PointerAdjustment), __arg0);
+                    __basicString0.Dispose(false);
+                    __allocator0.Dispose();
+                    global::CppSharp.Parser.AST.ClassTemplatePartialSpecialization __result0;
+                    if (__ret == IntPtr.Zero) __result0 = null;
+                    else if (global::CppSharp.Parser.AST.ClassTemplatePartialSpecialization.NativeToManagedMap.ContainsKey(__ret))
+                        __result0 = (global::CppSharp.Parser.AST.ClassTemplatePartialSpecialization) global::CppSharp.Parser.AST.ClassTemplatePartialSpecialization.NativeToManagedMap[__ret];
+                    else __result0 = global::CppSharp.Parser.AST.ClassTemplatePartialSpecialization.__CreateInstance(__ret);
+                    return __result0;
+                }
+
                 public uint SpecializationsCount
                 {
                     get
@@ -11000,13 +11060,13 @@ namespace CppSharp
                     internal int lineNumberEnd;
 
                     [FieldOffset(32)]
-                    internal global::Std.Cxx11.BasicString.__Internal Name;
+                    internal global::Std.Cxx11.BasicString.__Internal name;
 
                     [FieldOffset(64)]
                     internal global::Std.Cxx11.BasicString.__Internal USR;
 
                     [FieldOffset(96)]
-                    internal global::Std.Cxx11.BasicString.__Internal DebugText;
+                    internal global::Std.Cxx11.BasicString.__Internal debugText;
 
                     [FieldOffset(128)]
                     internal byte isIncomplete;
@@ -11310,13 +11370,13 @@ namespace CppSharp
                     internal int lineNumberEnd;
 
                     [FieldOffset(32)]
-                    internal global::Std.Cxx11.BasicString.__Internal Name;
+                    internal global::Std.Cxx11.BasicString.__Internal name;
 
                     [FieldOffset(64)]
                     internal global::Std.Cxx11.BasicString.__Internal USR;
 
                     [FieldOffset(96)]
-                    internal global::Std.Cxx11.BasicString.__Internal DebugText;
+                    internal global::Std.Cxx11.BasicString.__Internal debugText;
 
                     [FieldOffset(128)]
                     internal byte isIncomplete;
@@ -11540,13 +11600,13 @@ namespace CppSharp
                     internal int lineNumberEnd;
 
                     [FieldOffset(32)]
-                    internal global::Std.Cxx11.BasicString.__Internal Name;
+                    internal global::Std.Cxx11.BasicString.__Internal name;
 
                     [FieldOffset(64)]
                     internal global::Std.Cxx11.BasicString.__Internal USR;
 
                     [FieldOffset(96)]
-                    internal global::Std.Cxx11.BasicString.__Internal DebugText;
+                    internal global::Std.Cxx11.BasicString.__Internal debugText;
 
                     [FieldOffset(128)]
                     internal byte isIncomplete;
@@ -11613,6 +11673,11 @@ namespace CppSharp
                     [DllImport("CppSharp.CppParser", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
                         EntryPoint="_ZN8CppSharp9CppParser3AST16FunctionTemplate20clearSpecializationsEv")]
                     internal static extern void ClearSpecializations_0(global::System.IntPtr instance);
+
+                    [SuppressUnmanagedCodeSecurity]
+                    [DllImport("CppSharp.CppParser", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
+                        EntryPoint="_ZN8CppSharp9CppParser3AST16FunctionTemplate18FindSpecializationERKNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEE")]
+                    internal static extern global::System.IntPtr FindSpecialization_0(global::System.IntPtr instance, global::System.IntPtr usr);
 
                     [SuppressUnmanagedCodeSecurity]
                     [DllImport("CppSharp.CppParser", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
@@ -11709,6 +11774,22 @@ namespace CppSharp
                 public void ClearSpecializations()
                 {
                     __Internal.ClearSpecializations_0((__Instance + __PointerAdjustment));
+                }
+
+                public global::CppSharp.Parser.AST.FunctionTemplateSpecialization FindSpecialization(string usr)
+                {
+                    var __allocator0 = new global::Std.Allocator();
+                    var __basicString0 = new global::Std.Cxx11.BasicString(usr, __allocator0);
+                    var __arg0 = __basicString0.__Instance;
+                    var __ret = __Internal.FindSpecialization_0((__Instance + __PointerAdjustment), __arg0);
+                    __basicString0.Dispose(false);
+                    __allocator0.Dispose();
+                    global::CppSharp.Parser.AST.FunctionTemplateSpecialization __result0;
+                    if (__ret == IntPtr.Zero) __result0 = null;
+                    else if (global::CppSharp.Parser.AST.FunctionTemplateSpecialization.NativeToManagedMap.ContainsKey(__ret))
+                        __result0 = (global::CppSharp.Parser.AST.FunctionTemplateSpecialization) global::CppSharp.Parser.AST.FunctionTemplateSpecialization.NativeToManagedMap[__ret];
+                    else __result0 = global::CppSharp.Parser.AST.FunctionTemplateSpecialization.__CreateInstance(__ret);
+                    return __result0;
                 }
 
                 public uint SpecializationsCount
@@ -11953,13 +12034,13 @@ namespace CppSharp
                     internal int lineNumberEnd;
 
                     [FieldOffset(32)]
-                    internal global::Std.Cxx11.BasicString.__Internal Name;
+                    internal global::Std.Cxx11.BasicString.__Internal name;
 
                     [FieldOffset(64)]
                     internal global::Std.Cxx11.BasicString.__Internal USR;
 
                     [FieldOffset(96)]
-                    internal global::Std.Cxx11.BasicString.__Internal DebugText;
+                    internal global::Std.Cxx11.BasicString.__Internal debugText;
 
                     [FieldOffset(128)]
                     internal byte isIncomplete;
@@ -12026,6 +12107,16 @@ namespace CppSharp
                     [DllImport("CppSharp.CppParser", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
                         EntryPoint="_ZN8CppSharp9CppParser3AST11VarTemplate20clearSpecializationsEv")]
                     internal static extern void ClearSpecializations_0(global::System.IntPtr instance);
+
+                    [SuppressUnmanagedCodeSecurity]
+                    [DllImport("CppSharp.CppParser", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
+                        EntryPoint="_ZN8CppSharp9CppParser3AST11VarTemplate18FindSpecializationERKNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEE")]
+                    internal static extern global::System.IntPtr FindSpecialization_0(global::System.IntPtr instance, global::System.IntPtr usr);
+
+                    [SuppressUnmanagedCodeSecurity]
+                    [DllImport("CppSharp.CppParser", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
+                        EntryPoint="_ZN8CppSharp9CppParser3AST11VarTemplate25FindPartialSpecializationERKNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEE")]
+                    internal static extern global::System.IntPtr FindPartialSpecialization_0(global::System.IntPtr instance, global::System.IntPtr usr);
 
                     [SuppressUnmanagedCodeSecurity]
                     [DllImport("CppSharp.CppParser", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
@@ -12124,6 +12215,38 @@ namespace CppSharp
                     __Internal.ClearSpecializations_0((__Instance + __PointerAdjustment));
                 }
 
+                public global::CppSharp.Parser.AST.VarTemplateSpecialization FindSpecialization(string usr)
+                {
+                    var __allocator0 = new global::Std.Allocator();
+                    var __basicString0 = new global::Std.Cxx11.BasicString(usr, __allocator0);
+                    var __arg0 = __basicString0.__Instance;
+                    var __ret = __Internal.FindSpecialization_0((__Instance + __PointerAdjustment), __arg0);
+                    __basicString0.Dispose(false);
+                    __allocator0.Dispose();
+                    global::CppSharp.Parser.AST.VarTemplateSpecialization __result0;
+                    if (__ret == IntPtr.Zero) __result0 = null;
+                    else if (global::CppSharp.Parser.AST.VarTemplateSpecialization.NativeToManagedMap.ContainsKey(__ret))
+                        __result0 = (global::CppSharp.Parser.AST.VarTemplateSpecialization) global::CppSharp.Parser.AST.VarTemplateSpecialization.NativeToManagedMap[__ret];
+                    else __result0 = global::CppSharp.Parser.AST.VarTemplateSpecialization.__CreateInstance(__ret);
+                    return __result0;
+                }
+
+                public global::CppSharp.Parser.AST.VarTemplatePartialSpecialization FindPartialSpecialization(string usr)
+                {
+                    var __allocator0 = new global::Std.Allocator();
+                    var __basicString0 = new global::Std.Cxx11.BasicString(usr, __allocator0);
+                    var __arg0 = __basicString0.__Instance;
+                    var __ret = __Internal.FindPartialSpecialization_0((__Instance + __PointerAdjustment), __arg0);
+                    __basicString0.Dispose(false);
+                    __allocator0.Dispose();
+                    global::CppSharp.Parser.AST.VarTemplatePartialSpecialization __result0;
+                    if (__ret == IntPtr.Zero) __result0 = null;
+                    else if (global::CppSharp.Parser.AST.VarTemplatePartialSpecialization.NativeToManagedMap.ContainsKey(__ret))
+                        __result0 = (global::CppSharp.Parser.AST.VarTemplatePartialSpecialization) global::CppSharp.Parser.AST.VarTemplatePartialSpecialization.NativeToManagedMap[__ret];
+                    else __result0 = global::CppSharp.Parser.AST.VarTemplatePartialSpecialization.__CreateInstance(__ret);
+                    return __result0;
+                }
+
                 public uint SpecializationsCount
                 {
                     get
@@ -12158,13 +12281,13 @@ namespace CppSharp
                     internal int lineNumberEnd;
 
                     [FieldOffset(32)]
-                    internal global::Std.Cxx11.BasicString.__Internal Name;
+                    internal global::Std.Cxx11.BasicString.__Internal name;
 
                     [FieldOffset(64)]
                     internal global::Std.Cxx11.BasicString.__Internal USR;
 
                     [FieldOffset(96)]
-                    internal global::Std.Cxx11.BasicString.__Internal DebugText;
+                    internal global::Std.Cxx11.BasicString.__Internal debugText;
 
                     [FieldOffset(128)]
                     internal byte isIncomplete;
@@ -12194,7 +12317,7 @@ namespace CppSharp
                     internal global::System.IntPtr comment;
 
                     [FieldOffset(216)]
-                    internal global::Std.Cxx11.BasicString.__Internal Mangled;
+                    internal global::Std.Cxx11.BasicString.__Internal mangled;
 
                     [FieldOffset(248)]
                     internal global::CppSharp.Parser.AST.QualifiedType.__Internal qualifiedType;
@@ -12396,13 +12519,13 @@ namespace CppSharp
                     internal int lineNumberEnd;
 
                     [FieldOffset(32)]
-                    internal global::Std.Cxx11.BasicString.__Internal Name;
+                    internal global::Std.Cxx11.BasicString.__Internal name;
 
                     [FieldOffset(64)]
                     internal global::Std.Cxx11.BasicString.__Internal USR;
 
                     [FieldOffset(96)]
-                    internal global::Std.Cxx11.BasicString.__Internal DebugText;
+                    internal global::Std.Cxx11.BasicString.__Internal debugText;
 
                     [FieldOffset(128)]
                     internal byte isIncomplete;
@@ -12432,7 +12555,7 @@ namespace CppSharp
                     internal global::System.IntPtr comment;
 
                     [FieldOffset(216)]
-                    internal global::Std.Cxx11.BasicString.__Internal Mangled;
+                    internal global::Std.Cxx11.BasicString.__Internal mangled;
 
                     [FieldOffset(248)]
                     internal global::CppSharp.Parser.AST.QualifiedType.__Internal qualifiedType;
@@ -12554,13 +12677,13 @@ namespace CppSharp
                     internal int lineNumberEnd;
 
                     [FieldOffset(32)]
-                    internal global::Std.Cxx11.BasicString.__Internal Name;
+                    internal global::Std.Cxx11.BasicString.__Internal name;
 
                     [FieldOffset(64)]
                     internal global::Std.Cxx11.BasicString.__Internal USR;
 
                     [FieldOffset(96)]
-                    internal global::Std.Cxx11.BasicString.__Internal DebugText;
+                    internal global::Std.Cxx11.BasicString.__Internal debugText;
 
                     [FieldOffset(128)]
                     internal byte isIncomplete;
@@ -12873,10 +12996,10 @@ namespace CppSharp
                     internal global::CppSharp.Parser.AST.DeclarationKind kind;
 
                     [FieldOffset(24)]
-                    internal global::Std.Cxx11.BasicString.__Internal Name;
+                    internal global::Std.Cxx11.BasicString.__Internal name;
 
                     [FieldOffset(56)]
-                    internal global::Std.Cxx11.BasicString.__Internal Expression;
+                    internal global::Std.Cxx11.BasicString.__Internal expression;
 
                     [FieldOffset(88)]
                     internal int lineNumberStart;
@@ -12898,26 +13021,6 @@ namespace CppSharp
                     [DllImport("CppSharp.CppParser", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
                         EntryPoint="_ZN8CppSharp9CppParser3AST15MacroDefinitionD2Ev")]
                     internal static extern void dtor_0(global::System.IntPtr instance);
-
-                    [SuppressUnmanagedCodeSecurity]
-                    [DllImport("CppSharp.CppParser", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
-                        EntryPoint="_ZN8CppSharp9CppParser3AST15MacroDefinition7getNameEv")]
-                    internal static extern global::System.IntPtr GetName(global::System.IntPtr instance);
-
-                    [SuppressUnmanagedCodeSecurity]
-                    [DllImport("CppSharp.CppParser", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
-                        EntryPoint="_ZN8CppSharp9CppParser3AST15MacroDefinition7setNameEPKc")]
-                    internal static extern void SetName(global::System.IntPtr instance, [MarshalAs(UnmanagedType.LPStr)] string s);
-
-                    [SuppressUnmanagedCodeSecurity]
-                    [DllImport("CppSharp.CppParser", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
-                        EntryPoint="_ZN8CppSharp9CppParser3AST15MacroDefinition13getExpressionEv")]
-                    internal static extern global::System.IntPtr GetExpression(global::System.IntPtr instance);
-
-                    [SuppressUnmanagedCodeSecurity]
-                    [DllImport("CppSharp.CppParser", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
-                        EntryPoint="_ZN8CppSharp9CppParser3AST15MacroDefinition13setExpressionEPKc")]
-                    internal static extern void SetExpression(global::System.IntPtr instance, [MarshalAs(UnmanagedType.LPStr)] string s);
                 }
 
                 internal static new global::CppSharp.Parser.AST.MacroDefinition __CreateInstance(global::System.IntPtr native, bool skipVTables = false)
@@ -12987,6 +13090,36 @@ namespace CppSharp
                     __Instance = IntPtr.Zero;
                 }
 
+                public string Name
+                {
+                    get
+                    {
+                        return global::Std.Cxx11.BasicString.__CreateInstance(((global::CppSharp.Parser.AST.MacroDefinition.__Internal*) __Instance)->name).CStr();
+                    }
+
+                    set
+                    {
+                        var __allocator0 = new global::Std.Allocator();
+                        var __basicString0 = new global::Std.Cxx11.BasicString(value, __allocator0);
+                        ((global::CppSharp.Parser.AST.MacroDefinition.__Internal*) __Instance)->name = *(global::Std.Cxx11.BasicString.__Internal*) __basicString0.__Instance;
+                    }
+                }
+
+                public string Expression
+                {
+                    get
+                    {
+                        return global::Std.Cxx11.BasicString.__CreateInstance(((global::CppSharp.Parser.AST.MacroDefinition.__Internal*) __Instance)->expression).CStr();
+                    }
+
+                    set
+                    {
+                        var __allocator0 = new global::Std.Allocator();
+                        var __basicString0 = new global::Std.Cxx11.BasicString(value, __allocator0);
+                        ((global::CppSharp.Parser.AST.MacroDefinition.__Internal*) __Instance)->expression = *(global::Std.Cxx11.BasicString.__Internal*) __basicString0.__Instance;
+                    }
+                }
+
                 public int LineNumberStart
                 {
                     get
@@ -13012,34 +13145,6 @@ namespace CppSharp
                         ((global::CppSharp.Parser.AST.MacroDefinition.__Internal*) __Instance)->lineNumberEnd = value;
                     }
                 }
-
-                public string Name
-                {
-                    get
-                    {
-                        var __ret = __Internal.GetName((__Instance + __PointerAdjustment));
-                        return Marshal.PtrToStringAnsi(__ret);
-                    }
-
-                    set
-                    {
-                        __Internal.SetName((__Instance + __PointerAdjustment), value);
-                    }
-                }
-
-                public string Expression
-                {
-                    get
-                    {
-                        var __ret = __Internal.GetExpression((__Instance + __PointerAdjustment));
-                        return Marshal.PtrToStringAnsi(__ret);
-                    }
-
-                    set
-                    {
-                        __Internal.SetExpression((__Instance + __PointerAdjustment), value);
-                    }
-                }
             }
 
             public unsafe partial class MacroExpansion : global::CppSharp.Parser.AST.PreprocessedEntity, IDisposable
@@ -13057,10 +13162,10 @@ namespace CppSharp
                     internal global::CppSharp.Parser.AST.DeclarationKind kind;
 
                     [FieldOffset(24)]
-                    internal global::Std.Cxx11.BasicString.__Internal Name;
+                    internal global::Std.Cxx11.BasicString.__Internal name;
 
                     [FieldOffset(56)]
-                    internal global::Std.Cxx11.BasicString.__Internal Text;
+                    internal global::Std.Cxx11.BasicString.__Internal text;
 
                     [FieldOffset(88)]
                     internal global::System.IntPtr definition;
@@ -13079,26 +13184,6 @@ namespace CppSharp
                     [DllImport("CppSharp.CppParser", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
                         EntryPoint="_ZN8CppSharp9CppParser3AST14MacroExpansionD2Ev")]
                     internal static extern void dtor_0(global::System.IntPtr instance);
-
-                    [SuppressUnmanagedCodeSecurity]
-                    [DllImport("CppSharp.CppParser", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
-                        EntryPoint="_ZN8CppSharp9CppParser3AST14MacroExpansion7getNameEv")]
-                    internal static extern global::System.IntPtr GetName(global::System.IntPtr instance);
-
-                    [SuppressUnmanagedCodeSecurity]
-                    [DllImport("CppSharp.CppParser", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
-                        EntryPoint="_ZN8CppSharp9CppParser3AST14MacroExpansion7setNameEPKc")]
-                    internal static extern void SetName(global::System.IntPtr instance, [MarshalAs(UnmanagedType.LPStr)] string s);
-
-                    [SuppressUnmanagedCodeSecurity]
-                    [DllImport("CppSharp.CppParser", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
-                        EntryPoint="_ZN8CppSharp9CppParser3AST14MacroExpansion7getTextEv")]
-                    internal static extern global::System.IntPtr GetText(global::System.IntPtr instance);
-
-                    [SuppressUnmanagedCodeSecurity]
-                    [DllImport("CppSharp.CppParser", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
-                        EntryPoint="_ZN8CppSharp9CppParser3AST14MacroExpansion7setTextEPKc")]
-                    internal static extern void SetText(global::System.IntPtr instance, [MarshalAs(UnmanagedType.LPStr)] string s);
                 }
 
                 internal static new global::CppSharp.Parser.AST.MacroExpansion __CreateInstance(global::System.IntPtr native, bool skipVTables = false)
@@ -13168,6 +13253,36 @@ namespace CppSharp
                     __Instance = IntPtr.Zero;
                 }
 
+                public string Name
+                {
+                    get
+                    {
+                        return global::Std.Cxx11.BasicString.__CreateInstance(((global::CppSharp.Parser.AST.MacroExpansion.__Internal*) __Instance)->name).CStr();
+                    }
+
+                    set
+                    {
+                        var __allocator0 = new global::Std.Allocator();
+                        var __basicString0 = new global::Std.Cxx11.BasicString(value, __allocator0);
+                        ((global::CppSharp.Parser.AST.MacroExpansion.__Internal*) __Instance)->name = *(global::Std.Cxx11.BasicString.__Internal*) __basicString0.__Instance;
+                    }
+                }
+
+                public string Text
+                {
+                    get
+                    {
+                        return global::Std.Cxx11.BasicString.__CreateInstance(((global::CppSharp.Parser.AST.MacroExpansion.__Internal*) __Instance)->text).CStr();
+                    }
+
+                    set
+                    {
+                        var __allocator0 = new global::Std.Allocator();
+                        var __basicString0 = new global::Std.Cxx11.BasicString(value, __allocator0);
+                        ((global::CppSharp.Parser.AST.MacroExpansion.__Internal*) __Instance)->text = *(global::Std.Cxx11.BasicString.__Internal*) __basicString0.__Instance;
+                    }
+                }
+
                 public global::CppSharp.Parser.AST.MacroDefinition Definition
                 {
                     get
@@ -13183,34 +13298,6 @@ namespace CppSharp
                     set
                     {
                         ((global::CppSharp.Parser.AST.MacroExpansion.__Internal*) __Instance)->definition = ReferenceEquals(value, null) ? global::System.IntPtr.Zero : value.__Instance;
-                    }
-                }
-
-                public string Name
-                {
-                    get
-                    {
-                        var __ret = __Internal.GetName((__Instance + __PointerAdjustment));
-                        return Marshal.PtrToStringAnsi(__ret);
-                    }
-
-                    set
-                    {
-                        __Internal.SetName((__Instance + __PointerAdjustment), value);
-                    }
-                }
-
-                public string Text
-                {
-                    get
-                    {
-                        var __ret = __Internal.GetText((__Instance + __PointerAdjustment));
-                        return Marshal.PtrToStringAnsi(__ret);
-                    }
-
-                    set
-                    {
-                        __Internal.SetText((__Instance + __PointerAdjustment), value);
                     }
                 }
             }
@@ -13239,13 +13326,13 @@ namespace CppSharp
                     internal int lineNumberEnd;
 
                     [FieldOffset(32)]
-                    internal global::Std.Cxx11.BasicString.__Internal Name;
+                    internal global::Std.Cxx11.BasicString.__Internal name;
 
                     [FieldOffset(64)]
                     internal global::Std.Cxx11.BasicString.__Internal USR;
 
                     [FieldOffset(96)]
-                    internal global::Std.Cxx11.BasicString.__Internal DebugText;
+                    internal global::Std.Cxx11.BasicString.__Internal debugText;
 
                     [FieldOffset(128)]
                     internal byte isIncomplete;
@@ -13311,7 +13398,7 @@ namespace CppSharp
                     internal byte isInline;
 
                     [FieldOffset(488)]
-                    internal global::Std.Cxx11.BasicString.__Internal FileName;
+                    internal global::Std.Cxx11.BasicString.__Internal fileName;
 
                     [FieldOffset(520)]
                     internal byte isSystemHeader;
@@ -13348,16 +13435,6 @@ namespace CppSharp
                     [DllImport("CppSharp.CppParser", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
                         EntryPoint="_ZN8CppSharp9CppParser3AST15TranslationUnit11clearMacrosEv")]
                     internal static extern void ClearMacros_0(global::System.IntPtr instance);
-
-                    [SuppressUnmanagedCodeSecurity]
-                    [DllImport("CppSharp.CppParser", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
-                        EntryPoint="_ZN8CppSharp9CppParser3AST15TranslationUnit11getFileNameEv")]
-                    internal static extern global::System.IntPtr GetFileName(global::System.IntPtr instance);
-
-                    [SuppressUnmanagedCodeSecurity]
-                    [DllImport("CppSharp.CppParser", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
-                        EntryPoint="_ZN8CppSharp9CppParser3AST15TranslationUnit11setFileNameEPKc")]
-                    internal static extern void SetFileName(global::System.IntPtr instance, [MarshalAs(UnmanagedType.LPStr)] string s);
 
                     [SuppressUnmanagedCodeSecurity]
                     [DllImport("CppSharp.CppParser", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
@@ -13456,6 +13533,21 @@ namespace CppSharp
                     __Internal.ClearMacros_0((__Instance + __PointerAdjustment));
                 }
 
+                public string FileName
+                {
+                    get
+                    {
+                        return global::Std.Cxx11.BasicString.__CreateInstance(((global::CppSharp.Parser.AST.TranslationUnit.__Internal*) __Instance)->fileName).CStr();
+                    }
+
+                    set
+                    {
+                        var __allocator0 = new global::Std.Allocator();
+                        var __basicString0 = new global::Std.Cxx11.BasicString(value, __allocator0);
+                        ((global::CppSharp.Parser.AST.TranslationUnit.__Internal*) __Instance)->fileName = *(global::Std.Cxx11.BasicString.__Internal*) __basicString0.__Instance;
+                    }
+                }
+
                 public bool IsSystemHeader
                 {
                     get
@@ -13466,20 +13558,6 @@ namespace CppSharp
                     set
                     {
                         ((global::CppSharp.Parser.AST.TranslationUnit.__Internal*) __Instance)->isSystemHeader = (byte) (value ? 1 : 0);
-                    }
-                }
-
-                public string FileName
-                {
-                    get
-                    {
-                        var __ret = __Internal.GetFileName((__Instance + __PointerAdjustment));
-                        return Marshal.PtrToStringAnsi(__ret);
-                    }
-
-                    set
-                    {
-                        __Internal.SetFileName((__Instance + __PointerAdjustment), value);
                     }
                 }
 
@@ -13499,7 +13577,7 @@ namespace CppSharp
                 public partial struct __Internal
                 {
                     [FieldOffset(0)]
-                    internal global::Std.Cxx11.BasicString.__Internal FileName;
+                    internal global::Std.Cxx11.BasicString.__Internal fileName;
 
                     [FieldOffset(32)]
                     internal global::CppSharp.Parser.AST.ArchType archType;
@@ -13554,16 +13632,6 @@ namespace CppSharp
                     [DllImport("CppSharp.CppParser", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
                         EntryPoint="_ZN8CppSharp9CppParser3AST13NativeLibrary17clearDependenciesEv")]
                     internal static extern void ClearDependencies_0(global::System.IntPtr instance);
-
-                    [SuppressUnmanagedCodeSecurity]
-                    [DllImport("CppSharp.CppParser", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
-                        EntryPoint="_ZN8CppSharp9CppParser3AST13NativeLibrary11getFileNameEv")]
-                    internal static extern global::System.IntPtr GetFileName(global::System.IntPtr instance);
-
-                    [SuppressUnmanagedCodeSecurity]
-                    [DllImport("CppSharp.CppParser", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
-                        EntryPoint="_ZN8CppSharp9CppParser3AST13NativeLibrary11setFileNameEPKc")]
-                    internal static extern void SetFileName(global::System.IntPtr instance, [MarshalAs(UnmanagedType.LPStr)] string s);
 
                     [SuppressUnmanagedCodeSecurity]
                     [DllImport("CppSharp.CppParser", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
@@ -13684,6 +13752,21 @@ namespace CppSharp
                     __Internal.ClearDependencies_0((__Instance + __PointerAdjustment));
                 }
 
+                public string FileName
+                {
+                    get
+                    {
+                        return global::Std.Cxx11.BasicString.__CreateInstance(((global::CppSharp.Parser.AST.NativeLibrary.__Internal*) __Instance)->fileName).CStr();
+                    }
+
+                    set
+                    {
+                        var __allocator0 = new global::Std.Allocator();
+                        var __basicString0 = new global::Std.Cxx11.BasicString(value, __allocator0);
+                        ((global::CppSharp.Parser.AST.NativeLibrary.__Internal*) __Instance)->fileName = *(global::Std.Cxx11.BasicString.__Internal*) __basicString0.__Instance;
+                    }
+                }
+
                 public global::CppSharp.Parser.AST.ArchType ArchType
                 {
                     get
@@ -13694,20 +13777,6 @@ namespace CppSharp
                     set
                     {
                         ((global::CppSharp.Parser.AST.NativeLibrary.__Internal*) __Instance)->archType = value;
-                    }
-                }
-
-                public string FileName
-                {
-                    get
-                    {
-                        var __ret = __Internal.GetFileName((__Instance + __PointerAdjustment));
-                        return Marshal.PtrToStringAnsi(__ret);
-                    }
-
-                    set
-                    {
-                        __Internal.SetFileName((__Instance + __PointerAdjustment), value);
                     }
                 }
 
@@ -13752,6 +13821,11 @@ namespace CppSharp
                     [DllImport("CppSharp.CppParser", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
                         EntryPoint="_ZN8CppSharp9CppParser3AST10ASTContextD2Ev")]
                     internal static extern void dtor_0(global::System.IntPtr instance);
+
+                    [SuppressUnmanagedCodeSecurity]
+                    [DllImport("CppSharp.CppParser", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
+                        EntryPoint="_ZN8CppSharp9CppParser3AST10ASTContext18FindOrCreateModuleENSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEE")]
+                    internal static extern global::System.IntPtr FindOrCreateModule_0(global::System.IntPtr instance, global::Std.Cxx11.BasicString.__Internal File);
 
                     [SuppressUnmanagedCodeSecurity]
                     [DllImport("CppSharp.CppParser", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
@@ -13848,6 +13922,22 @@ namespace CppSharp
                     if (__ownsNativeInstance)
                         Marshal.FreeHGlobal(__Instance);
                     __Instance = IntPtr.Zero;
+                }
+
+                public global::CppSharp.Parser.AST.TranslationUnit FindOrCreateModule(string File)
+                {
+                    var __allocator0 = new global::Std.Allocator();
+                    var __basicString0 = new global::Std.Cxx11.BasicString(File, __allocator0);
+                    var __arg0 = *(global::Std.Cxx11.BasicString.__Internal*) __basicString0.__Instance;
+                    var __ret = __Internal.FindOrCreateModule_0((__Instance + __PointerAdjustment), __arg0);
+                    __basicString0.Dispose(false);
+                    __allocator0.Dispose();
+                    global::CppSharp.Parser.AST.TranslationUnit __result0;
+                    if (__ret == IntPtr.Zero) __result0 = null;
+                    else if (global::CppSharp.Parser.AST.TranslationUnit.NativeToManagedMap.ContainsKey(__ret))
+                        __result0 = (global::CppSharp.Parser.AST.TranslationUnit) global::CppSharp.Parser.AST.TranslationUnit.NativeToManagedMap[__ret];
+                    else __result0 = global::CppSharp.Parser.AST.TranslationUnit.__CreateInstance(__ret);
+                    return __result0;
                 }
 
                 public global::CppSharp.Parser.AST.TranslationUnit GetTranslationUnits(uint i)
@@ -14565,7 +14655,7 @@ namespace CppSharp
                     public partial struct __Internal
                     {
                         [FieldOffset(0)]
-                        internal global::Std.Cxx11.BasicString.__Internal Text;
+                        internal global::Std.Cxx11.BasicString.__Internal text;
 
                         [SuppressUnmanagedCodeSecurity]
                         [DllImport("CppSharp.CppParser", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
@@ -14581,16 +14671,6 @@ namespace CppSharp
                         [DllImport("CppSharp.CppParser", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
                             EntryPoint="_ZN8CppSharp9CppParser3AST19BlockCommandComment8ArgumentD2Ev")]
                         internal static extern void dtor_0(global::System.IntPtr instance);
-
-                        [SuppressUnmanagedCodeSecurity]
-                        [DllImport("CppSharp.CppParser", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
-                            EntryPoint="_ZN8CppSharp9CppParser3AST19BlockCommandComment8Argument7getTextEv")]
-                        internal static extern global::System.IntPtr GetText(global::System.IntPtr instance);
-
-                        [SuppressUnmanagedCodeSecurity]
-                        [DllImport("CppSharp.CppParser", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
-                            EntryPoint="_ZN8CppSharp9CppParser3AST19BlockCommandComment8Argument7setTextEPKc")]
-                        internal static extern void SetText(global::System.IntPtr instance, [MarshalAs(UnmanagedType.LPStr)] string s);
                     }
 
                     public global::System.IntPtr __Instance { get; protected set; }
@@ -14673,13 +14753,14 @@ namespace CppSharp
                     {
                         get
                         {
-                            var __ret = __Internal.GetText((__Instance + __PointerAdjustment));
-                            return Marshal.PtrToStringAnsi(__ret);
+                            return global::Std.Cxx11.BasicString.__CreateInstance(((global::CppSharp.Parser.AST.BlockCommandComment.Argument.__Internal*) __Instance)->text).CStr();
                         }
 
                         set
                         {
-                            __Internal.SetText((__Instance + __PointerAdjustment), value);
+                            var __allocator0 = new global::Std.Allocator();
+                            var __basicString0 = new global::Std.Cxx11.BasicString(value, __allocator0);
+                            ((global::CppSharp.Parser.AST.BlockCommandComment.Argument.__Internal*) __Instance)->text = *(global::Std.Cxx11.BasicString.__Internal*) __basicString0.__Instance;
                         }
                     }
                 }
@@ -15128,7 +15209,7 @@ namespace CppSharp
                     internal global::CppSharp.Parser.AST.CommentKind kind;
 
                     [FieldOffset(8)]
-                    internal global::Std.Cxx11.BasicString.__Internal Text;
+                    internal global::Std.Cxx11.BasicString.__Internal text;
 
                     [SuppressUnmanagedCodeSecurity]
                     [DllImport("CppSharp.CppParser", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
@@ -15144,16 +15225,6 @@ namespace CppSharp
                     [DllImport("CppSharp.CppParser", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
                         EntryPoint="_ZN8CppSharp9CppParser3AST24VerbatimBlockLineCommentD2Ev")]
                     internal static extern void dtor_0(global::System.IntPtr instance);
-
-                    [SuppressUnmanagedCodeSecurity]
-                    [DllImport("CppSharp.CppParser", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
-                        EntryPoint="_ZN8CppSharp9CppParser3AST24VerbatimBlockLineComment7getTextEv")]
-                    internal static extern global::System.IntPtr GetText(global::System.IntPtr instance);
-
-                    [SuppressUnmanagedCodeSecurity]
-                    [DllImport("CppSharp.CppParser", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
-                        EntryPoint="_ZN8CppSharp9CppParser3AST24VerbatimBlockLineComment7setTextEPKc")]
-                    internal static extern void SetText(global::System.IntPtr instance, [MarshalAs(UnmanagedType.LPStr)] string s);
                 }
 
                 internal static new global::CppSharp.Parser.AST.VerbatimBlockLineComment __CreateInstance(global::System.IntPtr native, bool skipVTables = false)
@@ -15227,13 +15298,14 @@ namespace CppSharp
                 {
                     get
                     {
-                        var __ret = __Internal.GetText((__Instance + __PointerAdjustment));
-                        return Marshal.PtrToStringAnsi(__ret);
+                        return global::Std.Cxx11.BasicString.__CreateInstance(((global::CppSharp.Parser.AST.VerbatimBlockLineComment.__Internal*) __Instance)->text).CStr();
                     }
 
                     set
                     {
-                        __Internal.SetText((__Instance + __PointerAdjustment), value);
+                        var __allocator0 = new global::Std.Allocator();
+                        var __basicString0 = new global::Std.Cxx11.BasicString(value, __allocator0);
+                        ((global::CppSharp.Parser.AST.VerbatimBlockLineComment.__Internal*) __Instance)->text = *(global::Std.Cxx11.BasicString.__Internal*) __basicString0.__Instance;
                     }
                 }
             }
@@ -15413,7 +15485,7 @@ namespace CppSharp
                     internal global::Std.Vector.__Internal Arguments;
 
                     [FieldOffset(40)]
-                    internal global::Std.Cxx11.BasicString.__Internal Text;
+                    internal global::Std.Cxx11.BasicString.__Internal text;
 
                     [SuppressUnmanagedCodeSecurity]
                     [DllImport("CppSharp.CppParser", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
@@ -15429,16 +15501,6 @@ namespace CppSharp
                     [DllImport("CppSharp.CppParser", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
                         EntryPoint="_ZN8CppSharp9CppParser3AST19VerbatimLineCommentD2Ev")]
                     internal static extern void dtor_0(global::System.IntPtr instance);
-
-                    [SuppressUnmanagedCodeSecurity]
-                    [DllImport("CppSharp.CppParser", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
-                        EntryPoint="_ZN8CppSharp9CppParser3AST19VerbatimLineComment7getTextEv")]
-                    internal static extern global::System.IntPtr GetText(global::System.IntPtr instance);
-
-                    [SuppressUnmanagedCodeSecurity]
-                    [DllImport("CppSharp.CppParser", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
-                        EntryPoint="_ZN8CppSharp9CppParser3AST19VerbatimLineComment7setTextEPKc")]
-                    internal static extern void SetText(global::System.IntPtr instance, [MarshalAs(UnmanagedType.LPStr)] string s);
                 }
 
                 internal static new global::CppSharp.Parser.AST.VerbatimLineComment __CreateInstance(global::System.IntPtr native, bool skipVTables = false)
@@ -15512,13 +15574,14 @@ namespace CppSharp
                 {
                     get
                     {
-                        var __ret = __Internal.GetText((__Instance + __PointerAdjustment));
-                        return Marshal.PtrToStringAnsi(__ret);
+                        return global::Std.Cxx11.BasicString.__CreateInstance(((global::CppSharp.Parser.AST.VerbatimLineComment.__Internal*) __Instance)->text).CStr();
                     }
 
                     set
                     {
-                        __Internal.SetText((__Instance + __PointerAdjustment), value);
+                        var __allocator0 = new global::Std.Allocator();
+                        var __basicString0 = new global::Std.Cxx11.BasicString(value, __allocator0);
+                        ((global::CppSharp.Parser.AST.VerbatimLineComment.__Internal*) __Instance)->text = *(global::Std.Cxx11.BasicString.__Internal*) __basicString0.__Instance;
                     }
                 }
             }
@@ -15593,7 +15656,7 @@ namespace CppSharp
                     public partial struct __Internal
                     {
                         [FieldOffset(0)]
-                        internal global::Std.Cxx11.BasicString.__Internal Text;
+                        internal global::Std.Cxx11.BasicString.__Internal text;
 
                         [SuppressUnmanagedCodeSecurity]
                         [DllImport("CppSharp.CppParser", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
@@ -15609,16 +15672,6 @@ namespace CppSharp
                         [DllImport("CppSharp.CppParser", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
                             EntryPoint="_ZN8CppSharp9CppParser3AST20InlineCommandComment8ArgumentD2Ev")]
                         internal static extern void dtor_0(global::System.IntPtr instance);
-
-                        [SuppressUnmanagedCodeSecurity]
-                        [DllImport("CppSharp.CppParser", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
-                            EntryPoint="_ZN8CppSharp9CppParser3AST20InlineCommandComment8Argument7getTextEv")]
-                        internal static extern global::System.IntPtr GetText(global::System.IntPtr instance);
-
-                        [SuppressUnmanagedCodeSecurity]
-                        [DllImport("CppSharp.CppParser", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
-                            EntryPoint="_ZN8CppSharp9CppParser3AST20InlineCommandComment8Argument7setTextEPKc")]
-                        internal static extern void SetText(global::System.IntPtr instance, [MarshalAs(UnmanagedType.LPStr)] string s);
                     }
 
                     public global::System.IntPtr __Instance { get; protected set; }
@@ -15701,13 +15754,14 @@ namespace CppSharp
                     {
                         get
                         {
-                            var __ret = __Internal.GetText((__Instance + __PointerAdjustment));
-                            return Marshal.PtrToStringAnsi(__ret);
+                            return global::Std.Cxx11.BasicString.__CreateInstance(((global::CppSharp.Parser.AST.InlineCommandComment.Argument.__Internal*) __Instance)->text).CStr();
                         }
 
                         set
                         {
-                            __Internal.SetText((__Instance + __PointerAdjustment), value);
+                            var __allocator0 = new global::Std.Allocator();
+                            var __basicString0 = new global::Std.Cxx11.BasicString(value, __allocator0);
+                            ((global::CppSharp.Parser.AST.InlineCommandComment.Argument.__Internal*) __Instance)->text = *(global::Std.Cxx11.BasicString.__Internal*) __basicString0.__Instance;
                         }
                     }
                 }
@@ -15940,7 +15994,7 @@ namespace CppSharp
                     internal byte hasTrailingNewline;
 
                     [FieldOffset(8)]
-                    internal global::Std.Cxx11.BasicString.__Internal TagName;
+                    internal global::Std.Cxx11.BasicString.__Internal tagName;
 
                     [FieldOffset(40)]
                     internal global::Std.Vector.__Internal Attributes;
@@ -15977,16 +16031,6 @@ namespace CppSharp
 
                     [SuppressUnmanagedCodeSecurity]
                     [DllImport("CppSharp.CppParser", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
-                        EntryPoint="_ZN8CppSharp9CppParser3AST19HTMLStartTagComment10getTagNameEv")]
-                    internal static extern global::System.IntPtr GetTagName(global::System.IntPtr instance);
-
-                    [SuppressUnmanagedCodeSecurity]
-                    [DllImport("CppSharp.CppParser", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
-                        EntryPoint="_ZN8CppSharp9CppParser3AST19HTMLStartTagComment10setTagNameEPKc")]
-                    internal static extern void SetTagName(global::System.IntPtr instance, [MarshalAs(UnmanagedType.LPStr)] string s);
-
-                    [SuppressUnmanagedCodeSecurity]
-                    [DllImport("CppSharp.CppParser", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
                         EntryPoint="_ZN8CppSharp9CppParser3AST19HTMLStartTagComment18getAttributesCountEv")]
                     internal static extern uint GetAttributesCount(global::System.IntPtr instance);
                 }
@@ -15997,10 +16041,10 @@ namespace CppSharp
                     public partial struct __Internal
                     {
                         [FieldOffset(0)]
-                        internal global::Std.Cxx11.BasicString.__Internal Name;
+                        internal global::Std.Cxx11.BasicString.__Internal name;
 
                         [FieldOffset(32)]
-                        internal global::Std.Cxx11.BasicString.__Internal Value;
+                        internal global::Std.Cxx11.BasicString.__Internal value;
 
                         [SuppressUnmanagedCodeSecurity]
                         [DllImport("CppSharp.CppParser", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
@@ -16016,26 +16060,6 @@ namespace CppSharp
                         [DllImport("CppSharp.CppParser", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
                             EntryPoint="_ZN8CppSharp9CppParser3AST19HTMLStartTagComment9AttributeD2Ev")]
                         internal static extern void dtor_0(global::System.IntPtr instance);
-
-                        [SuppressUnmanagedCodeSecurity]
-                        [DllImport("CppSharp.CppParser", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
-                            EntryPoint="_ZN8CppSharp9CppParser3AST19HTMLStartTagComment9Attribute7getNameEv")]
-                        internal static extern global::System.IntPtr GetName(global::System.IntPtr instance);
-
-                        [SuppressUnmanagedCodeSecurity]
-                        [DllImport("CppSharp.CppParser", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
-                            EntryPoint="_ZN8CppSharp9CppParser3AST19HTMLStartTagComment9Attribute7setNameEPKc")]
-                        internal static extern void SetName(global::System.IntPtr instance, [MarshalAs(UnmanagedType.LPStr)] string s);
-
-                        [SuppressUnmanagedCodeSecurity]
-                        [DllImport("CppSharp.CppParser", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
-                            EntryPoint="_ZN8CppSharp9CppParser3AST19HTMLStartTagComment9Attribute8getValueEv")]
-                        internal static extern global::System.IntPtr GetValue(global::System.IntPtr instance);
-
-                        [SuppressUnmanagedCodeSecurity]
-                        [DllImport("CppSharp.CppParser", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
-                            EntryPoint="_ZN8CppSharp9CppParser3AST19HTMLStartTagComment9Attribute8setValueEPKc")]
-                        internal static extern void SetValue(global::System.IntPtr instance, [MarshalAs(UnmanagedType.LPStr)] string s);
                     }
 
                     public global::System.IntPtr __Instance { get; protected set; }
@@ -16118,13 +16142,14 @@ namespace CppSharp
                     {
                         get
                         {
-                            var __ret = __Internal.GetName((__Instance + __PointerAdjustment));
-                            return Marshal.PtrToStringAnsi(__ret);
+                            return global::Std.Cxx11.BasicString.__CreateInstance(((global::CppSharp.Parser.AST.HTMLStartTagComment.Attribute.__Internal*) __Instance)->name).CStr();
                         }
 
                         set
                         {
-                            __Internal.SetName((__Instance + __PointerAdjustment), value);
+                            var __allocator0 = new global::Std.Allocator();
+                            var __basicString0 = new global::Std.Cxx11.BasicString(value, __allocator0);
+                            ((global::CppSharp.Parser.AST.HTMLStartTagComment.Attribute.__Internal*) __Instance)->name = *(global::Std.Cxx11.BasicString.__Internal*) __basicString0.__Instance;
                         }
                     }
 
@@ -16132,13 +16157,14 @@ namespace CppSharp
                     {
                         get
                         {
-                            var __ret = __Internal.GetValue((__Instance + __PointerAdjustment));
-                            return Marshal.PtrToStringAnsi(__ret);
+                            return global::Std.Cxx11.BasicString.__CreateInstance(((global::CppSharp.Parser.AST.HTMLStartTagComment.Attribute.__Internal*) __Instance)->value).CStr();
                         }
 
                         set
                         {
-                            __Internal.SetValue((__Instance + __PointerAdjustment), value);
+                            var __allocator0 = new global::Std.Allocator();
+                            var __basicString0 = new global::Std.Cxx11.BasicString(value, __allocator0);
+                            ((global::CppSharp.Parser.AST.HTMLStartTagComment.Attribute.__Internal*) __Instance)->value = *(global::Std.Cxx11.BasicString.__Internal*) __basicString0.__Instance;
                         }
                     }
                 }
@@ -16234,13 +16260,14 @@ namespace CppSharp
                 {
                     get
                     {
-                        var __ret = __Internal.GetTagName((__Instance + __PointerAdjustment));
-                        return Marshal.PtrToStringAnsi(__ret);
+                        return global::Std.Cxx11.BasicString.__CreateInstance(((global::CppSharp.Parser.AST.HTMLStartTagComment.__Internal*) __Instance)->tagName).CStr();
                     }
 
                     set
                     {
-                        __Internal.SetTagName((__Instance + __PointerAdjustment), value);
+                        var __allocator0 = new global::Std.Allocator();
+                        var __basicString0 = new global::Std.Cxx11.BasicString(value, __allocator0);
+                        ((global::CppSharp.Parser.AST.HTMLStartTagComment.__Internal*) __Instance)->tagName = *(global::Std.Cxx11.BasicString.__Internal*) __basicString0.__Instance;
                     }
                 }
 
@@ -16266,7 +16293,7 @@ namespace CppSharp
                     internal byte hasTrailingNewline;
 
                     [FieldOffset(8)]
-                    internal global::Std.Cxx11.BasicString.__Internal TagName;
+                    internal global::Std.Cxx11.BasicString.__Internal tagName;
 
                     [SuppressUnmanagedCodeSecurity]
                     [DllImport("CppSharp.CppParser", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
@@ -16282,16 +16309,6 @@ namespace CppSharp
                     [DllImport("CppSharp.CppParser", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
                         EntryPoint="_ZN8CppSharp9CppParser3AST17HTMLEndTagCommentD2Ev")]
                     internal static extern void dtor_0(global::System.IntPtr instance);
-
-                    [SuppressUnmanagedCodeSecurity]
-                    [DllImport("CppSharp.CppParser", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
-                        EntryPoint="_ZN8CppSharp9CppParser3AST17HTMLEndTagComment10getTagNameEv")]
-                    internal static extern global::System.IntPtr GetTagName(global::System.IntPtr instance);
-
-                    [SuppressUnmanagedCodeSecurity]
-                    [DllImport("CppSharp.CppParser", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
-                        EntryPoint="_ZN8CppSharp9CppParser3AST17HTMLEndTagComment10setTagNameEPKc")]
-                    internal static extern void SetTagName(global::System.IntPtr instance, [MarshalAs(UnmanagedType.LPStr)] string s);
                 }
 
                 internal static new global::CppSharp.Parser.AST.HTMLEndTagComment __CreateInstance(global::System.IntPtr native, bool skipVTables = false)
@@ -16365,13 +16382,14 @@ namespace CppSharp
                 {
                     get
                     {
-                        var __ret = __Internal.GetTagName((__Instance + __PointerAdjustment));
-                        return Marshal.PtrToStringAnsi(__ret);
+                        return global::Std.Cxx11.BasicString.__CreateInstance(((global::CppSharp.Parser.AST.HTMLEndTagComment.__Internal*) __Instance)->tagName).CStr();
                     }
 
                     set
                     {
-                        __Internal.SetTagName((__Instance + __PointerAdjustment), value);
+                        var __allocator0 = new global::Std.Allocator();
+                        var __basicString0 = new global::Std.Cxx11.BasicString(value, __allocator0);
+                        ((global::CppSharp.Parser.AST.HTMLEndTagComment.__Internal*) __Instance)->tagName = *(global::Std.Cxx11.BasicString.__Internal*) __basicString0.__Instance;
                     }
                 }
             }
@@ -16388,7 +16406,7 @@ namespace CppSharp
                     internal byte hasTrailingNewline;
 
                     [FieldOffset(8)]
-                    internal global::Std.Cxx11.BasicString.__Internal Text;
+                    internal global::Std.Cxx11.BasicString.__Internal text;
 
                     [SuppressUnmanagedCodeSecurity]
                     [DllImport("CppSharp.CppParser", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
@@ -16404,16 +16422,6 @@ namespace CppSharp
                     [DllImport("CppSharp.CppParser", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
                         EntryPoint="_ZN8CppSharp9CppParser3AST11TextCommentD2Ev")]
                     internal static extern void dtor_0(global::System.IntPtr instance);
-
-                    [SuppressUnmanagedCodeSecurity]
-                    [DllImport("CppSharp.CppParser", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
-                        EntryPoint="_ZN8CppSharp9CppParser3AST11TextComment7getTextEv")]
-                    internal static extern global::System.IntPtr GetText(global::System.IntPtr instance);
-
-                    [SuppressUnmanagedCodeSecurity]
-                    [DllImport("CppSharp.CppParser", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
-                        EntryPoint="_ZN8CppSharp9CppParser3AST11TextComment7setTextEPKc")]
-                    internal static extern void SetText(global::System.IntPtr instance, [MarshalAs(UnmanagedType.LPStr)] string s);
                 }
 
                 internal static new global::CppSharp.Parser.AST.TextComment __CreateInstance(global::System.IntPtr native, bool skipVTables = false)
@@ -16487,13 +16495,14 @@ namespace CppSharp
                 {
                     get
                     {
-                        var __ret = __Internal.GetText((__Instance + __PointerAdjustment));
-                        return Marshal.PtrToStringAnsi(__ret);
+                        return global::Std.Cxx11.BasicString.__CreateInstance(((global::CppSharp.Parser.AST.TextComment.__Internal*) __Instance)->text).CStr();
                     }
 
                     set
                     {
-                        __Internal.SetText((__Instance + __PointerAdjustment), value);
+                        var __allocator0 = new global::Std.Allocator();
+                        var __basicString0 = new global::Std.Cxx11.BasicString(value, __allocator0);
+                        ((global::CppSharp.Parser.AST.TextComment.__Internal*) __Instance)->text = *(global::Std.Cxx11.BasicString.__Internal*) __basicString0.__Instance;
                     }
                 }
             }
@@ -16507,10 +16516,10 @@ namespace CppSharp
                     internal global::CppSharp.Parser.AST.RawCommentKind kind;
 
                     [FieldOffset(8)]
-                    internal global::Std.Cxx11.BasicString.__Internal Text;
+                    internal global::Std.Cxx11.BasicString.__Internal text;
 
                     [FieldOffset(40)]
-                    internal global::Std.Cxx11.BasicString.__Internal BriefText;
+                    internal global::Std.Cxx11.BasicString.__Internal briefText;
 
                     [FieldOffset(72)]
                     internal global::System.IntPtr fullCommentBlock;
@@ -16529,26 +16538,6 @@ namespace CppSharp
                     [DllImport("CppSharp.CppParser", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
                         EntryPoint="_ZN8CppSharp9CppParser3AST10RawCommentD2Ev")]
                     internal static extern void dtor_0(global::System.IntPtr instance);
-
-                    [SuppressUnmanagedCodeSecurity]
-                    [DllImport("CppSharp.CppParser", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
-                        EntryPoint="_ZN8CppSharp9CppParser3AST10RawComment7getTextEv")]
-                    internal static extern global::System.IntPtr GetText(global::System.IntPtr instance);
-
-                    [SuppressUnmanagedCodeSecurity]
-                    [DllImport("CppSharp.CppParser", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
-                        EntryPoint="_ZN8CppSharp9CppParser3AST10RawComment7setTextEPKc")]
-                    internal static extern void SetText(global::System.IntPtr instance, [MarshalAs(UnmanagedType.LPStr)] string s);
-
-                    [SuppressUnmanagedCodeSecurity]
-                    [DllImport("CppSharp.CppParser", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
-                        EntryPoint="_ZN8CppSharp9CppParser3AST10RawComment12getBriefTextEv")]
-                    internal static extern global::System.IntPtr GetBriefText(global::System.IntPtr instance);
-
-                    [SuppressUnmanagedCodeSecurity]
-                    [DllImport("CppSharp.CppParser", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
-                        EntryPoint="_ZN8CppSharp9CppParser3AST10RawComment12setBriefTextEPKc")]
-                    internal static extern void SetBriefText(global::System.IntPtr instance, [MarshalAs(UnmanagedType.LPStr)] string s);
                 }
 
                 public global::System.IntPtr __Instance { get; protected set; }
@@ -16640,6 +16629,36 @@ namespace CppSharp
                     }
                 }
 
+                public string Text
+                {
+                    get
+                    {
+                        return global::Std.Cxx11.BasicString.__CreateInstance(((global::CppSharp.Parser.AST.RawComment.__Internal*) __Instance)->text).CStr();
+                    }
+
+                    set
+                    {
+                        var __allocator0 = new global::Std.Allocator();
+                        var __basicString0 = new global::Std.Cxx11.BasicString(value, __allocator0);
+                        ((global::CppSharp.Parser.AST.RawComment.__Internal*) __Instance)->text = *(global::Std.Cxx11.BasicString.__Internal*) __basicString0.__Instance;
+                    }
+                }
+
+                public string BriefText
+                {
+                    get
+                    {
+                        return global::Std.Cxx11.BasicString.__CreateInstance(((global::CppSharp.Parser.AST.RawComment.__Internal*) __Instance)->briefText).CStr();
+                    }
+
+                    set
+                    {
+                        var __allocator0 = new global::Std.Allocator();
+                        var __basicString0 = new global::Std.Cxx11.BasicString(value, __allocator0);
+                        ((global::CppSharp.Parser.AST.RawComment.__Internal*) __Instance)->briefText = *(global::Std.Cxx11.BasicString.__Internal*) __basicString0.__Instance;
+                    }
+                }
+
                 public global::CppSharp.Parser.AST.FullComment FullCommentBlock
                 {
                     get
@@ -16655,34 +16674,6 @@ namespace CppSharp
                     set
                     {
                         ((global::CppSharp.Parser.AST.RawComment.__Internal*) __Instance)->fullCommentBlock = ReferenceEquals(value, null) ? global::System.IntPtr.Zero : value.__Instance;
-                    }
-                }
-
-                public string Text
-                {
-                    get
-                    {
-                        var __ret = __Internal.GetText((__Instance + __PointerAdjustment));
-                        return Marshal.PtrToStringAnsi(__ret);
-                    }
-
-                    set
-                    {
-                        __Internal.SetText((__Instance + __PointerAdjustment), value);
-                    }
-                }
-
-                public string BriefText
-                {
-                    get
-                    {
-                        var __ret = __Internal.GetBriefText((__Instance + __PointerAdjustment));
-                        return Marshal.PtrToStringAnsi(__ret);
-                    }
-
-                    set
-                    {
-                        __Internal.SetBriefText((__Instance + __PointerAdjustment), value);
                     }
                 }
             }
@@ -16944,16 +16935,6 @@ namespace CppSharp
                 [DllImport("CppSharp.CppParser", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
                     EntryPoint="_ZN8CppSharp9CppParser16ParserTargetInfoD2Ev")]
                 internal static extern void dtor_0(global::System.IntPtr instance);
-
-                [SuppressUnmanagedCodeSecurity]
-                [DllImport("CppSharp.CppParser", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
-                    EntryPoint="_ZN8CppSharp9CppParser16ParserTargetInfo6getABIEv")]
-                internal static extern global::System.IntPtr GetABI(global::System.IntPtr instance);
-
-                [SuppressUnmanagedCodeSecurity]
-                [DllImport("CppSharp.CppParser", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
-                    EntryPoint="_ZN8CppSharp9CppParser16ParserTargetInfo6setABIEPKc")]
-                internal static extern void SetABI(global::System.IntPtr instance, [MarshalAs(UnmanagedType.LPStr)] string s);
             }
 
             public global::System.IntPtr __Instance { get; protected set; }
@@ -17030,6 +17011,21 @@ namespace CppSharp
                 if (__ownsNativeInstance)
                     Marshal.FreeHGlobal(__Instance);
                 __Instance = IntPtr.Zero;
+            }
+
+            public string ABI
+            {
+                get
+                {
+                    return global::Std.Cxx11.BasicString.__CreateInstance(((global::CppSharp.Parser.ParserTargetInfo.__Internal*) __Instance)->ABI).CStr();
+                }
+
+                set
+                {
+                    var __allocator0 = new global::Std.Allocator();
+                    var __basicString0 = new global::Std.Cxx11.BasicString(value, __allocator0);
+                    ((global::CppSharp.Parser.ParserTargetInfo.__Internal*) __Instance)->ABI = *(global::Std.Cxx11.BasicString.__Internal*) __basicString0.__Instance;
+                }
             }
 
             public global::CppSharp.Parser.ParserIntType Char16Type
@@ -17551,20 +17547,6 @@ namespace CppSharp
                     ((global::CppSharp.Parser.ParserTargetInfo.__Internal*) __Instance)->float128Width = value;
                 }
             }
-
-            public string ABI
-            {
-                get
-                {
-                    var __ret = __Internal.GetABI((__Instance + __PointerAdjustment));
-                    return Marshal.PtrToStringAnsi(__ret);
-                }
-
-                set
-                {
-                    __Internal.SetABI((__Instance + __PointerAdjustment), value);
-                }
-            }
         }
     }
 }
@@ -17670,7 +17652,7 @@ namespace CppSharp
                 internal global::Std.Vector.__Internal Arguments;
 
                 [FieldOffset(24)]
-                internal global::Std.Cxx11.BasicString.__Internal LibraryFile;
+                internal global::Std.Cxx11.BasicString.__Internal libraryFile;
 
                 [FieldOffset(56)]
                 internal global::Std.Vector.__Internal SourceFiles;
@@ -17697,7 +17679,7 @@ namespace CppSharp
                 internal int toolSetToUse;
 
                 [FieldOffset(216)]
-                internal global::Std.Cxx11.BasicString.__Internal TargetTriple;
+                internal global::Std.Cxx11.BasicString.__Internal targetTriple;
 
                 [FieldOffset(248)]
                 internal global::CppSharp.Parser.AST.CppAbi abi;
@@ -17839,26 +17821,6 @@ namespace CppSharp
                 [DllImport("CppSharp.CppParser", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
                     EntryPoint="_ZN8CppSharp9CppParser16CppParserOptions16clearLibraryDirsEv")]
                 internal static extern void ClearLibraryDirs_0(global::System.IntPtr instance);
-
-                [SuppressUnmanagedCodeSecurity]
-                [DllImport("CppSharp.CppParser", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
-                    EntryPoint="_ZN8CppSharp9CppParser16CppParserOptions14getLibraryFileEv")]
-                internal static extern global::System.IntPtr GetLibraryFile(global::System.IntPtr instance);
-
-                [SuppressUnmanagedCodeSecurity]
-                [DllImport("CppSharp.CppParser", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
-                    EntryPoint="_ZN8CppSharp9CppParser16CppParserOptions14setLibraryFileEPKc")]
-                internal static extern void SetLibraryFile(global::System.IntPtr instance, [MarshalAs(UnmanagedType.LPStr)] string s);
-
-                [SuppressUnmanagedCodeSecurity]
-                [DllImport("CppSharp.CppParser", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
-                    EntryPoint="_ZN8CppSharp9CppParser16CppParserOptions15getTargetTripleEv")]
-                internal static extern global::System.IntPtr GetTargetTriple(global::System.IntPtr instance);
-
-                [SuppressUnmanagedCodeSecurity]
-                [DllImport("CppSharp.CppParser", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
-                    EntryPoint="_ZN8CppSharp9CppParser16CppParserOptions15setTargetTripleEPKc")]
-                internal static extern void SetTargetTriple(global::System.IntPtr instance, [MarshalAs(UnmanagedType.LPStr)] string s);
 
                 [SuppressUnmanagedCodeSecurity]
                 [DllImport("CppSharp.CppParser", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
@@ -18084,6 +18046,21 @@ namespace CppSharp
                 __Internal.ClearLibraryDirs_0((__Instance + __PointerAdjustment));
             }
 
+            public string LibraryFile
+            {
+                get
+                {
+                    return global::Std.Cxx11.BasicString.__CreateInstance(((global::CppSharp.Parser.CppParserOptions.__Internal*) __Instance)->libraryFile).CStr();
+                }
+
+                set
+                {
+                    var __allocator0 = new global::Std.Allocator();
+                    var __basicString0 = new global::Std.Cxx11.BasicString(value, __allocator0);
+                    ((global::CppSharp.Parser.CppParserOptions.__Internal*) __Instance)->libraryFile = *(global::Std.Cxx11.BasicString.__Internal*) __basicString0.__Instance;
+                }
+            }
+
             public global::CppSharp.Parser.AST.ASTContext ASTContext
             {
                 get
@@ -18112,6 +18089,21 @@ namespace CppSharp
                 set
                 {
                     ((global::CppSharp.Parser.CppParserOptions.__Internal*) __Instance)->toolSetToUse = value;
+                }
+            }
+
+            public string TargetTriple
+            {
+                get
+                {
+                    return global::Std.Cxx11.BasicString.__CreateInstance(((global::CppSharp.Parser.CppParserOptions.__Internal*) __Instance)->targetTriple).CStr();
+                }
+
+                set
+                {
+                    var __allocator0 = new global::Std.Allocator();
+                    var __basicString0 = new global::Std.Cxx11.BasicString(value, __allocator0);
+                    ((global::CppSharp.Parser.CppParserOptions.__Internal*) __Instance)->targetTriple = *(global::Std.Cxx11.BasicString.__Internal*) __basicString0.__Instance;
                 }
             }
 
@@ -18211,34 +18203,6 @@ namespace CppSharp
                 }
             }
 
-            public string LibraryFile
-            {
-                get
-                {
-                    var __ret = __Internal.GetLibraryFile((__Instance + __PointerAdjustment));
-                    return Marshal.PtrToStringAnsi(__ret);
-                }
-
-                set
-                {
-                    __Internal.SetLibraryFile((__Instance + __PointerAdjustment), value);
-                }
-            }
-
-            public string TargetTriple
-            {
-                get
-                {
-                    var __ret = __Internal.GetTargetTriple((__Instance + __PointerAdjustment));
-                    return Marshal.PtrToStringAnsi(__ret);
-                }
-
-                set
-                {
-                    __Internal.SetTargetTriple((__Instance + __PointerAdjustment), value);
-                }
-            }
-
             public uint ArgumentsCount
             {
                 get
@@ -18309,10 +18273,10 @@ namespace CppSharp
             public partial struct __Internal
             {
                 [FieldOffset(0)]
-                internal global::Std.Cxx11.BasicString.__Internal FileName;
+                internal global::Std.Cxx11.BasicString.__Internal fileName;
 
                 [FieldOffset(32)]
-                internal global::Std.Cxx11.BasicString.__Internal Message;
+                internal global::Std.Cxx11.BasicString.__Internal message;
 
                 [FieldOffset(64)]
                 internal global::CppSharp.Parser.ParserDiagnosticLevel level;
@@ -18337,26 +18301,6 @@ namespace CppSharp
                 [DllImport("CppSharp.CppParser", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
                     EntryPoint="_ZN8CppSharp9CppParser16ParserDiagnosticD2Ev")]
                 internal static extern void dtor_0(global::System.IntPtr instance);
-
-                [SuppressUnmanagedCodeSecurity]
-                [DllImport("CppSharp.CppParser", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
-                    EntryPoint="_ZN8CppSharp9CppParser16ParserDiagnostic11getFileNameEv")]
-                internal static extern global::System.IntPtr GetFileName(global::System.IntPtr instance);
-
-                [SuppressUnmanagedCodeSecurity]
-                [DllImport("CppSharp.CppParser", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
-                    EntryPoint="_ZN8CppSharp9CppParser16ParserDiagnostic11setFileNameEPKc")]
-                internal static extern void SetFileName(global::System.IntPtr instance, [MarshalAs(UnmanagedType.LPStr)] string s);
-
-                [SuppressUnmanagedCodeSecurity]
-                [DllImport("CppSharp.CppParser", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
-                    EntryPoint="_ZN8CppSharp9CppParser16ParserDiagnostic10getMessageEv")]
-                internal static extern global::System.IntPtr GetMessage(global::System.IntPtr instance);
-
-                [SuppressUnmanagedCodeSecurity]
-                [DllImport("CppSharp.CppParser", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
-                    EntryPoint="_ZN8CppSharp9CppParser16ParserDiagnostic10setMessageEPKc")]
-                internal static extern void SetMessage(global::System.IntPtr instance, [MarshalAs(UnmanagedType.LPStr)] string s);
             }
 
             public global::System.IntPtr __Instance { get; protected set; }
@@ -18435,6 +18379,36 @@ namespace CppSharp
                 __Instance = IntPtr.Zero;
             }
 
+            public string FileName
+            {
+                get
+                {
+                    return global::Std.Cxx11.BasicString.__CreateInstance(((global::CppSharp.Parser.ParserDiagnostic.__Internal*) __Instance)->fileName).CStr();
+                }
+
+                set
+                {
+                    var __allocator0 = new global::Std.Allocator();
+                    var __basicString0 = new global::Std.Cxx11.BasicString(value, __allocator0);
+                    ((global::CppSharp.Parser.ParserDiagnostic.__Internal*) __Instance)->fileName = *(global::Std.Cxx11.BasicString.__Internal*) __basicString0.__Instance;
+                }
+            }
+
+            public string Message
+            {
+                get
+                {
+                    return global::Std.Cxx11.BasicString.__CreateInstance(((global::CppSharp.Parser.ParserDiagnostic.__Internal*) __Instance)->message).CStr();
+                }
+
+                set
+                {
+                    var __allocator0 = new global::Std.Allocator();
+                    var __basicString0 = new global::Std.Cxx11.BasicString(value, __allocator0);
+                    ((global::CppSharp.Parser.ParserDiagnostic.__Internal*) __Instance)->message = *(global::Std.Cxx11.BasicString.__Internal*) __basicString0.__Instance;
+                }
+            }
+
             public global::CppSharp.Parser.ParserDiagnosticLevel Level
             {
                 get
@@ -18471,34 +18445,6 @@ namespace CppSharp
                 set
                 {
                     ((global::CppSharp.Parser.ParserDiagnostic.__Internal*) __Instance)->columnNumber = value;
-                }
-            }
-
-            public string FileName
-            {
-                get
-                {
-                    var __ret = __Internal.GetFileName((__Instance + __PointerAdjustment));
-                    return Marshal.PtrToStringAnsi(__ret);
-                }
-
-                set
-                {
-                    __Internal.SetFileName((__Instance + __PointerAdjustment), value);
-                }
-            }
-
-            public string Message
-            {
-                get
-                {
-                    var __ret = __Internal.GetMessage((__Instance + __PointerAdjustment));
-                    return Marshal.PtrToStringAnsi(__ret);
-                }
-
-                set
-                {
-                    __Internal.SetMessage((__Instance + __PointerAdjustment), value);
                 }
             }
         }

--- a/src/CppParser/Bindings/CSharp/x86_64-linux-gnu-cxx11abi/Std.cs
+++ b/src/CppParser/Bindings/CSharp/x86_64-linux-gnu-cxx11abi/Std.cs
@@ -337,68 +337,6 @@ public unsafe partial class MbstateT
 
 namespace Std
 {
-    public unsafe partial class CharTraits : IDisposable
-    {
-        [StructLayout(LayoutKind.Explicit, Size = 0)]
-        public unsafe partial struct __Internal
-        {
-        }
-
-        public global::System.IntPtr __Instance { get; protected set; }
-
-        protected int __PointerAdjustment;
-        internal static readonly global::System.Collections.Concurrent.ConcurrentDictionary<IntPtr, global::Std.CharTraits> NativeToManagedMap = new global::System.Collections.Concurrent.ConcurrentDictionary<IntPtr, global::Std.CharTraits>();
-        protected void*[] __OriginalVTables;
-
-        protected bool __ownsNativeInstance;
-
-        internal static global::Std.CharTraits __CreateInstance(global::System.IntPtr native, bool skipVTables = false)
-        {
-            return new global::Std.CharTraits(native.ToPointer(), skipVTables);
-        }
-
-        internal static global::Std.CharTraits __CreateInstance(global::Std.CharTraits.__Internal native, bool skipVTables = false)
-        {
-            return new global::Std.CharTraits(native, skipVTables);
-        }
-
-        private static void* __CopyValue(global::Std.CharTraits.__Internal native)
-        {
-            var ret = Marshal.AllocHGlobal(sizeof(global::Std.CharTraits.__Internal));
-            *(global::Std.CharTraits.__Internal*) ret = native;
-            return ret.ToPointer();
-        }
-
-        private CharTraits(global::Std.CharTraits.__Internal native, bool skipVTables = false)
-            : this(__CopyValue(native), skipVTables)
-        {
-            __ownsNativeInstance = true;
-            NativeToManagedMap[__Instance] = this;
-        }
-
-        protected CharTraits(void* native, bool skipVTables = false)
-        {
-            if (native == null)
-                return;
-            __Instance = new global::System.IntPtr(native);
-        }
-
-        public void Dispose()
-        {
-            Dispose(disposing: true);
-        }
-
-        public virtual void Dispose(bool disposing)
-        {
-            if (__Instance == IntPtr.Zero)
-                return;
-            global::Std.CharTraits __dummy;
-            NativeToManagedMap.TryRemove(__Instance, out __dummy);
-            if (__ownsNativeInstance)
-                Marshal.FreeHGlobal(__Instance);
-            __Instance = IntPtr.Zero;
-        }
-    }
 }
 
 namespace Std
@@ -647,6 +585,11 @@ namespace Std
 
                 [SuppressUnmanagedCodeSecurity]
                 [DllImport("Std-symbols", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
+                    EntryPoint="_ZNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEC2EPKcRKS3_")]
+                internal static extern void ctorc__N_std_N___cxx11_S_basic_string__C___N_std_S_char_traits__C___N_std_S_allocator__C_0(global::System.IntPtr instance, [MarshalAs(UnmanagedType.LPStr)] string __s, global::System.IntPtr __a);
+
+                [SuppressUnmanagedCodeSecurity]
+                [DllImport("Std-symbols", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
                     EntryPoint="_ZNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEED2Ev")]
                 internal static extern void dtorc__N_std_N___cxx11_S_basic_string__C___N_std_S_char_traits__C___N_std_S_allocator__C_0(global::System.IntPtr instance);
 
@@ -721,6 +664,17 @@ namespace Std
                 if (native == null)
                     return;
                 __Instance = new global::System.IntPtr(native);
+            }
+
+            public BasicString(string __s, global::Std.Allocator __a)
+            {
+                __Instance = Marshal.AllocHGlobal(sizeof(global::Std.Cxx11.BasicString.__Internal));
+                __ownsNativeInstance = true;
+                NativeToManagedMap[__Instance] = this;
+                if (ReferenceEquals(__a, null))
+                    throw new global::System.ArgumentNullException("__a", "Cannot be null because it is a C++ reference (&).");
+                var __arg1 = ((global::Std.Allocator) (object) __a).__Instance;
+                global::Std.Cxx11.BasicString.__Internal.ctorc__N_std_N___cxx11_S_basic_string__C___N_std_S_char_traits__C___N_std_S_allocator__C_0((__Instance + __PointerAdjustment), __s, __arg1);
             }
 
             public void Dispose()

--- a/src/CppParser/Bindings/CSharp/x86_64-linux-gnu/CppSharp.CppParser.cs
+++ b/src/CppParser/Bindings/CSharp/x86_64-linux-gnu/CppSharp.CppParser.cs
@@ -2589,7 +2589,7 @@ namespace CppSharp
                     internal global::CppSharp.Parser.AST.QualifiedType.__Internal qualifier;
 
                     [FieldOffset(24)]
-                    internal global::Std.BasicString.__Internal Identifier;
+                    internal global::Std.BasicString.__Internal identifier;
 
                     [SuppressUnmanagedCodeSecurity]
                     [DllImport("CppSharp.CppParser", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
@@ -2605,16 +2605,6 @@ namespace CppSharp
                     [DllImport("CppSharp.CppParser", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
                         EntryPoint="_ZN8CppSharp9CppParser3AST17DependentNameTypeD2Ev")]
                     internal static extern void dtor_0(global::System.IntPtr instance);
-
-                    [SuppressUnmanagedCodeSecurity]
-                    [DllImport("CppSharp.CppParser", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
-                        EntryPoint="_ZN8CppSharp9CppParser3AST17DependentNameType13getIdentifierEv")]
-                    internal static extern global::System.IntPtr GetIdentifier(global::System.IntPtr instance);
-
-                    [SuppressUnmanagedCodeSecurity]
-                    [DllImport("CppSharp.CppParser", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
-                        EntryPoint="_ZN8CppSharp9CppParser3AST17DependentNameType13setIdentifierEPKc")]
-                    internal static extern void SetIdentifier(global::System.IntPtr instance, [MarshalAs(UnmanagedType.LPStr)] string s);
                 }
 
                 internal static new global::CppSharp.Parser.AST.DependentNameType __CreateInstance(global::System.IntPtr native, bool skipVTables = false)
@@ -2701,13 +2691,14 @@ namespace CppSharp
                 {
                     get
                     {
-                        var __ret = __Internal.GetIdentifier((__Instance + __PointerAdjustment));
-                        return Marshal.PtrToStringAnsi(__ret);
+                        return global::Std.BasicString.__CreateInstance(((global::CppSharp.Parser.AST.DependentNameType.__Internal*) __Instance)->identifier).CStr();
                     }
 
                     set
                     {
-                        __Internal.SetIdentifier((__Instance + __PointerAdjustment), value);
+                        var __allocator0 = new global::Std.Allocator();
+                        var __basicString0 = new global::Std.BasicString(value, __allocator0);
+                        ((global::CppSharp.Parser.AST.DependentNameType.__Internal*) __Instance)->identifier = *(global::Std.BasicString.__Internal*) __basicString0.__Instance;
                     }
                 }
             }
@@ -3561,7 +3552,7 @@ namespace CppSharp
                     internal uint offset;
 
                     [FieldOffset(8)]
-                    internal global::Std.BasicString.__Internal Name;
+                    internal global::Std.BasicString.__Internal name;
 
                     [FieldOffset(16)]
                     internal global::CppSharp.Parser.AST.QualifiedType.__Internal qualifiedType;
@@ -3583,16 +3574,6 @@ namespace CppSharp
                     [DllImport("CppSharp.CppParser", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
                         EntryPoint="_ZN8CppSharp9CppParser3AST11LayoutFieldD2Ev")]
                     internal static extern void dtor_0(global::System.IntPtr instance);
-
-                    [SuppressUnmanagedCodeSecurity]
-                    [DllImport("CppSharp.CppParser", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
-                        EntryPoint="_ZN8CppSharp9CppParser3AST11LayoutField7getNameEv")]
-                    internal static extern global::System.IntPtr GetName(global::System.IntPtr instance);
-
-                    [SuppressUnmanagedCodeSecurity]
-                    [DllImport("CppSharp.CppParser", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
-                        EntryPoint="_ZN8CppSharp9CppParser3AST11LayoutField7setNameEPKc")]
-                    internal static extern void SetName(global::System.IntPtr instance, [MarshalAs(UnmanagedType.LPStr)] string s);
                 }
 
                 public global::System.IntPtr __Instance { get; protected set; }
@@ -3684,6 +3665,21 @@ namespace CppSharp
                     }
                 }
 
+                public string Name
+                {
+                    get
+                    {
+                        return global::Std.BasicString.__CreateInstance(((global::CppSharp.Parser.AST.LayoutField.__Internal*) __Instance)->name).CStr();
+                    }
+
+                    set
+                    {
+                        var __allocator0 = new global::Std.Allocator();
+                        var __basicString0 = new global::Std.BasicString(value, __allocator0);
+                        ((global::CppSharp.Parser.AST.LayoutField.__Internal*) __Instance)->name = *(global::Std.BasicString.__Internal*) __basicString0.__Instance;
+                    }
+                }
+
                 public global::CppSharp.Parser.AST.QualifiedType QualifiedType
                 {
                     get
@@ -3707,20 +3703,6 @@ namespace CppSharp
                     set
                     {
                         ((global::CppSharp.Parser.AST.LayoutField.__Internal*) __Instance)->fieldPtr = (global::System.IntPtr) value;
-                    }
-                }
-
-                public string Name
-                {
-                    get
-                    {
-                        var __ret = __Internal.GetName((__Instance + __PointerAdjustment));
-                        return Marshal.PtrToStringAnsi(__ret);
-                    }
-
-                    set
-                    {
-                        __Internal.SetName((__Instance + __PointerAdjustment), value);
                     }
                 }
             }
@@ -4250,13 +4232,13 @@ namespace CppSharp
                     internal int lineNumberEnd;
 
                     [FieldOffset(32)]
-                    internal global::Std.BasicString.__Internal Name;
+                    internal global::Std.BasicString.__Internal name;
 
                     [FieldOffset(40)]
                     internal global::Std.BasicString.__Internal USR;
 
                     [FieldOffset(48)]
-                    internal global::Std.BasicString.__Internal DebugText;
+                    internal global::Std.BasicString.__Internal debugText;
 
                     [FieldOffset(56)]
                     internal byte isIncomplete;
@@ -4329,36 +4311,6 @@ namespace CppSharp
                     [DllImport("CppSharp.CppParser", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
                         EntryPoint="_ZN8CppSharp9CppParser3AST11Declaration19clearRedeclarationsEv")]
                     internal static extern void ClearRedeclarations_0(global::System.IntPtr instance);
-
-                    [SuppressUnmanagedCodeSecurity]
-                    [DllImport("CppSharp.CppParser", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
-                        EntryPoint="_ZN8CppSharp9CppParser3AST11Declaration7getNameEv")]
-                    internal static extern global::System.IntPtr GetName(global::System.IntPtr instance);
-
-                    [SuppressUnmanagedCodeSecurity]
-                    [DllImport("CppSharp.CppParser", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
-                        EntryPoint="_ZN8CppSharp9CppParser3AST11Declaration7setNameEPKc")]
-                    internal static extern void SetName(global::System.IntPtr instance, [MarshalAs(UnmanagedType.LPStr)] string s);
-
-                    [SuppressUnmanagedCodeSecurity]
-                    [DllImport("CppSharp.CppParser", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
-                        EntryPoint="_ZN8CppSharp9CppParser3AST11Declaration6getUSREv")]
-                    internal static extern global::System.IntPtr GetUSR(global::System.IntPtr instance);
-
-                    [SuppressUnmanagedCodeSecurity]
-                    [DllImport("CppSharp.CppParser", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
-                        EntryPoint="_ZN8CppSharp9CppParser3AST11Declaration6setUSREPKc")]
-                    internal static extern void SetUSR(global::System.IntPtr instance, [MarshalAs(UnmanagedType.LPStr)] string s);
-
-                    [SuppressUnmanagedCodeSecurity]
-                    [DllImport("CppSharp.CppParser", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
-                        EntryPoint="_ZN8CppSharp9CppParser3AST11Declaration12getDebugTextEv")]
-                    internal static extern global::System.IntPtr GetDebugText(global::System.IntPtr instance);
-
-                    [SuppressUnmanagedCodeSecurity]
-                    [DllImport("CppSharp.CppParser", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
-                        EntryPoint="_ZN8CppSharp9CppParser3AST11Declaration12setDebugTextEPKc")]
-                    internal static extern void SetDebugText(global::System.IntPtr instance, [MarshalAs(UnmanagedType.LPStr)] string s);
 
                     [SuppressUnmanagedCodeSecurity]
                     [DllImport("CppSharp.CppParser", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
@@ -4583,6 +4535,51 @@ namespace CppSharp
                     }
                 }
 
+                public string Name
+                {
+                    get
+                    {
+                        return global::Std.BasicString.__CreateInstance(((global::CppSharp.Parser.AST.Declaration.__Internal*) __Instance)->name).CStr();
+                    }
+
+                    set
+                    {
+                        var __allocator0 = new global::Std.Allocator();
+                        var __basicString0 = new global::Std.BasicString(value, __allocator0);
+                        ((global::CppSharp.Parser.AST.Declaration.__Internal*) __Instance)->name = *(global::Std.BasicString.__Internal*) __basicString0.__Instance;
+                    }
+                }
+
+                public string USR
+                {
+                    get
+                    {
+                        return global::Std.BasicString.__CreateInstance(((global::CppSharp.Parser.AST.Declaration.__Internal*) __Instance)->USR).CStr();
+                    }
+
+                    set
+                    {
+                        var __allocator0 = new global::Std.Allocator();
+                        var __basicString0 = new global::Std.BasicString(value, __allocator0);
+                        ((global::CppSharp.Parser.AST.Declaration.__Internal*) __Instance)->USR = *(global::Std.BasicString.__Internal*) __basicString0.__Instance;
+                    }
+                }
+
+                public string DebugText
+                {
+                    get
+                    {
+                        return global::Std.BasicString.__CreateInstance(((global::CppSharp.Parser.AST.Declaration.__Internal*) __Instance)->debugText).CStr();
+                    }
+
+                    set
+                    {
+                        var __allocator0 = new global::Std.Allocator();
+                        var __basicString0 = new global::Std.BasicString(value, __allocator0);
+                        ((global::CppSharp.Parser.AST.Declaration.__Internal*) __Instance)->debugText = *(global::Std.BasicString.__Internal*) __basicString0.__Instance;
+                    }
+                }
+
                 public bool IsIncomplete
                 {
                     get
@@ -4684,48 +4681,6 @@ namespace CppSharp
                     }
                 }
 
-                public string Name
-                {
-                    get
-                    {
-                        var __ret = __Internal.GetName((__Instance + __PointerAdjustment));
-                        return Marshal.PtrToStringAnsi(__ret);
-                    }
-
-                    set
-                    {
-                        __Internal.SetName((__Instance + __PointerAdjustment), value);
-                    }
-                }
-
-                public string USR
-                {
-                    get
-                    {
-                        var __ret = __Internal.GetUSR((__Instance + __PointerAdjustment));
-                        return Marshal.PtrToStringAnsi(__ret);
-                    }
-
-                    set
-                    {
-                        __Internal.SetUSR((__Instance + __PointerAdjustment), value);
-                    }
-                }
-
-                public string DebugText
-                {
-                    get
-                    {
-                        var __ret = __Internal.GetDebugText((__Instance + __PointerAdjustment));
-                        return Marshal.PtrToStringAnsi(__ret);
-                    }
-
-                    set
-                    {
-                        __Internal.SetDebugText((__Instance + __PointerAdjustment), value);
-                    }
-                }
-
                 public uint PreprocessedEntitiesCount
                 {
                     get
@@ -4769,13 +4724,13 @@ namespace CppSharp
                     internal int lineNumberEnd;
 
                     [FieldOffset(32)]
-                    internal global::Std.BasicString.__Internal Name;
+                    internal global::Std.BasicString.__Internal name;
 
                     [FieldOffset(40)]
                     internal global::Std.BasicString.__Internal USR;
 
                     [FieldOffset(48)]
-                    internal global::Std.BasicString.__Internal DebugText;
+                    internal global::Std.BasicString.__Internal debugText;
 
                     [FieldOffset(56)]
                     internal byte isIncomplete;
@@ -5440,13 +5395,13 @@ namespace CppSharp
                     internal int lineNumberEnd;
 
                     [FieldOffset(32)]
-                    internal global::Std.BasicString.__Internal Name;
+                    internal global::Std.BasicString.__Internal name;
 
                     [FieldOffset(40)]
                     internal global::Std.BasicString.__Internal USR;
 
                     [FieldOffset(48)]
-                    internal global::Std.BasicString.__Internal DebugText;
+                    internal global::Std.BasicString.__Internal debugText;
 
                     [FieldOffset(56)]
                     internal byte isIncomplete;
@@ -5604,13 +5559,13 @@ namespace CppSharp
                     internal int lineNumberEnd;
 
                     [FieldOffset(32)]
-                    internal global::Std.BasicString.__Internal Name;
+                    internal global::Std.BasicString.__Internal name;
 
                     [FieldOffset(40)]
                     internal global::Std.BasicString.__Internal USR;
 
                     [FieldOffset(48)]
-                    internal global::Std.BasicString.__Internal DebugText;
+                    internal global::Std.BasicString.__Internal debugText;
 
                     [FieldOffset(56)]
                     internal byte isIncomplete;
@@ -5750,13 +5705,13 @@ namespace CppSharp
                     internal int lineNumberEnd;
 
                     [FieldOffset(32)]
-                    internal global::Std.BasicString.__Internal Name;
+                    internal global::Std.BasicString.__Internal name;
 
                     [FieldOffset(40)]
                     internal global::Std.BasicString.__Internal USR;
 
                     [FieldOffset(48)]
-                    internal global::Std.BasicString.__Internal DebugText;
+                    internal global::Std.BasicString.__Internal debugText;
 
                     [FieldOffset(56)]
                     internal byte isIncomplete;
@@ -5917,13 +5872,13 @@ namespace CppSharp
                     internal int lineNumberEnd;
 
                     [FieldOffset(32)]
-                    internal global::Std.BasicString.__Internal Name;
+                    internal global::Std.BasicString.__Internal name;
 
                     [FieldOffset(40)]
                     internal global::Std.BasicString.__Internal USR;
 
                     [FieldOffset(48)]
-                    internal global::Std.BasicString.__Internal DebugText;
+                    internal global::Std.BasicString.__Internal debugText;
 
                     [FieldOffset(56)]
                     internal byte isIncomplete;
@@ -6069,27 +6024,22 @@ namespace CppSharp
                     internal global::System.IntPtr decl;
 
                     [FieldOffset(16)]
-                    internal global::Std.BasicString.__Internal String;
+                    internal global::Std.BasicString.__Internal @string;
+
+                    [SuppressUnmanagedCodeSecurity]
+                    [DllImport("CppSharp.CppParser", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
+                        EntryPoint="_ZN8CppSharp9CppParser3AST9StatementC2ERKSsNS1_14StatementClassEPNS1_11DeclarationE")]
+                    internal static extern void ctor_0(global::System.IntPtr instance, global::System.IntPtr str, global::CppSharp.Parser.AST.StatementClass Class, global::System.IntPtr decl);
 
                     [SuppressUnmanagedCodeSecurity]
                     [DllImport("CppSharp.CppParser", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
                         EntryPoint="_ZN8CppSharp9CppParser3AST9StatementC2ERKS2_")]
-                    internal static extern void cctor_0(global::System.IntPtr instance, global::System.IntPtr _0);
+                    internal static extern void cctor_1(global::System.IntPtr instance, global::System.IntPtr _0);
 
                     [SuppressUnmanagedCodeSecurity]
                     [DllImport("CppSharp.CppParser", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
                         EntryPoint="_ZN8CppSharp9CppParser3AST9StatementD2Ev")]
                     internal static extern void dtor_0(global::System.IntPtr instance);
-
-                    [SuppressUnmanagedCodeSecurity]
-                    [DllImport("CppSharp.CppParser", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
-                        EntryPoint="_ZN8CppSharp9CppParser3AST9Statement9getStringEv")]
-                    internal static extern global::System.IntPtr GetString(global::System.IntPtr instance);
-
-                    [SuppressUnmanagedCodeSecurity]
-                    [DllImport("CppSharp.CppParser", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
-                        EntryPoint="_ZN8CppSharp9CppParser3AST9Statement9setStringEPKc")]
-                    internal static extern void SetString(global::System.IntPtr instance, [MarshalAs(UnmanagedType.LPStr)] string s);
                 }
 
                 public global::System.IntPtr __Instance { get; protected set; }
@@ -6113,7 +6063,7 @@ namespace CppSharp
                 private static void* __CopyValue(global::CppSharp.Parser.AST.Statement.__Internal native)
                 {
                     var ret = Marshal.AllocHGlobal(sizeof(global::CppSharp.Parser.AST.Statement.__Internal));
-                    global::CppSharp.Parser.AST.Statement.__Internal.cctor_0(ret, new global::System.IntPtr(&native));
+                    global::CppSharp.Parser.AST.Statement.__Internal.cctor_1(ret, new global::System.IntPtr(&native));
                     return ret.ToPointer();
                 }
 
@@ -6131,6 +6081,20 @@ namespace CppSharp
                     __Instance = new global::System.IntPtr(native);
                 }
 
+                public Statement(string str, global::CppSharp.Parser.AST.StatementClass Class, global::CppSharp.Parser.AST.Declaration decl)
+                {
+                    __Instance = Marshal.AllocHGlobal(sizeof(global::CppSharp.Parser.AST.Statement.__Internal));
+                    __ownsNativeInstance = true;
+                    NativeToManagedMap[__Instance] = this;
+                    var __allocator0 = new global::Std.Allocator();
+                    var __basicString0 = new global::Std.BasicString(str, __allocator0);
+                    var __arg0 = __basicString0.__Instance;
+                    var __arg2 = ReferenceEquals(decl, null) ? global::System.IntPtr.Zero : decl.__Instance;
+                    __Internal.ctor_0((__Instance + __PointerAdjustment), __arg0, Class, __arg2);
+                    __basicString0.Dispose(false);
+                    __allocator0.Dispose();
+                }
+
                 public Statement(global::CppSharp.Parser.AST.Statement _0)
                 {
                     __Instance = Marshal.AllocHGlobal(sizeof(global::CppSharp.Parser.AST.Statement.__Internal));
@@ -6139,7 +6103,7 @@ namespace CppSharp
                     if (ReferenceEquals(_0, null))
                         throw new global::System.ArgumentNullException("_0", "Cannot be null because it is a C++ reference (&).");
                     var __arg0 = _0.__Instance;
-                    __Internal.cctor_0((__Instance + __PointerAdjustment), __arg0);
+                    __Internal.cctor_1((__Instance + __PointerAdjustment), __arg0);
                 }
 
                 public void Dispose()
@@ -6195,13 +6159,14 @@ namespace CppSharp
                 {
                     get
                     {
-                        var __ret = __Internal.GetString((__Instance + __PointerAdjustment));
-                        return Marshal.PtrToStringAnsi(__ret);
+                        return global::Std.BasicString.__CreateInstance(((global::CppSharp.Parser.AST.Statement.__Internal*) __Instance)->@string).CStr();
                     }
 
                     set
                     {
-                        __Internal.SetString((__Instance + __PointerAdjustment), value);
+                        var __allocator0 = new global::Std.Allocator();
+                        var __basicString0 = new global::Std.BasicString(value, __allocator0);
+                        ((global::CppSharp.Parser.AST.Statement.__Internal*) __Instance)->@string = *(global::Std.BasicString.__Internal*) __basicString0.__Instance;
                     }
                 }
             }
@@ -6218,12 +6183,17 @@ namespace CppSharp
                     internal global::System.IntPtr decl;
 
                     [FieldOffset(16)]
-                    internal global::Std.BasicString.__Internal String;
+                    internal global::Std.BasicString.__Internal @string;
+
+                    [SuppressUnmanagedCodeSecurity]
+                    [DllImport("CppSharp.CppParser", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
+                        EntryPoint="_ZN8CppSharp9CppParser3AST10ExpressionC2ERKSsNS1_14StatementClassEPNS1_11DeclarationE")]
+                    internal static extern void ctor_0(global::System.IntPtr instance, global::System.IntPtr str, global::CppSharp.Parser.AST.StatementClass Class, global::System.IntPtr decl);
 
                     [SuppressUnmanagedCodeSecurity]
                     [DllImport("CppSharp.CppParser", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
                         EntryPoint="_ZN8CppSharp9CppParser3AST10ExpressionC2ERKS2_")]
-                    internal static extern void cctor_0(global::System.IntPtr instance, global::System.IntPtr _0);
+                    internal static extern void cctor_1(global::System.IntPtr instance, global::System.IntPtr _0);
 
                     [SuppressUnmanagedCodeSecurity]
                     [DllImport("CppSharp.CppParser", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
@@ -6244,7 +6214,7 @@ namespace CppSharp
                 private static void* __CopyValue(global::CppSharp.Parser.AST.Expression.__Internal native)
                 {
                     var ret = Marshal.AllocHGlobal(sizeof(global::CppSharp.Parser.AST.Expression.__Internal));
-                    global::CppSharp.Parser.AST.Expression.__Internal.cctor_0(ret, new global::System.IntPtr(&native));
+                    global::CppSharp.Parser.AST.Expression.__Internal.cctor_1(ret, new global::System.IntPtr(&native));
                     return ret.ToPointer();
                 }
 
@@ -6264,6 +6234,21 @@ namespace CppSharp
                     __Instance = new global::System.IntPtr(native);
                 }
 
+                public Expression(string str, global::CppSharp.Parser.AST.StatementClass Class, global::CppSharp.Parser.AST.Declaration decl)
+                    : this((void*) null)
+                {
+                    __Instance = Marshal.AllocHGlobal(sizeof(global::CppSharp.Parser.AST.Expression.__Internal));
+                    __ownsNativeInstance = true;
+                    NativeToManagedMap[__Instance] = this;
+                    var __allocator0 = new global::Std.Allocator();
+                    var __basicString0 = new global::Std.BasicString(str, __allocator0);
+                    var __arg0 = __basicString0.__Instance;
+                    var __arg2 = ReferenceEquals(decl, null) ? global::System.IntPtr.Zero : decl.__Instance;
+                    __Internal.ctor_0((__Instance + __PointerAdjustment), __arg0, Class, __arg2);
+                    __basicString0.Dispose(false);
+                    __allocator0.Dispose();
+                }
+
                 public Expression(global::CppSharp.Parser.AST.Expression _0)
                     : this((void*) null)
                 {
@@ -6273,7 +6258,7 @@ namespace CppSharp
                     if (ReferenceEquals(_0, null))
                         throw new global::System.ArgumentNullException("_0", "Cannot be null because it is a C++ reference (&).");
                     var __arg0 = _0.__Instance;
-                    __Internal.cctor_0((__Instance + __PointerAdjustment), __arg0);
+                    __Internal.cctor_1((__Instance + __PointerAdjustment), __arg0);
                 }
 
                 public override void Dispose(bool disposing)
@@ -6302,7 +6287,7 @@ namespace CppSharp
                     internal global::System.IntPtr decl;
 
                     [FieldOffset(16)]
-                    internal global::Std.BasicString.__Internal String;
+                    internal global::Std.BasicString.__Internal @string;
 
                     [FieldOffset(24)]
                     internal global::System.IntPtr LHS;
@@ -6311,27 +6296,22 @@ namespace CppSharp
                     internal global::System.IntPtr RHS;
 
                     [FieldOffset(40)]
-                    internal global::Std.BasicString.__Internal OpcodeStr;
+                    internal global::Std.BasicString.__Internal opcodeStr;
+
+                    [SuppressUnmanagedCodeSecurity]
+                    [DllImport("CppSharp.CppParser", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
+                        EntryPoint="_ZN8CppSharp9CppParser3AST14BinaryOperatorC2ERKSsPNS1_10ExpressionES6_S4_")]
+                    internal static extern void ctor_0(global::System.IntPtr instance, global::System.IntPtr str, global::System.IntPtr lhs, global::System.IntPtr rhs, global::System.IntPtr opcodeStr);
 
                     [SuppressUnmanagedCodeSecurity]
                     [DllImport("CppSharp.CppParser", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
                         EntryPoint="_ZN8CppSharp9CppParser3AST14BinaryOperatorC2ERKS2_")]
-                    internal static extern void cctor_0(global::System.IntPtr instance, global::System.IntPtr _0);
+                    internal static extern void cctor_1(global::System.IntPtr instance, global::System.IntPtr _0);
 
                     [SuppressUnmanagedCodeSecurity]
                     [DllImport("CppSharp.CppParser", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
                         EntryPoint="_ZN8CppSharp9CppParser3AST14BinaryOperatorD2Ev")]
                     internal static extern void dtor_0(global::System.IntPtr instance);
-
-                    [SuppressUnmanagedCodeSecurity]
-                    [DllImport("CppSharp.CppParser", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
-                        EntryPoint="_ZN8CppSharp9CppParser3AST14BinaryOperator12getOpcodeStrEv")]
-                    internal static extern global::System.IntPtr GetOpcodeStr(global::System.IntPtr instance);
-
-                    [SuppressUnmanagedCodeSecurity]
-                    [DllImport("CppSharp.CppParser", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
-                        EntryPoint="_ZN8CppSharp9CppParser3AST14BinaryOperator12setOpcodeStrEPKc")]
-                    internal static extern void SetOpcodeStr(global::System.IntPtr instance, [MarshalAs(UnmanagedType.LPStr)] string s);
                 }
 
                 internal static new global::CppSharp.Parser.AST.BinaryOperator __CreateInstance(global::System.IntPtr native, bool skipVTables = false)
@@ -6347,7 +6327,7 @@ namespace CppSharp
                 private static void* __CopyValue(global::CppSharp.Parser.AST.BinaryOperator.__Internal native)
                 {
                     var ret = Marshal.AllocHGlobal(sizeof(global::CppSharp.Parser.AST.BinaryOperator.__Internal));
-                    global::CppSharp.Parser.AST.BinaryOperator.__Internal.cctor_0(ret, new global::System.IntPtr(&native));
+                    global::CppSharp.Parser.AST.BinaryOperator.__Internal.cctor_1(ret, new global::System.IntPtr(&native));
                     return ret.ToPointer();
                 }
 
@@ -6367,6 +6347,27 @@ namespace CppSharp
                     __Instance = new global::System.IntPtr(native);
                 }
 
+                public BinaryOperator(string str, global::CppSharp.Parser.AST.Expression lhs, global::CppSharp.Parser.AST.Expression rhs, string opcodeStr)
+                    : this((void*) null)
+                {
+                    __Instance = Marshal.AllocHGlobal(sizeof(global::CppSharp.Parser.AST.BinaryOperator.__Internal));
+                    __ownsNativeInstance = true;
+                    NativeToManagedMap[__Instance] = this;
+                    var __allocator0 = new global::Std.Allocator();
+                    var __basicString0 = new global::Std.BasicString(str, __allocator0);
+                    var __arg0 = __basicString0.__Instance;
+                    var __arg1 = ReferenceEquals(lhs, null) ? global::System.IntPtr.Zero : lhs.__Instance;
+                    var __arg2 = ReferenceEquals(rhs, null) ? global::System.IntPtr.Zero : rhs.__Instance;
+                    var __allocator3 = new global::Std.Allocator();
+                    var __basicString3 = new global::Std.BasicString(opcodeStr, __allocator3);
+                    var __arg3 = __basicString3.__Instance;
+                    __Internal.ctor_0((__Instance + __PointerAdjustment), __arg0, __arg1, __arg2, __arg3);
+                    __basicString0.Dispose(false);
+                    __allocator0.Dispose();
+                    __basicString3.Dispose(false);
+                    __allocator3.Dispose();
+                }
+
                 public BinaryOperator(global::CppSharp.Parser.AST.BinaryOperator _0)
                     : this((void*) null)
                 {
@@ -6376,7 +6377,7 @@ namespace CppSharp
                     if (ReferenceEquals(_0, null))
                         throw new global::System.ArgumentNullException("_0", "Cannot be null because it is a C++ reference (&).");
                     var __arg0 = _0.__Instance;
-                    __Internal.cctor_0((__Instance + __PointerAdjustment), __arg0);
+                    __Internal.cctor_1((__Instance + __PointerAdjustment), __arg0);
                 }
 
                 public override void Dispose(bool disposing)
@@ -6432,13 +6433,14 @@ namespace CppSharp
                 {
                     get
                     {
-                        var __ret = __Internal.GetOpcodeStr((__Instance + __PointerAdjustment));
-                        return Marshal.PtrToStringAnsi(__ret);
+                        return global::Std.BasicString.__CreateInstance(((global::CppSharp.Parser.AST.BinaryOperator.__Internal*) __Instance)->opcodeStr).CStr();
                     }
 
                     set
                     {
-                        __Internal.SetOpcodeStr((__Instance + __PointerAdjustment), value);
+                        var __allocator0 = new global::Std.Allocator();
+                        var __basicString0 = new global::Std.BasicString(value, __allocator0);
+                        ((global::CppSharp.Parser.AST.BinaryOperator.__Internal*) __Instance)->opcodeStr = *(global::Std.BasicString.__Internal*) __basicString0.__Instance;
                     }
                 }
             }
@@ -6455,15 +6457,20 @@ namespace CppSharp
                     internal global::System.IntPtr decl;
 
                     [FieldOffset(16)]
-                    internal global::Std.BasicString.__Internal String;
+                    internal global::Std.BasicString.__Internal @string;
 
                     [FieldOffset(24)]
                     internal global::Std.Vector.__Internal Arguments;
 
                     [SuppressUnmanagedCodeSecurity]
                     [DllImport("CppSharp.CppParser", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
+                        EntryPoint="_ZN8CppSharp9CppParser3AST8CallExprC2ERKSsPNS1_11DeclarationE")]
+                    internal static extern void ctor_0(global::System.IntPtr instance, global::System.IntPtr str, global::System.IntPtr decl);
+
+                    [SuppressUnmanagedCodeSecurity]
+                    [DllImport("CppSharp.CppParser", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
                         EntryPoint="_ZN8CppSharp9CppParser3AST8CallExprC2ERKS2_")]
-                    internal static extern void cctor_0(global::System.IntPtr instance, global::System.IntPtr _0);
+                    internal static extern void cctor_1(global::System.IntPtr instance, global::System.IntPtr _0);
 
                     [SuppressUnmanagedCodeSecurity]
                     [DllImport("CppSharp.CppParser", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
@@ -6504,7 +6511,7 @@ namespace CppSharp
                 private static void* __CopyValue(global::CppSharp.Parser.AST.CallExpr.__Internal native)
                 {
                     var ret = Marshal.AllocHGlobal(sizeof(global::CppSharp.Parser.AST.CallExpr.__Internal));
-                    global::CppSharp.Parser.AST.CallExpr.__Internal.cctor_0(ret, new global::System.IntPtr(&native));
+                    global::CppSharp.Parser.AST.CallExpr.__Internal.cctor_1(ret, new global::System.IntPtr(&native));
                     return ret.ToPointer();
                 }
 
@@ -6524,6 +6531,21 @@ namespace CppSharp
                     __Instance = new global::System.IntPtr(native);
                 }
 
+                public CallExpr(string str, global::CppSharp.Parser.AST.Declaration decl)
+                    : this((void*) null)
+                {
+                    __Instance = Marshal.AllocHGlobal(sizeof(global::CppSharp.Parser.AST.CallExpr.__Internal));
+                    __ownsNativeInstance = true;
+                    NativeToManagedMap[__Instance] = this;
+                    var __allocator0 = new global::Std.Allocator();
+                    var __basicString0 = new global::Std.BasicString(str, __allocator0);
+                    var __arg0 = __basicString0.__Instance;
+                    var __arg1 = ReferenceEquals(decl, null) ? global::System.IntPtr.Zero : decl.__Instance;
+                    __Internal.ctor_0((__Instance + __PointerAdjustment), __arg0, __arg1);
+                    __basicString0.Dispose(false);
+                    __allocator0.Dispose();
+                }
+
                 public CallExpr(global::CppSharp.Parser.AST.CallExpr _0)
                     : this((void*) null)
                 {
@@ -6533,7 +6555,7 @@ namespace CppSharp
                     if (ReferenceEquals(_0, null))
                         throw new global::System.ArgumentNullException("_0", "Cannot be null because it is a C++ reference (&).");
                     var __arg0 = _0.__Instance;
-                    __Internal.cctor_0((__Instance + __PointerAdjustment), __arg0);
+                    __Internal.cctor_1((__Instance + __PointerAdjustment), __arg0);
                 }
 
                 public override void Dispose(bool disposing)
@@ -6595,15 +6617,20 @@ namespace CppSharp
                     internal global::System.IntPtr decl;
 
                     [FieldOffset(16)]
-                    internal global::Std.BasicString.__Internal String;
+                    internal global::Std.BasicString.__Internal @string;
 
                     [FieldOffset(24)]
                     internal global::Std.Vector.__Internal Arguments;
 
                     [SuppressUnmanagedCodeSecurity]
                     [DllImport("CppSharp.CppParser", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
+                        EntryPoint="_ZN8CppSharp9CppParser3AST16CXXConstructExprC2ERKSsPNS1_11DeclarationE")]
+                    internal static extern void ctor_0(global::System.IntPtr instance, global::System.IntPtr str, global::System.IntPtr decl);
+
+                    [SuppressUnmanagedCodeSecurity]
+                    [DllImport("CppSharp.CppParser", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
                         EntryPoint="_ZN8CppSharp9CppParser3AST16CXXConstructExprC2ERKS2_")]
-                    internal static extern void cctor_0(global::System.IntPtr instance, global::System.IntPtr _0);
+                    internal static extern void cctor_1(global::System.IntPtr instance, global::System.IntPtr _0);
 
                     [SuppressUnmanagedCodeSecurity]
                     [DllImport("CppSharp.CppParser", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
@@ -6644,7 +6671,7 @@ namespace CppSharp
                 private static void* __CopyValue(global::CppSharp.Parser.AST.CXXConstructExpr.__Internal native)
                 {
                     var ret = Marshal.AllocHGlobal(sizeof(global::CppSharp.Parser.AST.CXXConstructExpr.__Internal));
-                    global::CppSharp.Parser.AST.CXXConstructExpr.__Internal.cctor_0(ret, new global::System.IntPtr(&native));
+                    global::CppSharp.Parser.AST.CXXConstructExpr.__Internal.cctor_1(ret, new global::System.IntPtr(&native));
                     return ret.ToPointer();
                 }
 
@@ -6664,6 +6691,21 @@ namespace CppSharp
                     __Instance = new global::System.IntPtr(native);
                 }
 
+                public CXXConstructExpr(string str, global::CppSharp.Parser.AST.Declaration decl)
+                    : this((void*) null)
+                {
+                    __Instance = Marshal.AllocHGlobal(sizeof(global::CppSharp.Parser.AST.CXXConstructExpr.__Internal));
+                    __ownsNativeInstance = true;
+                    NativeToManagedMap[__Instance] = this;
+                    var __allocator0 = new global::Std.Allocator();
+                    var __basicString0 = new global::Std.BasicString(str, __allocator0);
+                    var __arg0 = __basicString0.__Instance;
+                    var __arg1 = ReferenceEquals(decl, null) ? global::System.IntPtr.Zero : decl.__Instance;
+                    __Internal.ctor_0((__Instance + __PointerAdjustment), __arg0, __arg1);
+                    __basicString0.Dispose(false);
+                    __allocator0.Dispose();
+                }
+
                 public CXXConstructExpr(global::CppSharp.Parser.AST.CXXConstructExpr _0)
                     : this((void*) null)
                 {
@@ -6673,7 +6715,7 @@ namespace CppSharp
                     if (ReferenceEquals(_0, null))
                         throw new global::System.ArgumentNullException("_0", "Cannot be null because it is a C++ reference (&).");
                     var __arg0 = _0.__Instance;
-                    __Internal.cctor_0((__Instance + __PointerAdjustment), __arg0);
+                    __Internal.cctor_1((__Instance + __PointerAdjustment), __arg0);
                 }
 
                 public override void Dispose(bool disposing)
@@ -6747,13 +6789,13 @@ namespace CppSharp
                     internal int lineNumberEnd;
 
                     [FieldOffset(32)]
-                    internal global::Std.BasicString.__Internal Name;
+                    internal global::Std.BasicString.__Internal name;
 
                     [FieldOffset(40)]
                     internal global::Std.BasicString.__Internal USR;
 
                     [FieldOffset(48)]
-                    internal global::Std.BasicString.__Internal DebugText;
+                    internal global::Std.BasicString.__Internal debugText;
 
                     [FieldOffset(56)]
                     internal byte isIncomplete;
@@ -6975,13 +7017,13 @@ namespace CppSharp
                     internal int lineNumberEnd;
 
                     [FieldOffset(32)]
-                    internal global::Std.BasicString.__Internal Name;
+                    internal global::Std.BasicString.__Internal name;
 
                     [FieldOffset(40)]
                     internal global::Std.BasicString.__Internal USR;
 
                     [FieldOffset(48)]
-                    internal global::Std.BasicString.__Internal DebugText;
+                    internal global::Std.BasicString.__Internal debugText;
 
                     [FieldOffset(56)]
                     internal byte isIncomplete;
@@ -7041,13 +7083,13 @@ namespace CppSharp
                     internal global::CppSharp.Parser.AST.CXXOperatorKind operatorKind;
 
                     [FieldOffset(176)]
-                    internal global::Std.BasicString.__Internal Mangled;
+                    internal global::Std.BasicString.__Internal mangled;
 
                     [FieldOffset(184)]
-                    internal global::Std.BasicString.__Internal Signature;
+                    internal global::Std.BasicString.__Internal signature;
 
                     [FieldOffset(192)]
-                    internal global::Std.BasicString.__Internal Body;
+                    internal global::Std.BasicString.__Internal body;
 
                     [FieldOffset(200)]
                     internal global::CppSharp.Parser.AST.CallingConvention callingConvention;
@@ -7093,36 +7135,6 @@ namespace CppSharp
                     [DllImport("CppSharp.CppParser", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
                         EntryPoint="_ZN8CppSharp9CppParser3AST8Function15clearParametersEv")]
                     internal static extern void ClearParameters_0(global::System.IntPtr instance);
-
-                    [SuppressUnmanagedCodeSecurity]
-                    [DllImport("CppSharp.CppParser", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
-                        EntryPoint="_ZN8CppSharp9CppParser3AST8Function10getMangledEv")]
-                    internal static extern global::System.IntPtr GetMangled(global::System.IntPtr instance);
-
-                    [SuppressUnmanagedCodeSecurity]
-                    [DllImport("CppSharp.CppParser", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
-                        EntryPoint="_ZN8CppSharp9CppParser3AST8Function10setMangledEPKc")]
-                    internal static extern void SetMangled(global::System.IntPtr instance, [MarshalAs(UnmanagedType.LPStr)] string s);
-
-                    [SuppressUnmanagedCodeSecurity]
-                    [DllImport("CppSharp.CppParser", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
-                        EntryPoint="_ZN8CppSharp9CppParser3AST8Function12getSignatureEv")]
-                    internal static extern global::System.IntPtr GetSignature(global::System.IntPtr instance);
-
-                    [SuppressUnmanagedCodeSecurity]
-                    [DllImport("CppSharp.CppParser", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
-                        EntryPoint="_ZN8CppSharp9CppParser3AST8Function12setSignatureEPKc")]
-                    internal static extern void SetSignature(global::System.IntPtr instance, [MarshalAs(UnmanagedType.LPStr)] string s);
-
-                    [SuppressUnmanagedCodeSecurity]
-                    [DllImport("CppSharp.CppParser", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
-                        EntryPoint="_ZN8CppSharp9CppParser3AST8Function7getBodyEv")]
-                    internal static extern global::System.IntPtr GetBody(global::System.IntPtr instance);
-
-                    [SuppressUnmanagedCodeSecurity]
-                    [DllImport("CppSharp.CppParser", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
-                        EntryPoint="_ZN8CppSharp9CppParser3AST8Function7setBodyEPKc")]
-                    internal static extern void SetBody(global::System.IntPtr instance, [MarshalAs(UnmanagedType.LPStr)] string s);
 
                     [SuppressUnmanagedCodeSecurity]
                     [DllImport("CppSharp.CppParser", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
@@ -7351,6 +7363,51 @@ namespace CppSharp
                     }
                 }
 
+                public string Mangled
+                {
+                    get
+                    {
+                        return global::Std.BasicString.__CreateInstance(((global::CppSharp.Parser.AST.Function.__Internal*) __Instance)->mangled).CStr();
+                    }
+
+                    set
+                    {
+                        var __allocator0 = new global::Std.Allocator();
+                        var __basicString0 = new global::Std.BasicString(value, __allocator0);
+                        ((global::CppSharp.Parser.AST.Function.__Internal*) __Instance)->mangled = *(global::Std.BasicString.__Internal*) __basicString0.__Instance;
+                    }
+                }
+
+                public string Signature
+                {
+                    get
+                    {
+                        return global::Std.BasicString.__CreateInstance(((global::CppSharp.Parser.AST.Function.__Internal*) __Instance)->signature).CStr();
+                    }
+
+                    set
+                    {
+                        var __allocator0 = new global::Std.Allocator();
+                        var __basicString0 = new global::Std.BasicString(value, __allocator0);
+                        ((global::CppSharp.Parser.AST.Function.__Internal*) __Instance)->signature = *(global::Std.BasicString.__Internal*) __basicString0.__Instance;
+                    }
+                }
+
+                public string Body
+                {
+                    get
+                    {
+                        return global::Std.BasicString.__CreateInstance(((global::CppSharp.Parser.AST.Function.__Internal*) __Instance)->body).CStr();
+                    }
+
+                    set
+                    {
+                        var __allocator0 = new global::Std.Allocator();
+                        var __basicString0 = new global::Std.BasicString(value, __allocator0);
+                        ((global::CppSharp.Parser.AST.Function.__Internal*) __Instance)->body = *(global::Std.BasicString.__Internal*) __basicString0.__Instance;
+                    }
+                }
+
                 public global::CppSharp.Parser.AST.CallingConvention CallingConvention
                 {
                     get
@@ -7413,48 +7470,6 @@ namespace CppSharp
                     }
                 }
 
-                public string Mangled
-                {
-                    get
-                    {
-                        var __ret = __Internal.GetMangled((__Instance + __PointerAdjustment));
-                        return Marshal.PtrToStringAnsi(__ret);
-                    }
-
-                    set
-                    {
-                        __Internal.SetMangled((__Instance + __PointerAdjustment), value);
-                    }
-                }
-
-                public string Signature
-                {
-                    get
-                    {
-                        var __ret = __Internal.GetSignature((__Instance + __PointerAdjustment));
-                        return Marshal.PtrToStringAnsi(__ret);
-                    }
-
-                    set
-                    {
-                        __Internal.SetSignature((__Instance + __PointerAdjustment), value);
-                    }
-                }
-
-                public string Body
-                {
-                    get
-                    {
-                        var __ret = __Internal.GetBody((__Instance + __PointerAdjustment));
-                        return Marshal.PtrToStringAnsi(__ret);
-                    }
-
-                    set
-                    {
-                        __Internal.SetBody((__Instance + __PointerAdjustment), value);
-                    }
-                }
-
                 public uint ParametersCount
                 {
                     get
@@ -7489,13 +7504,13 @@ namespace CppSharp
                     internal int lineNumberEnd;
 
                     [FieldOffset(32)]
-                    internal global::Std.BasicString.__Internal Name;
+                    internal global::Std.BasicString.__Internal name;
 
                     [FieldOffset(40)]
                     internal global::Std.BasicString.__Internal USR;
 
                     [FieldOffset(48)]
-                    internal global::Std.BasicString.__Internal DebugText;
+                    internal global::Std.BasicString.__Internal debugText;
 
                     [FieldOffset(56)]
                     internal byte isIncomplete;
@@ -7555,13 +7570,13 @@ namespace CppSharp
                     internal global::CppSharp.Parser.AST.CXXOperatorKind operatorKind;
 
                     [FieldOffset(176)]
-                    internal global::Std.BasicString.__Internal Mangled;
+                    internal global::Std.BasicString.__Internal mangled;
 
                     [FieldOffset(184)]
-                    internal global::Std.BasicString.__Internal Signature;
+                    internal global::Std.BasicString.__Internal signature;
 
                     [FieldOffset(192)]
-                    internal global::Std.BasicString.__Internal Body;
+                    internal global::Std.BasicString.__Internal body;
 
                     [FieldOffset(200)]
                     internal global::CppSharp.Parser.AST.CallingConvention callingConvention;
@@ -7862,13 +7877,13 @@ namespace CppSharp
                     internal int lineNumberEnd;
 
                     [FieldOffset(32)]
-                    internal global::Std.BasicString.__Internal Name;
+                    internal global::Std.BasicString.__Internal name;
 
                     [FieldOffset(40)]
                     internal global::Std.BasicString.__Internal USR;
 
                     [FieldOffset(48)]
-                    internal global::Std.BasicString.__Internal DebugText;
+                    internal global::Std.BasicString.__Internal debugText;
 
                     [FieldOffset(56)]
                     internal byte isIncomplete;
@@ -7974,6 +7989,11 @@ namespace CppSharp
 
                     [SuppressUnmanagedCodeSecurity]
                     [DllImport("CppSharp.CppParser", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
+                        EntryPoint="_ZN8CppSharp9CppParser3AST11Enumeration14FindItemByNameERKSs")]
+                    internal static extern global::System.IntPtr FindItemByName_0(global::System.IntPtr instance, global::System.IntPtr Name);
+
+                    [SuppressUnmanagedCodeSecurity]
+                    [DllImport("CppSharp.CppParser", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
                         EntryPoint="_ZN8CppSharp9CppParser3AST11Enumeration13getItemsCountEv")]
                     internal static extern uint GetItemsCount(global::System.IntPtr instance);
                 }
@@ -8010,13 +8030,13 @@ namespace CppSharp
                         internal int lineNumberEnd;
 
                         [FieldOffset(32)]
-                        internal global::Std.BasicString.__Internal Name;
+                        internal global::Std.BasicString.__Internal name;
 
                         [FieldOffset(40)]
                         internal global::Std.BasicString.__Internal USR;
 
                         [FieldOffset(48)]
-                        internal global::Std.BasicString.__Internal DebugText;
+                        internal global::Std.BasicString.__Internal debugText;
 
                         [FieldOffset(56)]
                         internal byte isIncomplete;
@@ -8046,7 +8066,7 @@ namespace CppSharp
                         internal global::System.IntPtr comment;
 
                         [FieldOffset(144)]
-                        internal global::Std.BasicString.__Internal Expression;
+                        internal global::Std.BasicString.__Internal expression;
 
                         [FieldOffset(152)]
                         internal ulong value;
@@ -8065,16 +8085,6 @@ namespace CppSharp
                         [DllImport("CppSharp.CppParser", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
                             EntryPoint="_ZN8CppSharp9CppParser3AST11Enumeration4ItemD2Ev")]
                         internal static extern void dtor_0(global::System.IntPtr instance);
-
-                        [SuppressUnmanagedCodeSecurity]
-                        [DllImport("CppSharp.CppParser", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
-                            EntryPoint="_ZN8CppSharp9CppParser3AST11Enumeration4Item13getExpressionEv")]
-                        internal static extern global::System.IntPtr GetExpression(global::System.IntPtr instance);
-
-                        [SuppressUnmanagedCodeSecurity]
-                        [DllImport("CppSharp.CppParser", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
-                            EntryPoint="_ZN8CppSharp9CppParser3AST11Enumeration4Item13setExpressionEPKc")]
-                        internal static extern void SetExpression(global::System.IntPtr instance, [MarshalAs(UnmanagedType.LPStr)] string s);
                     }
 
                     internal static new global::CppSharp.Parser.AST.Enumeration.Item __CreateInstance(global::System.IntPtr native, bool skipVTables = false)
@@ -8144,6 +8154,21 @@ namespace CppSharp
                         __Instance = IntPtr.Zero;
                     }
 
+                    public string Expression
+                    {
+                        get
+                        {
+                            return global::Std.BasicString.__CreateInstance(((global::CppSharp.Parser.AST.Enumeration.Item.__Internal*) __Instance)->expression).CStr();
+                        }
+
+                        set
+                        {
+                            var __allocator0 = new global::Std.Allocator();
+                            var __basicString0 = new global::Std.BasicString(value, __allocator0);
+                            ((global::CppSharp.Parser.AST.Enumeration.Item.__Internal*) __Instance)->expression = *(global::Std.BasicString.__Internal*) __basicString0.__Instance;
+                        }
+                    }
+
                     public ulong Value
                     {
                         get
@@ -8154,20 +8179,6 @@ namespace CppSharp
                         set
                         {
                             ((global::CppSharp.Parser.AST.Enumeration.Item.__Internal*) __Instance)->value = value;
-                        }
-                    }
-
-                    public string Expression
-                    {
-                        get
-                        {
-                            var __ret = __Internal.GetExpression((__Instance + __PointerAdjustment));
-                            return Marshal.PtrToStringAnsi(__ret);
-                        }
-
-                        set
-                        {
-                            __Internal.SetExpression((__Instance + __PointerAdjustment), value);
                         }
                     }
                 }
@@ -8263,6 +8274,22 @@ namespace CppSharp
                     __Internal.ClearItems_0((__Instance + __PointerAdjustment));
                 }
 
+                public global::CppSharp.Parser.AST.Enumeration.Item FindItemByName(string Name)
+                {
+                    var __allocator0 = new global::Std.Allocator();
+                    var __basicString0 = new global::Std.BasicString(Name, __allocator0);
+                    var __arg0 = __basicString0.__Instance;
+                    var __ret = __Internal.FindItemByName_0((__Instance + __PointerAdjustment), __arg0);
+                    __basicString0.Dispose(false);
+                    __allocator0.Dispose();
+                    global::CppSharp.Parser.AST.Enumeration.Item __result0;
+                    if (__ret == IntPtr.Zero) __result0 = null;
+                    else if (global::CppSharp.Parser.AST.Enumeration.Item.NativeToManagedMap.ContainsKey(__ret))
+                        __result0 = (global::CppSharp.Parser.AST.Enumeration.Item) global::CppSharp.Parser.AST.Enumeration.Item.NativeToManagedMap[__ret];
+                    else __result0 = global::CppSharp.Parser.AST.Enumeration.Item.__CreateInstance(__ret);
+                    return __result0;
+                }
+
                 public global::CppSharp.Parser.AST.Enumeration.EnumModifiers Modifiers
                 {
                     get
@@ -8346,13 +8373,13 @@ namespace CppSharp
                     internal int lineNumberEnd;
 
                     [FieldOffset(32)]
-                    internal global::Std.BasicString.__Internal Name;
+                    internal global::Std.BasicString.__Internal name;
 
                     [FieldOffset(40)]
                     internal global::Std.BasicString.__Internal USR;
 
                     [FieldOffset(48)]
-                    internal global::Std.BasicString.__Internal DebugText;
+                    internal global::Std.BasicString.__Internal debugText;
 
                     [FieldOffset(56)]
                     internal byte isIncomplete;
@@ -8382,7 +8409,7 @@ namespace CppSharp
                     internal global::System.IntPtr comment;
 
                     [FieldOffset(144)]
-                    internal global::Std.BasicString.__Internal Mangled;
+                    internal global::Std.BasicString.__Internal mangled;
 
                     [FieldOffset(152)]
                     internal global::CppSharp.Parser.AST.QualifiedType.__Internal qualifiedType;
@@ -8401,16 +8428,6 @@ namespace CppSharp
                     [DllImport("CppSharp.CppParser", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
                         EntryPoint="_ZN8CppSharp9CppParser3AST8VariableD2Ev")]
                     internal static extern void dtor_0(global::System.IntPtr instance);
-
-                    [SuppressUnmanagedCodeSecurity]
-                    [DllImport("CppSharp.CppParser", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
-                        EntryPoint="_ZN8CppSharp9CppParser3AST8Variable10getMangledEv")]
-                    internal static extern global::System.IntPtr GetMangled(global::System.IntPtr instance);
-
-                    [SuppressUnmanagedCodeSecurity]
-                    [DllImport("CppSharp.CppParser", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
-                        EntryPoint="_ZN8CppSharp9CppParser3AST8Variable10setMangledEPKc")]
-                    internal static extern void SetMangled(global::System.IntPtr instance, [MarshalAs(UnmanagedType.LPStr)] string s);
                 }
 
                 internal static new global::CppSharp.Parser.AST.Variable __CreateInstance(global::System.IntPtr native, bool skipVTables = false)
@@ -8480,6 +8497,21 @@ namespace CppSharp
                     __Instance = IntPtr.Zero;
                 }
 
+                public string Mangled
+                {
+                    get
+                    {
+                        return global::Std.BasicString.__CreateInstance(((global::CppSharp.Parser.AST.Variable.__Internal*) __Instance)->mangled).CStr();
+                    }
+
+                    set
+                    {
+                        var __allocator0 = new global::Std.Allocator();
+                        var __basicString0 = new global::Std.BasicString(value, __allocator0);
+                        ((global::CppSharp.Parser.AST.Variable.__Internal*) __Instance)->mangled = *(global::Std.BasicString.__Internal*) __basicString0.__Instance;
+                    }
+                }
+
                 public global::CppSharp.Parser.AST.QualifiedType QualifiedType
                 {
                     get
@@ -8490,20 +8522,6 @@ namespace CppSharp
                     set
                     {
                         ((global::CppSharp.Parser.AST.Variable.__Internal*) __Instance)->qualifiedType = ReferenceEquals(value, null) ? new global::CppSharp.Parser.AST.QualifiedType.__Internal() : *(global::CppSharp.Parser.AST.QualifiedType.__Internal*) value.__Instance;
-                    }
-                }
-
-                public string Mangled
-                {
-                    get
-                    {
-                        var __ret = __Internal.GetMangled((__Instance + __PointerAdjustment));
-                        return Marshal.PtrToStringAnsi(__ret);
-                    }
-
-                    set
-                    {
-                        __Internal.SetMangled((__Instance + __PointerAdjustment), value);
                     }
                 }
             }
@@ -8689,13 +8707,13 @@ namespace CppSharp
                     internal int lineNumberEnd;
 
                     [FieldOffset(32)]
-                    internal global::Std.BasicString.__Internal Name;
+                    internal global::Std.BasicString.__Internal name;
 
                     [FieldOffset(40)]
                     internal global::Std.BasicString.__Internal USR;
 
                     [FieldOffset(48)]
-                    internal global::Std.BasicString.__Internal DebugText;
+                    internal global::Std.BasicString.__Internal debugText;
 
                     [FieldOffset(56)]
                     internal byte isIncomplete;
@@ -8901,13 +8919,13 @@ namespace CppSharp
                     internal int lineNumberEnd;
 
                     [FieldOffset(32)]
-                    internal global::Std.BasicString.__Internal Name;
+                    internal global::Std.BasicString.__Internal name;
 
                     [FieldOffset(40)]
                     internal global::Std.BasicString.__Internal USR;
 
                     [FieldOffset(48)]
-                    internal global::Std.BasicString.__Internal DebugText;
+                    internal global::Std.BasicString.__Internal debugText;
 
                     [FieldOffset(56)]
                     internal byte isIncomplete;
@@ -9044,13 +9062,13 @@ namespace CppSharp
                     internal int lineNumberEnd;
 
                     [FieldOffset(32)]
-                    internal global::Std.BasicString.__Internal Name;
+                    internal global::Std.BasicString.__Internal name;
 
                     [FieldOffset(40)]
                     internal global::Std.BasicString.__Internal USR;
 
                     [FieldOffset(48)]
-                    internal global::Std.BasicString.__Internal DebugText;
+                    internal global::Std.BasicString.__Internal debugText;
 
                     [FieldOffset(56)]
                     internal byte isIncomplete;
@@ -9625,13 +9643,13 @@ namespace CppSharp
                     internal int lineNumberEnd;
 
                     [FieldOffset(32)]
-                    internal global::Std.BasicString.__Internal Name;
+                    internal global::Std.BasicString.__Internal name;
 
                     [FieldOffset(40)]
                     internal global::Std.BasicString.__Internal USR;
 
                     [FieldOffset(48)]
-                    internal global::Std.BasicString.__Internal DebugText;
+                    internal global::Std.BasicString.__Internal debugText;
 
                     [FieldOffset(56)]
                     internal byte isIncomplete;
@@ -9864,13 +9882,13 @@ namespace CppSharp
                     internal int lineNumberEnd;
 
                     [FieldOffset(32)]
-                    internal global::Std.BasicString.__Internal Name;
+                    internal global::Std.BasicString.__Internal name;
 
                     [FieldOffset(40)]
                     internal global::Std.BasicString.__Internal USR;
 
                     [FieldOffset(48)]
-                    internal global::Std.BasicString.__Internal DebugText;
+                    internal global::Std.BasicString.__Internal debugText;
 
                     [FieldOffset(56)]
                     internal byte isIncomplete;
@@ -10013,13 +10031,13 @@ namespace CppSharp
                     internal int lineNumberEnd;
 
                     [FieldOffset(32)]
-                    internal global::Std.BasicString.__Internal Name;
+                    internal global::Std.BasicString.__Internal name;
 
                     [FieldOffset(40)]
                     internal global::Std.BasicString.__Internal USR;
 
                     [FieldOffset(48)]
-                    internal global::Std.BasicString.__Internal DebugText;
+                    internal global::Std.BasicString.__Internal debugText;
 
                     [FieldOffset(56)]
                     internal byte isIncomplete;
@@ -10209,13 +10227,13 @@ namespace CppSharp
                     internal int lineNumberEnd;
 
                     [FieldOffset(32)]
-                    internal global::Std.BasicString.__Internal Name;
+                    internal global::Std.BasicString.__Internal name;
 
                     [FieldOffset(40)]
                     internal global::Std.BasicString.__Internal USR;
 
                     [FieldOffset(48)]
-                    internal global::Std.BasicString.__Internal DebugText;
+                    internal global::Std.BasicString.__Internal debugText;
 
                     [FieldOffset(56)]
                     internal byte isIncomplete;
@@ -10406,13 +10424,13 @@ namespace CppSharp
                     internal int lineNumberEnd;
 
                     [FieldOffset(32)]
-                    internal global::Std.BasicString.__Internal Name;
+                    internal global::Std.BasicString.__Internal name;
 
                     [FieldOffset(40)]
                     internal global::Std.BasicString.__Internal USR;
 
                     [FieldOffset(48)]
-                    internal global::Std.BasicString.__Internal DebugText;
+                    internal global::Std.BasicString.__Internal debugText;
 
                     [FieldOffset(56)]
                     internal byte isIncomplete;
@@ -10574,13 +10592,13 @@ namespace CppSharp
                     internal int lineNumberEnd;
 
                     [FieldOffset(32)]
-                    internal global::Std.BasicString.__Internal Name;
+                    internal global::Std.BasicString.__Internal name;
 
                     [FieldOffset(40)]
                     internal global::Std.BasicString.__Internal USR;
 
                     [FieldOffset(48)]
-                    internal global::Std.BasicString.__Internal DebugText;
+                    internal global::Std.BasicString.__Internal debugText;
 
                     [FieldOffset(56)]
                     internal byte isIncomplete;
@@ -10795,13 +10813,13 @@ namespace CppSharp
                     internal int lineNumberEnd;
 
                     [FieldOffset(32)]
-                    internal global::Std.BasicString.__Internal Name;
+                    internal global::Std.BasicString.__Internal name;
 
                     [FieldOffset(40)]
                     internal global::Std.BasicString.__Internal USR;
 
                     [FieldOffset(48)]
-                    internal global::Std.BasicString.__Internal DebugText;
+                    internal global::Std.BasicString.__Internal debugText;
 
                     [FieldOffset(56)]
                     internal byte isIncomplete;
@@ -10868,6 +10886,16 @@ namespace CppSharp
                     [DllImport("CppSharp.CppParser", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
                         EntryPoint="_ZN8CppSharp9CppParser3AST13ClassTemplate20clearSpecializationsEv")]
                     internal static extern void ClearSpecializations_0(global::System.IntPtr instance);
+
+                    [SuppressUnmanagedCodeSecurity]
+                    [DllImport("CppSharp.CppParser", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
+                        EntryPoint="_ZN8CppSharp9CppParser3AST13ClassTemplate18FindSpecializationERKSs")]
+                    internal static extern global::System.IntPtr FindSpecialization_0(global::System.IntPtr instance, global::System.IntPtr usr);
+
+                    [SuppressUnmanagedCodeSecurity]
+                    [DllImport("CppSharp.CppParser", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
+                        EntryPoint="_ZN8CppSharp9CppParser3AST13ClassTemplate25FindPartialSpecializationERKSs")]
+                    internal static extern global::System.IntPtr FindPartialSpecialization_0(global::System.IntPtr instance, global::System.IntPtr usr);
 
                     [SuppressUnmanagedCodeSecurity]
                     [DllImport("CppSharp.CppParser", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
@@ -10966,6 +10994,38 @@ namespace CppSharp
                     __Internal.ClearSpecializations_0((__Instance + __PointerAdjustment));
                 }
 
+                public global::CppSharp.Parser.AST.ClassTemplateSpecialization FindSpecialization(string usr)
+                {
+                    var __allocator0 = new global::Std.Allocator();
+                    var __basicString0 = new global::Std.BasicString(usr, __allocator0);
+                    var __arg0 = __basicString0.__Instance;
+                    var __ret = __Internal.FindSpecialization_0((__Instance + __PointerAdjustment), __arg0);
+                    __basicString0.Dispose(false);
+                    __allocator0.Dispose();
+                    global::CppSharp.Parser.AST.ClassTemplateSpecialization __result0;
+                    if (__ret == IntPtr.Zero) __result0 = null;
+                    else if (global::CppSharp.Parser.AST.ClassTemplateSpecialization.NativeToManagedMap.ContainsKey(__ret))
+                        __result0 = (global::CppSharp.Parser.AST.ClassTemplateSpecialization) global::CppSharp.Parser.AST.ClassTemplateSpecialization.NativeToManagedMap[__ret];
+                    else __result0 = global::CppSharp.Parser.AST.ClassTemplateSpecialization.__CreateInstance(__ret);
+                    return __result0;
+                }
+
+                public global::CppSharp.Parser.AST.ClassTemplatePartialSpecialization FindPartialSpecialization(string usr)
+                {
+                    var __allocator0 = new global::Std.Allocator();
+                    var __basicString0 = new global::Std.BasicString(usr, __allocator0);
+                    var __arg0 = __basicString0.__Instance;
+                    var __ret = __Internal.FindPartialSpecialization_0((__Instance + __PointerAdjustment), __arg0);
+                    __basicString0.Dispose(false);
+                    __allocator0.Dispose();
+                    global::CppSharp.Parser.AST.ClassTemplatePartialSpecialization __result0;
+                    if (__ret == IntPtr.Zero) __result0 = null;
+                    else if (global::CppSharp.Parser.AST.ClassTemplatePartialSpecialization.NativeToManagedMap.ContainsKey(__ret))
+                        __result0 = (global::CppSharp.Parser.AST.ClassTemplatePartialSpecialization) global::CppSharp.Parser.AST.ClassTemplatePartialSpecialization.NativeToManagedMap[__ret];
+                    else __result0 = global::CppSharp.Parser.AST.ClassTemplatePartialSpecialization.__CreateInstance(__ret);
+                    return __result0;
+                }
+
                 public uint SpecializationsCount
                 {
                     get
@@ -11000,13 +11060,13 @@ namespace CppSharp
                     internal int lineNumberEnd;
 
                     [FieldOffset(32)]
-                    internal global::Std.BasicString.__Internal Name;
+                    internal global::Std.BasicString.__Internal name;
 
                     [FieldOffset(40)]
                     internal global::Std.BasicString.__Internal USR;
 
                     [FieldOffset(48)]
-                    internal global::Std.BasicString.__Internal DebugText;
+                    internal global::Std.BasicString.__Internal debugText;
 
                     [FieldOffset(56)]
                     internal byte isIncomplete;
@@ -11310,13 +11370,13 @@ namespace CppSharp
                     internal int lineNumberEnd;
 
                     [FieldOffset(32)]
-                    internal global::Std.BasicString.__Internal Name;
+                    internal global::Std.BasicString.__Internal name;
 
                     [FieldOffset(40)]
                     internal global::Std.BasicString.__Internal USR;
 
                     [FieldOffset(48)]
-                    internal global::Std.BasicString.__Internal DebugText;
+                    internal global::Std.BasicString.__Internal debugText;
 
                     [FieldOffset(56)]
                     internal byte isIncomplete;
@@ -11540,13 +11600,13 @@ namespace CppSharp
                     internal int lineNumberEnd;
 
                     [FieldOffset(32)]
-                    internal global::Std.BasicString.__Internal Name;
+                    internal global::Std.BasicString.__Internal name;
 
                     [FieldOffset(40)]
                     internal global::Std.BasicString.__Internal USR;
 
                     [FieldOffset(48)]
-                    internal global::Std.BasicString.__Internal DebugText;
+                    internal global::Std.BasicString.__Internal debugText;
 
                     [FieldOffset(56)]
                     internal byte isIncomplete;
@@ -11613,6 +11673,11 @@ namespace CppSharp
                     [DllImport("CppSharp.CppParser", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
                         EntryPoint="_ZN8CppSharp9CppParser3AST16FunctionTemplate20clearSpecializationsEv")]
                     internal static extern void ClearSpecializations_0(global::System.IntPtr instance);
+
+                    [SuppressUnmanagedCodeSecurity]
+                    [DllImport("CppSharp.CppParser", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
+                        EntryPoint="_ZN8CppSharp9CppParser3AST16FunctionTemplate18FindSpecializationERKSs")]
+                    internal static extern global::System.IntPtr FindSpecialization_0(global::System.IntPtr instance, global::System.IntPtr usr);
 
                     [SuppressUnmanagedCodeSecurity]
                     [DllImport("CppSharp.CppParser", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
@@ -11709,6 +11774,22 @@ namespace CppSharp
                 public void ClearSpecializations()
                 {
                     __Internal.ClearSpecializations_0((__Instance + __PointerAdjustment));
+                }
+
+                public global::CppSharp.Parser.AST.FunctionTemplateSpecialization FindSpecialization(string usr)
+                {
+                    var __allocator0 = new global::Std.Allocator();
+                    var __basicString0 = new global::Std.BasicString(usr, __allocator0);
+                    var __arg0 = __basicString0.__Instance;
+                    var __ret = __Internal.FindSpecialization_0((__Instance + __PointerAdjustment), __arg0);
+                    __basicString0.Dispose(false);
+                    __allocator0.Dispose();
+                    global::CppSharp.Parser.AST.FunctionTemplateSpecialization __result0;
+                    if (__ret == IntPtr.Zero) __result0 = null;
+                    else if (global::CppSharp.Parser.AST.FunctionTemplateSpecialization.NativeToManagedMap.ContainsKey(__ret))
+                        __result0 = (global::CppSharp.Parser.AST.FunctionTemplateSpecialization) global::CppSharp.Parser.AST.FunctionTemplateSpecialization.NativeToManagedMap[__ret];
+                    else __result0 = global::CppSharp.Parser.AST.FunctionTemplateSpecialization.__CreateInstance(__ret);
+                    return __result0;
                 }
 
                 public uint SpecializationsCount
@@ -11953,13 +12034,13 @@ namespace CppSharp
                     internal int lineNumberEnd;
 
                     [FieldOffset(32)]
-                    internal global::Std.BasicString.__Internal Name;
+                    internal global::Std.BasicString.__Internal name;
 
                     [FieldOffset(40)]
                     internal global::Std.BasicString.__Internal USR;
 
                     [FieldOffset(48)]
-                    internal global::Std.BasicString.__Internal DebugText;
+                    internal global::Std.BasicString.__Internal debugText;
 
                     [FieldOffset(56)]
                     internal byte isIncomplete;
@@ -12026,6 +12107,16 @@ namespace CppSharp
                     [DllImport("CppSharp.CppParser", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
                         EntryPoint="_ZN8CppSharp9CppParser3AST11VarTemplate20clearSpecializationsEv")]
                     internal static extern void ClearSpecializations_0(global::System.IntPtr instance);
+
+                    [SuppressUnmanagedCodeSecurity]
+                    [DllImport("CppSharp.CppParser", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
+                        EntryPoint="_ZN8CppSharp9CppParser3AST11VarTemplate18FindSpecializationERKSs")]
+                    internal static extern global::System.IntPtr FindSpecialization_0(global::System.IntPtr instance, global::System.IntPtr usr);
+
+                    [SuppressUnmanagedCodeSecurity]
+                    [DllImport("CppSharp.CppParser", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
+                        EntryPoint="_ZN8CppSharp9CppParser3AST11VarTemplate25FindPartialSpecializationERKSs")]
+                    internal static extern global::System.IntPtr FindPartialSpecialization_0(global::System.IntPtr instance, global::System.IntPtr usr);
 
                     [SuppressUnmanagedCodeSecurity]
                     [DllImport("CppSharp.CppParser", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
@@ -12124,6 +12215,38 @@ namespace CppSharp
                     __Internal.ClearSpecializations_0((__Instance + __PointerAdjustment));
                 }
 
+                public global::CppSharp.Parser.AST.VarTemplateSpecialization FindSpecialization(string usr)
+                {
+                    var __allocator0 = new global::Std.Allocator();
+                    var __basicString0 = new global::Std.BasicString(usr, __allocator0);
+                    var __arg0 = __basicString0.__Instance;
+                    var __ret = __Internal.FindSpecialization_0((__Instance + __PointerAdjustment), __arg0);
+                    __basicString0.Dispose(false);
+                    __allocator0.Dispose();
+                    global::CppSharp.Parser.AST.VarTemplateSpecialization __result0;
+                    if (__ret == IntPtr.Zero) __result0 = null;
+                    else if (global::CppSharp.Parser.AST.VarTemplateSpecialization.NativeToManagedMap.ContainsKey(__ret))
+                        __result0 = (global::CppSharp.Parser.AST.VarTemplateSpecialization) global::CppSharp.Parser.AST.VarTemplateSpecialization.NativeToManagedMap[__ret];
+                    else __result0 = global::CppSharp.Parser.AST.VarTemplateSpecialization.__CreateInstance(__ret);
+                    return __result0;
+                }
+
+                public global::CppSharp.Parser.AST.VarTemplatePartialSpecialization FindPartialSpecialization(string usr)
+                {
+                    var __allocator0 = new global::Std.Allocator();
+                    var __basicString0 = new global::Std.BasicString(usr, __allocator0);
+                    var __arg0 = __basicString0.__Instance;
+                    var __ret = __Internal.FindPartialSpecialization_0((__Instance + __PointerAdjustment), __arg0);
+                    __basicString0.Dispose(false);
+                    __allocator0.Dispose();
+                    global::CppSharp.Parser.AST.VarTemplatePartialSpecialization __result0;
+                    if (__ret == IntPtr.Zero) __result0 = null;
+                    else if (global::CppSharp.Parser.AST.VarTemplatePartialSpecialization.NativeToManagedMap.ContainsKey(__ret))
+                        __result0 = (global::CppSharp.Parser.AST.VarTemplatePartialSpecialization) global::CppSharp.Parser.AST.VarTemplatePartialSpecialization.NativeToManagedMap[__ret];
+                    else __result0 = global::CppSharp.Parser.AST.VarTemplatePartialSpecialization.__CreateInstance(__ret);
+                    return __result0;
+                }
+
                 public uint SpecializationsCount
                 {
                     get
@@ -12158,13 +12281,13 @@ namespace CppSharp
                     internal int lineNumberEnd;
 
                     [FieldOffset(32)]
-                    internal global::Std.BasicString.__Internal Name;
+                    internal global::Std.BasicString.__Internal name;
 
                     [FieldOffset(40)]
                     internal global::Std.BasicString.__Internal USR;
 
                     [FieldOffset(48)]
-                    internal global::Std.BasicString.__Internal DebugText;
+                    internal global::Std.BasicString.__Internal debugText;
 
                     [FieldOffset(56)]
                     internal byte isIncomplete;
@@ -12194,7 +12317,7 @@ namespace CppSharp
                     internal global::System.IntPtr comment;
 
                     [FieldOffset(144)]
-                    internal global::Std.BasicString.__Internal Mangled;
+                    internal global::Std.BasicString.__Internal mangled;
 
                     [FieldOffset(152)]
                     internal global::CppSharp.Parser.AST.QualifiedType.__Internal qualifiedType;
@@ -12396,13 +12519,13 @@ namespace CppSharp
                     internal int lineNumberEnd;
 
                     [FieldOffset(32)]
-                    internal global::Std.BasicString.__Internal Name;
+                    internal global::Std.BasicString.__Internal name;
 
                     [FieldOffset(40)]
                     internal global::Std.BasicString.__Internal USR;
 
                     [FieldOffset(48)]
-                    internal global::Std.BasicString.__Internal DebugText;
+                    internal global::Std.BasicString.__Internal debugText;
 
                     [FieldOffset(56)]
                     internal byte isIncomplete;
@@ -12432,7 +12555,7 @@ namespace CppSharp
                     internal global::System.IntPtr comment;
 
                     [FieldOffset(144)]
-                    internal global::Std.BasicString.__Internal Mangled;
+                    internal global::Std.BasicString.__Internal mangled;
 
                     [FieldOffset(152)]
                     internal global::CppSharp.Parser.AST.QualifiedType.__Internal qualifiedType;
@@ -12554,13 +12677,13 @@ namespace CppSharp
                     internal int lineNumberEnd;
 
                     [FieldOffset(32)]
-                    internal global::Std.BasicString.__Internal Name;
+                    internal global::Std.BasicString.__Internal name;
 
                     [FieldOffset(40)]
                     internal global::Std.BasicString.__Internal USR;
 
                     [FieldOffset(48)]
-                    internal global::Std.BasicString.__Internal DebugText;
+                    internal global::Std.BasicString.__Internal debugText;
 
                     [FieldOffset(56)]
                     internal byte isIncomplete;
@@ -12873,10 +12996,10 @@ namespace CppSharp
                     internal global::CppSharp.Parser.AST.DeclarationKind kind;
 
                     [FieldOffset(24)]
-                    internal global::Std.BasicString.__Internal Name;
+                    internal global::Std.BasicString.__Internal name;
 
                     [FieldOffset(32)]
-                    internal global::Std.BasicString.__Internal Expression;
+                    internal global::Std.BasicString.__Internal expression;
 
                     [FieldOffset(40)]
                     internal int lineNumberStart;
@@ -12898,26 +13021,6 @@ namespace CppSharp
                     [DllImport("CppSharp.CppParser", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
                         EntryPoint="_ZN8CppSharp9CppParser3AST15MacroDefinitionD2Ev")]
                     internal static extern void dtor_0(global::System.IntPtr instance);
-
-                    [SuppressUnmanagedCodeSecurity]
-                    [DllImport("CppSharp.CppParser", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
-                        EntryPoint="_ZN8CppSharp9CppParser3AST15MacroDefinition7getNameEv")]
-                    internal static extern global::System.IntPtr GetName(global::System.IntPtr instance);
-
-                    [SuppressUnmanagedCodeSecurity]
-                    [DllImport("CppSharp.CppParser", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
-                        EntryPoint="_ZN8CppSharp9CppParser3AST15MacroDefinition7setNameEPKc")]
-                    internal static extern void SetName(global::System.IntPtr instance, [MarshalAs(UnmanagedType.LPStr)] string s);
-
-                    [SuppressUnmanagedCodeSecurity]
-                    [DllImport("CppSharp.CppParser", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
-                        EntryPoint="_ZN8CppSharp9CppParser3AST15MacroDefinition13getExpressionEv")]
-                    internal static extern global::System.IntPtr GetExpression(global::System.IntPtr instance);
-
-                    [SuppressUnmanagedCodeSecurity]
-                    [DllImport("CppSharp.CppParser", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
-                        EntryPoint="_ZN8CppSharp9CppParser3AST15MacroDefinition13setExpressionEPKc")]
-                    internal static extern void SetExpression(global::System.IntPtr instance, [MarshalAs(UnmanagedType.LPStr)] string s);
                 }
 
                 internal static new global::CppSharp.Parser.AST.MacroDefinition __CreateInstance(global::System.IntPtr native, bool skipVTables = false)
@@ -12987,6 +13090,36 @@ namespace CppSharp
                     __Instance = IntPtr.Zero;
                 }
 
+                public string Name
+                {
+                    get
+                    {
+                        return global::Std.BasicString.__CreateInstance(((global::CppSharp.Parser.AST.MacroDefinition.__Internal*) __Instance)->name).CStr();
+                    }
+
+                    set
+                    {
+                        var __allocator0 = new global::Std.Allocator();
+                        var __basicString0 = new global::Std.BasicString(value, __allocator0);
+                        ((global::CppSharp.Parser.AST.MacroDefinition.__Internal*) __Instance)->name = *(global::Std.BasicString.__Internal*) __basicString0.__Instance;
+                    }
+                }
+
+                public string Expression
+                {
+                    get
+                    {
+                        return global::Std.BasicString.__CreateInstance(((global::CppSharp.Parser.AST.MacroDefinition.__Internal*) __Instance)->expression).CStr();
+                    }
+
+                    set
+                    {
+                        var __allocator0 = new global::Std.Allocator();
+                        var __basicString0 = new global::Std.BasicString(value, __allocator0);
+                        ((global::CppSharp.Parser.AST.MacroDefinition.__Internal*) __Instance)->expression = *(global::Std.BasicString.__Internal*) __basicString0.__Instance;
+                    }
+                }
+
                 public int LineNumberStart
                 {
                     get
@@ -13012,34 +13145,6 @@ namespace CppSharp
                         ((global::CppSharp.Parser.AST.MacroDefinition.__Internal*) __Instance)->lineNumberEnd = value;
                     }
                 }
-
-                public string Name
-                {
-                    get
-                    {
-                        var __ret = __Internal.GetName((__Instance + __PointerAdjustment));
-                        return Marshal.PtrToStringAnsi(__ret);
-                    }
-
-                    set
-                    {
-                        __Internal.SetName((__Instance + __PointerAdjustment), value);
-                    }
-                }
-
-                public string Expression
-                {
-                    get
-                    {
-                        var __ret = __Internal.GetExpression((__Instance + __PointerAdjustment));
-                        return Marshal.PtrToStringAnsi(__ret);
-                    }
-
-                    set
-                    {
-                        __Internal.SetExpression((__Instance + __PointerAdjustment), value);
-                    }
-                }
             }
 
             public unsafe partial class MacroExpansion : global::CppSharp.Parser.AST.PreprocessedEntity, IDisposable
@@ -13057,10 +13162,10 @@ namespace CppSharp
                     internal global::CppSharp.Parser.AST.DeclarationKind kind;
 
                     [FieldOffset(24)]
-                    internal global::Std.BasicString.__Internal Name;
+                    internal global::Std.BasicString.__Internal name;
 
                     [FieldOffset(32)]
-                    internal global::Std.BasicString.__Internal Text;
+                    internal global::Std.BasicString.__Internal text;
 
                     [FieldOffset(40)]
                     internal global::System.IntPtr definition;
@@ -13079,26 +13184,6 @@ namespace CppSharp
                     [DllImport("CppSharp.CppParser", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
                         EntryPoint="_ZN8CppSharp9CppParser3AST14MacroExpansionD2Ev")]
                     internal static extern void dtor_0(global::System.IntPtr instance);
-
-                    [SuppressUnmanagedCodeSecurity]
-                    [DllImport("CppSharp.CppParser", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
-                        EntryPoint="_ZN8CppSharp9CppParser3AST14MacroExpansion7getNameEv")]
-                    internal static extern global::System.IntPtr GetName(global::System.IntPtr instance);
-
-                    [SuppressUnmanagedCodeSecurity]
-                    [DllImport("CppSharp.CppParser", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
-                        EntryPoint="_ZN8CppSharp9CppParser3AST14MacroExpansion7setNameEPKc")]
-                    internal static extern void SetName(global::System.IntPtr instance, [MarshalAs(UnmanagedType.LPStr)] string s);
-
-                    [SuppressUnmanagedCodeSecurity]
-                    [DllImport("CppSharp.CppParser", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
-                        EntryPoint="_ZN8CppSharp9CppParser3AST14MacroExpansion7getTextEv")]
-                    internal static extern global::System.IntPtr GetText(global::System.IntPtr instance);
-
-                    [SuppressUnmanagedCodeSecurity]
-                    [DllImport("CppSharp.CppParser", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
-                        EntryPoint="_ZN8CppSharp9CppParser3AST14MacroExpansion7setTextEPKc")]
-                    internal static extern void SetText(global::System.IntPtr instance, [MarshalAs(UnmanagedType.LPStr)] string s);
                 }
 
                 internal static new global::CppSharp.Parser.AST.MacroExpansion __CreateInstance(global::System.IntPtr native, bool skipVTables = false)
@@ -13168,6 +13253,36 @@ namespace CppSharp
                     __Instance = IntPtr.Zero;
                 }
 
+                public string Name
+                {
+                    get
+                    {
+                        return global::Std.BasicString.__CreateInstance(((global::CppSharp.Parser.AST.MacroExpansion.__Internal*) __Instance)->name).CStr();
+                    }
+
+                    set
+                    {
+                        var __allocator0 = new global::Std.Allocator();
+                        var __basicString0 = new global::Std.BasicString(value, __allocator0);
+                        ((global::CppSharp.Parser.AST.MacroExpansion.__Internal*) __Instance)->name = *(global::Std.BasicString.__Internal*) __basicString0.__Instance;
+                    }
+                }
+
+                public string Text
+                {
+                    get
+                    {
+                        return global::Std.BasicString.__CreateInstance(((global::CppSharp.Parser.AST.MacroExpansion.__Internal*) __Instance)->text).CStr();
+                    }
+
+                    set
+                    {
+                        var __allocator0 = new global::Std.Allocator();
+                        var __basicString0 = new global::Std.BasicString(value, __allocator0);
+                        ((global::CppSharp.Parser.AST.MacroExpansion.__Internal*) __Instance)->text = *(global::Std.BasicString.__Internal*) __basicString0.__Instance;
+                    }
+                }
+
                 public global::CppSharp.Parser.AST.MacroDefinition Definition
                 {
                     get
@@ -13183,34 +13298,6 @@ namespace CppSharp
                     set
                     {
                         ((global::CppSharp.Parser.AST.MacroExpansion.__Internal*) __Instance)->definition = ReferenceEquals(value, null) ? global::System.IntPtr.Zero : value.__Instance;
-                    }
-                }
-
-                public string Name
-                {
-                    get
-                    {
-                        var __ret = __Internal.GetName((__Instance + __PointerAdjustment));
-                        return Marshal.PtrToStringAnsi(__ret);
-                    }
-
-                    set
-                    {
-                        __Internal.SetName((__Instance + __PointerAdjustment), value);
-                    }
-                }
-
-                public string Text
-                {
-                    get
-                    {
-                        var __ret = __Internal.GetText((__Instance + __PointerAdjustment));
-                        return Marshal.PtrToStringAnsi(__ret);
-                    }
-
-                    set
-                    {
-                        __Internal.SetText((__Instance + __PointerAdjustment), value);
                     }
                 }
             }
@@ -13239,13 +13326,13 @@ namespace CppSharp
                     internal int lineNumberEnd;
 
                     [FieldOffset(32)]
-                    internal global::Std.BasicString.__Internal Name;
+                    internal global::Std.BasicString.__Internal name;
 
                     [FieldOffset(40)]
                     internal global::Std.BasicString.__Internal USR;
 
                     [FieldOffset(48)]
-                    internal global::Std.BasicString.__Internal DebugText;
+                    internal global::Std.BasicString.__Internal debugText;
 
                     [FieldOffset(56)]
                     internal byte isIncomplete;
@@ -13311,7 +13398,7 @@ namespace CppSharp
                     internal byte isInline;
 
                     [FieldOffset(416)]
-                    internal global::Std.BasicString.__Internal FileName;
+                    internal global::Std.BasicString.__Internal fileName;
 
                     [FieldOffset(424)]
                     internal byte isSystemHeader;
@@ -13348,16 +13435,6 @@ namespace CppSharp
                     [DllImport("CppSharp.CppParser", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
                         EntryPoint="_ZN8CppSharp9CppParser3AST15TranslationUnit11clearMacrosEv")]
                     internal static extern void ClearMacros_0(global::System.IntPtr instance);
-
-                    [SuppressUnmanagedCodeSecurity]
-                    [DllImport("CppSharp.CppParser", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
-                        EntryPoint="_ZN8CppSharp9CppParser3AST15TranslationUnit11getFileNameEv")]
-                    internal static extern global::System.IntPtr GetFileName(global::System.IntPtr instance);
-
-                    [SuppressUnmanagedCodeSecurity]
-                    [DllImport("CppSharp.CppParser", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
-                        EntryPoint="_ZN8CppSharp9CppParser3AST15TranslationUnit11setFileNameEPKc")]
-                    internal static extern void SetFileName(global::System.IntPtr instance, [MarshalAs(UnmanagedType.LPStr)] string s);
 
                     [SuppressUnmanagedCodeSecurity]
                     [DllImport("CppSharp.CppParser", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
@@ -13456,6 +13533,21 @@ namespace CppSharp
                     __Internal.ClearMacros_0((__Instance + __PointerAdjustment));
                 }
 
+                public string FileName
+                {
+                    get
+                    {
+                        return global::Std.BasicString.__CreateInstance(((global::CppSharp.Parser.AST.TranslationUnit.__Internal*) __Instance)->fileName).CStr();
+                    }
+
+                    set
+                    {
+                        var __allocator0 = new global::Std.Allocator();
+                        var __basicString0 = new global::Std.BasicString(value, __allocator0);
+                        ((global::CppSharp.Parser.AST.TranslationUnit.__Internal*) __Instance)->fileName = *(global::Std.BasicString.__Internal*) __basicString0.__Instance;
+                    }
+                }
+
                 public bool IsSystemHeader
                 {
                     get
@@ -13466,20 +13558,6 @@ namespace CppSharp
                     set
                     {
                         ((global::CppSharp.Parser.AST.TranslationUnit.__Internal*) __Instance)->isSystemHeader = (byte) (value ? 1 : 0);
-                    }
-                }
-
-                public string FileName
-                {
-                    get
-                    {
-                        var __ret = __Internal.GetFileName((__Instance + __PointerAdjustment));
-                        return Marshal.PtrToStringAnsi(__ret);
-                    }
-
-                    set
-                    {
-                        __Internal.SetFileName((__Instance + __PointerAdjustment), value);
                     }
                 }
 
@@ -13499,7 +13577,7 @@ namespace CppSharp
                 public partial struct __Internal
                 {
                     [FieldOffset(0)]
-                    internal global::Std.BasicString.__Internal FileName;
+                    internal global::Std.BasicString.__Internal fileName;
 
                     [FieldOffset(8)]
                     internal global::CppSharp.Parser.AST.ArchType archType;
@@ -13554,16 +13632,6 @@ namespace CppSharp
                     [DllImport("CppSharp.CppParser", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
                         EntryPoint="_ZN8CppSharp9CppParser3AST13NativeLibrary17clearDependenciesEv")]
                     internal static extern void ClearDependencies_0(global::System.IntPtr instance);
-
-                    [SuppressUnmanagedCodeSecurity]
-                    [DllImport("CppSharp.CppParser", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
-                        EntryPoint="_ZN8CppSharp9CppParser3AST13NativeLibrary11getFileNameEv")]
-                    internal static extern global::System.IntPtr GetFileName(global::System.IntPtr instance);
-
-                    [SuppressUnmanagedCodeSecurity]
-                    [DllImport("CppSharp.CppParser", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
-                        EntryPoint="_ZN8CppSharp9CppParser3AST13NativeLibrary11setFileNameEPKc")]
-                    internal static extern void SetFileName(global::System.IntPtr instance, [MarshalAs(UnmanagedType.LPStr)] string s);
 
                     [SuppressUnmanagedCodeSecurity]
                     [DllImport("CppSharp.CppParser", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
@@ -13684,6 +13752,21 @@ namespace CppSharp
                     __Internal.ClearDependencies_0((__Instance + __PointerAdjustment));
                 }
 
+                public string FileName
+                {
+                    get
+                    {
+                        return global::Std.BasicString.__CreateInstance(((global::CppSharp.Parser.AST.NativeLibrary.__Internal*) __Instance)->fileName).CStr();
+                    }
+
+                    set
+                    {
+                        var __allocator0 = new global::Std.Allocator();
+                        var __basicString0 = new global::Std.BasicString(value, __allocator0);
+                        ((global::CppSharp.Parser.AST.NativeLibrary.__Internal*) __Instance)->fileName = *(global::Std.BasicString.__Internal*) __basicString0.__Instance;
+                    }
+                }
+
                 public global::CppSharp.Parser.AST.ArchType ArchType
                 {
                     get
@@ -13694,20 +13777,6 @@ namespace CppSharp
                     set
                     {
                         ((global::CppSharp.Parser.AST.NativeLibrary.__Internal*) __Instance)->archType = value;
-                    }
-                }
-
-                public string FileName
-                {
-                    get
-                    {
-                        var __ret = __Internal.GetFileName((__Instance + __PointerAdjustment));
-                        return Marshal.PtrToStringAnsi(__ret);
-                    }
-
-                    set
-                    {
-                        __Internal.SetFileName((__Instance + __PointerAdjustment), value);
                     }
                 }
 
@@ -13752,6 +13821,11 @@ namespace CppSharp
                     [DllImport("CppSharp.CppParser", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
                         EntryPoint="_ZN8CppSharp9CppParser3AST10ASTContextD2Ev")]
                     internal static extern void dtor_0(global::System.IntPtr instance);
+
+                    [SuppressUnmanagedCodeSecurity]
+                    [DllImport("CppSharp.CppParser", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
+                        EntryPoint="_ZN8CppSharp9CppParser3AST10ASTContext18FindOrCreateModuleESs")]
+                    internal static extern global::System.IntPtr FindOrCreateModule_0(global::System.IntPtr instance, global::Std.BasicString.__Internal File);
 
                     [SuppressUnmanagedCodeSecurity]
                     [DllImport("CppSharp.CppParser", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
@@ -13848,6 +13922,22 @@ namespace CppSharp
                     if (__ownsNativeInstance)
                         Marshal.FreeHGlobal(__Instance);
                     __Instance = IntPtr.Zero;
+                }
+
+                public global::CppSharp.Parser.AST.TranslationUnit FindOrCreateModule(string File)
+                {
+                    var __allocator0 = new global::Std.Allocator();
+                    var __basicString0 = new global::Std.BasicString(File, __allocator0);
+                    var __arg0 = *(global::Std.BasicString.__Internal*) __basicString0.__Instance;
+                    var __ret = __Internal.FindOrCreateModule_0((__Instance + __PointerAdjustment), __arg0);
+                    __basicString0.Dispose(false);
+                    __allocator0.Dispose();
+                    global::CppSharp.Parser.AST.TranslationUnit __result0;
+                    if (__ret == IntPtr.Zero) __result0 = null;
+                    else if (global::CppSharp.Parser.AST.TranslationUnit.NativeToManagedMap.ContainsKey(__ret))
+                        __result0 = (global::CppSharp.Parser.AST.TranslationUnit) global::CppSharp.Parser.AST.TranslationUnit.NativeToManagedMap[__ret];
+                    else __result0 = global::CppSharp.Parser.AST.TranslationUnit.__CreateInstance(__ret);
+                    return __result0;
                 }
 
                 public global::CppSharp.Parser.AST.TranslationUnit GetTranslationUnits(uint i)
@@ -14565,7 +14655,7 @@ namespace CppSharp
                     public partial struct __Internal
                     {
                         [FieldOffset(0)]
-                        internal global::Std.BasicString.__Internal Text;
+                        internal global::Std.BasicString.__Internal text;
 
                         [SuppressUnmanagedCodeSecurity]
                         [DllImport("CppSharp.CppParser", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
@@ -14581,16 +14671,6 @@ namespace CppSharp
                         [DllImport("CppSharp.CppParser", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
                             EntryPoint="_ZN8CppSharp9CppParser3AST19BlockCommandComment8ArgumentD2Ev")]
                         internal static extern void dtor_0(global::System.IntPtr instance);
-
-                        [SuppressUnmanagedCodeSecurity]
-                        [DllImport("CppSharp.CppParser", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
-                            EntryPoint="_ZN8CppSharp9CppParser3AST19BlockCommandComment8Argument7getTextEv")]
-                        internal static extern global::System.IntPtr GetText(global::System.IntPtr instance);
-
-                        [SuppressUnmanagedCodeSecurity]
-                        [DllImport("CppSharp.CppParser", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
-                            EntryPoint="_ZN8CppSharp9CppParser3AST19BlockCommandComment8Argument7setTextEPKc")]
-                        internal static extern void SetText(global::System.IntPtr instance, [MarshalAs(UnmanagedType.LPStr)] string s);
                     }
 
                     public global::System.IntPtr __Instance { get; protected set; }
@@ -14673,13 +14753,14 @@ namespace CppSharp
                     {
                         get
                         {
-                            var __ret = __Internal.GetText((__Instance + __PointerAdjustment));
-                            return Marshal.PtrToStringAnsi(__ret);
+                            return global::Std.BasicString.__CreateInstance(((global::CppSharp.Parser.AST.BlockCommandComment.Argument.__Internal*) __Instance)->text).CStr();
                         }
 
                         set
                         {
-                            __Internal.SetText((__Instance + __PointerAdjustment), value);
+                            var __allocator0 = new global::Std.Allocator();
+                            var __basicString0 = new global::Std.BasicString(value, __allocator0);
+                            ((global::CppSharp.Parser.AST.BlockCommandComment.Argument.__Internal*) __Instance)->text = *(global::Std.BasicString.__Internal*) __basicString0.__Instance;
                         }
                     }
                 }
@@ -15128,7 +15209,7 @@ namespace CppSharp
                     internal global::CppSharp.Parser.AST.CommentKind kind;
 
                     [FieldOffset(8)]
-                    internal global::Std.BasicString.__Internal Text;
+                    internal global::Std.BasicString.__Internal text;
 
                     [SuppressUnmanagedCodeSecurity]
                     [DllImport("CppSharp.CppParser", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
@@ -15144,16 +15225,6 @@ namespace CppSharp
                     [DllImport("CppSharp.CppParser", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
                         EntryPoint="_ZN8CppSharp9CppParser3AST24VerbatimBlockLineCommentD2Ev")]
                     internal static extern void dtor_0(global::System.IntPtr instance);
-
-                    [SuppressUnmanagedCodeSecurity]
-                    [DllImport("CppSharp.CppParser", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
-                        EntryPoint="_ZN8CppSharp9CppParser3AST24VerbatimBlockLineComment7getTextEv")]
-                    internal static extern global::System.IntPtr GetText(global::System.IntPtr instance);
-
-                    [SuppressUnmanagedCodeSecurity]
-                    [DllImport("CppSharp.CppParser", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
-                        EntryPoint="_ZN8CppSharp9CppParser3AST24VerbatimBlockLineComment7setTextEPKc")]
-                    internal static extern void SetText(global::System.IntPtr instance, [MarshalAs(UnmanagedType.LPStr)] string s);
                 }
 
                 internal static new global::CppSharp.Parser.AST.VerbatimBlockLineComment __CreateInstance(global::System.IntPtr native, bool skipVTables = false)
@@ -15227,13 +15298,14 @@ namespace CppSharp
                 {
                     get
                     {
-                        var __ret = __Internal.GetText((__Instance + __PointerAdjustment));
-                        return Marshal.PtrToStringAnsi(__ret);
+                        return global::Std.BasicString.__CreateInstance(((global::CppSharp.Parser.AST.VerbatimBlockLineComment.__Internal*) __Instance)->text).CStr();
                     }
 
                     set
                     {
-                        __Internal.SetText((__Instance + __PointerAdjustment), value);
+                        var __allocator0 = new global::Std.Allocator();
+                        var __basicString0 = new global::Std.BasicString(value, __allocator0);
+                        ((global::CppSharp.Parser.AST.VerbatimBlockLineComment.__Internal*) __Instance)->text = *(global::Std.BasicString.__Internal*) __basicString0.__Instance;
                     }
                 }
             }
@@ -15413,7 +15485,7 @@ namespace CppSharp
                     internal global::Std.Vector.__Internal Arguments;
 
                     [FieldOffset(40)]
-                    internal global::Std.BasicString.__Internal Text;
+                    internal global::Std.BasicString.__Internal text;
 
                     [SuppressUnmanagedCodeSecurity]
                     [DllImport("CppSharp.CppParser", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
@@ -15429,16 +15501,6 @@ namespace CppSharp
                     [DllImport("CppSharp.CppParser", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
                         EntryPoint="_ZN8CppSharp9CppParser3AST19VerbatimLineCommentD2Ev")]
                     internal static extern void dtor_0(global::System.IntPtr instance);
-
-                    [SuppressUnmanagedCodeSecurity]
-                    [DllImport("CppSharp.CppParser", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
-                        EntryPoint="_ZN8CppSharp9CppParser3AST19VerbatimLineComment7getTextEv")]
-                    internal static extern global::System.IntPtr GetText(global::System.IntPtr instance);
-
-                    [SuppressUnmanagedCodeSecurity]
-                    [DllImport("CppSharp.CppParser", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
-                        EntryPoint="_ZN8CppSharp9CppParser3AST19VerbatimLineComment7setTextEPKc")]
-                    internal static extern void SetText(global::System.IntPtr instance, [MarshalAs(UnmanagedType.LPStr)] string s);
                 }
 
                 internal static new global::CppSharp.Parser.AST.VerbatimLineComment __CreateInstance(global::System.IntPtr native, bool skipVTables = false)
@@ -15512,13 +15574,14 @@ namespace CppSharp
                 {
                     get
                     {
-                        var __ret = __Internal.GetText((__Instance + __PointerAdjustment));
-                        return Marshal.PtrToStringAnsi(__ret);
+                        return global::Std.BasicString.__CreateInstance(((global::CppSharp.Parser.AST.VerbatimLineComment.__Internal*) __Instance)->text).CStr();
                     }
 
                     set
                     {
-                        __Internal.SetText((__Instance + __PointerAdjustment), value);
+                        var __allocator0 = new global::Std.Allocator();
+                        var __basicString0 = new global::Std.BasicString(value, __allocator0);
+                        ((global::CppSharp.Parser.AST.VerbatimLineComment.__Internal*) __Instance)->text = *(global::Std.BasicString.__Internal*) __basicString0.__Instance;
                     }
                 }
             }
@@ -15593,7 +15656,7 @@ namespace CppSharp
                     public partial struct __Internal
                     {
                         [FieldOffset(0)]
-                        internal global::Std.BasicString.__Internal Text;
+                        internal global::Std.BasicString.__Internal text;
 
                         [SuppressUnmanagedCodeSecurity]
                         [DllImport("CppSharp.CppParser", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
@@ -15609,16 +15672,6 @@ namespace CppSharp
                         [DllImport("CppSharp.CppParser", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
                             EntryPoint="_ZN8CppSharp9CppParser3AST20InlineCommandComment8ArgumentD2Ev")]
                         internal static extern void dtor_0(global::System.IntPtr instance);
-
-                        [SuppressUnmanagedCodeSecurity]
-                        [DllImport("CppSharp.CppParser", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
-                            EntryPoint="_ZN8CppSharp9CppParser3AST20InlineCommandComment8Argument7getTextEv")]
-                        internal static extern global::System.IntPtr GetText(global::System.IntPtr instance);
-
-                        [SuppressUnmanagedCodeSecurity]
-                        [DllImport("CppSharp.CppParser", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
-                            EntryPoint="_ZN8CppSharp9CppParser3AST20InlineCommandComment8Argument7setTextEPKc")]
-                        internal static extern void SetText(global::System.IntPtr instance, [MarshalAs(UnmanagedType.LPStr)] string s);
                     }
 
                     public global::System.IntPtr __Instance { get; protected set; }
@@ -15701,13 +15754,14 @@ namespace CppSharp
                     {
                         get
                         {
-                            var __ret = __Internal.GetText((__Instance + __PointerAdjustment));
-                            return Marshal.PtrToStringAnsi(__ret);
+                            return global::Std.BasicString.__CreateInstance(((global::CppSharp.Parser.AST.InlineCommandComment.Argument.__Internal*) __Instance)->text).CStr();
                         }
 
                         set
                         {
-                            __Internal.SetText((__Instance + __PointerAdjustment), value);
+                            var __allocator0 = new global::Std.Allocator();
+                            var __basicString0 = new global::Std.BasicString(value, __allocator0);
+                            ((global::CppSharp.Parser.AST.InlineCommandComment.Argument.__Internal*) __Instance)->text = *(global::Std.BasicString.__Internal*) __basicString0.__Instance;
                         }
                     }
                 }
@@ -15940,7 +15994,7 @@ namespace CppSharp
                     internal byte hasTrailingNewline;
 
                     [FieldOffset(8)]
-                    internal global::Std.BasicString.__Internal TagName;
+                    internal global::Std.BasicString.__Internal tagName;
 
                     [FieldOffset(16)]
                     internal global::Std.Vector.__Internal Attributes;
@@ -15977,16 +16031,6 @@ namespace CppSharp
 
                     [SuppressUnmanagedCodeSecurity]
                     [DllImport("CppSharp.CppParser", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
-                        EntryPoint="_ZN8CppSharp9CppParser3AST19HTMLStartTagComment10getTagNameEv")]
-                    internal static extern global::System.IntPtr GetTagName(global::System.IntPtr instance);
-
-                    [SuppressUnmanagedCodeSecurity]
-                    [DllImport("CppSharp.CppParser", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
-                        EntryPoint="_ZN8CppSharp9CppParser3AST19HTMLStartTagComment10setTagNameEPKc")]
-                    internal static extern void SetTagName(global::System.IntPtr instance, [MarshalAs(UnmanagedType.LPStr)] string s);
-
-                    [SuppressUnmanagedCodeSecurity]
-                    [DllImport("CppSharp.CppParser", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
                         EntryPoint="_ZN8CppSharp9CppParser3AST19HTMLStartTagComment18getAttributesCountEv")]
                     internal static extern uint GetAttributesCount(global::System.IntPtr instance);
                 }
@@ -15997,10 +16041,10 @@ namespace CppSharp
                     public partial struct __Internal
                     {
                         [FieldOffset(0)]
-                        internal global::Std.BasicString.__Internal Name;
+                        internal global::Std.BasicString.__Internal name;
 
                         [FieldOffset(8)]
-                        internal global::Std.BasicString.__Internal Value;
+                        internal global::Std.BasicString.__Internal value;
 
                         [SuppressUnmanagedCodeSecurity]
                         [DllImport("CppSharp.CppParser", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
@@ -16016,26 +16060,6 @@ namespace CppSharp
                         [DllImport("CppSharp.CppParser", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
                             EntryPoint="_ZN8CppSharp9CppParser3AST19HTMLStartTagComment9AttributeD2Ev")]
                         internal static extern void dtor_0(global::System.IntPtr instance);
-
-                        [SuppressUnmanagedCodeSecurity]
-                        [DllImport("CppSharp.CppParser", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
-                            EntryPoint="_ZN8CppSharp9CppParser3AST19HTMLStartTagComment9Attribute7getNameEv")]
-                        internal static extern global::System.IntPtr GetName(global::System.IntPtr instance);
-
-                        [SuppressUnmanagedCodeSecurity]
-                        [DllImport("CppSharp.CppParser", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
-                            EntryPoint="_ZN8CppSharp9CppParser3AST19HTMLStartTagComment9Attribute7setNameEPKc")]
-                        internal static extern void SetName(global::System.IntPtr instance, [MarshalAs(UnmanagedType.LPStr)] string s);
-
-                        [SuppressUnmanagedCodeSecurity]
-                        [DllImport("CppSharp.CppParser", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
-                            EntryPoint="_ZN8CppSharp9CppParser3AST19HTMLStartTagComment9Attribute8getValueEv")]
-                        internal static extern global::System.IntPtr GetValue(global::System.IntPtr instance);
-
-                        [SuppressUnmanagedCodeSecurity]
-                        [DllImport("CppSharp.CppParser", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
-                            EntryPoint="_ZN8CppSharp9CppParser3AST19HTMLStartTagComment9Attribute8setValueEPKc")]
-                        internal static extern void SetValue(global::System.IntPtr instance, [MarshalAs(UnmanagedType.LPStr)] string s);
                     }
 
                     public global::System.IntPtr __Instance { get; protected set; }
@@ -16118,13 +16142,14 @@ namespace CppSharp
                     {
                         get
                         {
-                            var __ret = __Internal.GetName((__Instance + __PointerAdjustment));
-                            return Marshal.PtrToStringAnsi(__ret);
+                            return global::Std.BasicString.__CreateInstance(((global::CppSharp.Parser.AST.HTMLStartTagComment.Attribute.__Internal*) __Instance)->name).CStr();
                         }
 
                         set
                         {
-                            __Internal.SetName((__Instance + __PointerAdjustment), value);
+                            var __allocator0 = new global::Std.Allocator();
+                            var __basicString0 = new global::Std.BasicString(value, __allocator0);
+                            ((global::CppSharp.Parser.AST.HTMLStartTagComment.Attribute.__Internal*) __Instance)->name = *(global::Std.BasicString.__Internal*) __basicString0.__Instance;
                         }
                     }
 
@@ -16132,13 +16157,14 @@ namespace CppSharp
                     {
                         get
                         {
-                            var __ret = __Internal.GetValue((__Instance + __PointerAdjustment));
-                            return Marshal.PtrToStringAnsi(__ret);
+                            return global::Std.BasicString.__CreateInstance(((global::CppSharp.Parser.AST.HTMLStartTagComment.Attribute.__Internal*) __Instance)->value).CStr();
                         }
 
                         set
                         {
-                            __Internal.SetValue((__Instance + __PointerAdjustment), value);
+                            var __allocator0 = new global::Std.Allocator();
+                            var __basicString0 = new global::Std.BasicString(value, __allocator0);
+                            ((global::CppSharp.Parser.AST.HTMLStartTagComment.Attribute.__Internal*) __Instance)->value = *(global::Std.BasicString.__Internal*) __basicString0.__Instance;
                         }
                     }
                 }
@@ -16234,13 +16260,14 @@ namespace CppSharp
                 {
                     get
                     {
-                        var __ret = __Internal.GetTagName((__Instance + __PointerAdjustment));
-                        return Marshal.PtrToStringAnsi(__ret);
+                        return global::Std.BasicString.__CreateInstance(((global::CppSharp.Parser.AST.HTMLStartTagComment.__Internal*) __Instance)->tagName).CStr();
                     }
 
                     set
                     {
-                        __Internal.SetTagName((__Instance + __PointerAdjustment), value);
+                        var __allocator0 = new global::Std.Allocator();
+                        var __basicString0 = new global::Std.BasicString(value, __allocator0);
+                        ((global::CppSharp.Parser.AST.HTMLStartTagComment.__Internal*) __Instance)->tagName = *(global::Std.BasicString.__Internal*) __basicString0.__Instance;
                     }
                 }
 
@@ -16266,7 +16293,7 @@ namespace CppSharp
                     internal byte hasTrailingNewline;
 
                     [FieldOffset(8)]
-                    internal global::Std.BasicString.__Internal TagName;
+                    internal global::Std.BasicString.__Internal tagName;
 
                     [SuppressUnmanagedCodeSecurity]
                     [DllImport("CppSharp.CppParser", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
@@ -16282,16 +16309,6 @@ namespace CppSharp
                     [DllImport("CppSharp.CppParser", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
                         EntryPoint="_ZN8CppSharp9CppParser3AST17HTMLEndTagCommentD2Ev")]
                     internal static extern void dtor_0(global::System.IntPtr instance);
-
-                    [SuppressUnmanagedCodeSecurity]
-                    [DllImport("CppSharp.CppParser", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
-                        EntryPoint="_ZN8CppSharp9CppParser3AST17HTMLEndTagComment10getTagNameEv")]
-                    internal static extern global::System.IntPtr GetTagName(global::System.IntPtr instance);
-
-                    [SuppressUnmanagedCodeSecurity]
-                    [DllImport("CppSharp.CppParser", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
-                        EntryPoint="_ZN8CppSharp9CppParser3AST17HTMLEndTagComment10setTagNameEPKc")]
-                    internal static extern void SetTagName(global::System.IntPtr instance, [MarshalAs(UnmanagedType.LPStr)] string s);
                 }
 
                 internal static new global::CppSharp.Parser.AST.HTMLEndTagComment __CreateInstance(global::System.IntPtr native, bool skipVTables = false)
@@ -16365,13 +16382,14 @@ namespace CppSharp
                 {
                     get
                     {
-                        var __ret = __Internal.GetTagName((__Instance + __PointerAdjustment));
-                        return Marshal.PtrToStringAnsi(__ret);
+                        return global::Std.BasicString.__CreateInstance(((global::CppSharp.Parser.AST.HTMLEndTagComment.__Internal*) __Instance)->tagName).CStr();
                     }
 
                     set
                     {
-                        __Internal.SetTagName((__Instance + __PointerAdjustment), value);
+                        var __allocator0 = new global::Std.Allocator();
+                        var __basicString0 = new global::Std.BasicString(value, __allocator0);
+                        ((global::CppSharp.Parser.AST.HTMLEndTagComment.__Internal*) __Instance)->tagName = *(global::Std.BasicString.__Internal*) __basicString0.__Instance;
                     }
                 }
             }
@@ -16388,7 +16406,7 @@ namespace CppSharp
                     internal byte hasTrailingNewline;
 
                     [FieldOffset(8)]
-                    internal global::Std.BasicString.__Internal Text;
+                    internal global::Std.BasicString.__Internal text;
 
                     [SuppressUnmanagedCodeSecurity]
                     [DllImport("CppSharp.CppParser", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
@@ -16404,16 +16422,6 @@ namespace CppSharp
                     [DllImport("CppSharp.CppParser", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
                         EntryPoint="_ZN8CppSharp9CppParser3AST11TextCommentD2Ev")]
                     internal static extern void dtor_0(global::System.IntPtr instance);
-
-                    [SuppressUnmanagedCodeSecurity]
-                    [DllImport("CppSharp.CppParser", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
-                        EntryPoint="_ZN8CppSharp9CppParser3AST11TextComment7getTextEv")]
-                    internal static extern global::System.IntPtr GetText(global::System.IntPtr instance);
-
-                    [SuppressUnmanagedCodeSecurity]
-                    [DllImport("CppSharp.CppParser", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
-                        EntryPoint="_ZN8CppSharp9CppParser3AST11TextComment7setTextEPKc")]
-                    internal static extern void SetText(global::System.IntPtr instance, [MarshalAs(UnmanagedType.LPStr)] string s);
                 }
 
                 internal static new global::CppSharp.Parser.AST.TextComment __CreateInstance(global::System.IntPtr native, bool skipVTables = false)
@@ -16487,13 +16495,14 @@ namespace CppSharp
                 {
                     get
                     {
-                        var __ret = __Internal.GetText((__Instance + __PointerAdjustment));
-                        return Marshal.PtrToStringAnsi(__ret);
+                        return global::Std.BasicString.__CreateInstance(((global::CppSharp.Parser.AST.TextComment.__Internal*) __Instance)->text).CStr();
                     }
 
                     set
                     {
-                        __Internal.SetText((__Instance + __PointerAdjustment), value);
+                        var __allocator0 = new global::Std.Allocator();
+                        var __basicString0 = new global::Std.BasicString(value, __allocator0);
+                        ((global::CppSharp.Parser.AST.TextComment.__Internal*) __Instance)->text = *(global::Std.BasicString.__Internal*) __basicString0.__Instance;
                     }
                 }
             }
@@ -16507,10 +16516,10 @@ namespace CppSharp
                     internal global::CppSharp.Parser.AST.RawCommentKind kind;
 
                     [FieldOffset(8)]
-                    internal global::Std.BasicString.__Internal Text;
+                    internal global::Std.BasicString.__Internal text;
 
                     [FieldOffset(16)]
-                    internal global::Std.BasicString.__Internal BriefText;
+                    internal global::Std.BasicString.__Internal briefText;
 
                     [FieldOffset(24)]
                     internal global::System.IntPtr fullCommentBlock;
@@ -16529,26 +16538,6 @@ namespace CppSharp
                     [DllImport("CppSharp.CppParser", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
                         EntryPoint="_ZN8CppSharp9CppParser3AST10RawCommentD2Ev")]
                     internal static extern void dtor_0(global::System.IntPtr instance);
-
-                    [SuppressUnmanagedCodeSecurity]
-                    [DllImport("CppSharp.CppParser", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
-                        EntryPoint="_ZN8CppSharp9CppParser3AST10RawComment7getTextEv")]
-                    internal static extern global::System.IntPtr GetText(global::System.IntPtr instance);
-
-                    [SuppressUnmanagedCodeSecurity]
-                    [DllImport("CppSharp.CppParser", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
-                        EntryPoint="_ZN8CppSharp9CppParser3AST10RawComment7setTextEPKc")]
-                    internal static extern void SetText(global::System.IntPtr instance, [MarshalAs(UnmanagedType.LPStr)] string s);
-
-                    [SuppressUnmanagedCodeSecurity]
-                    [DllImport("CppSharp.CppParser", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
-                        EntryPoint="_ZN8CppSharp9CppParser3AST10RawComment12getBriefTextEv")]
-                    internal static extern global::System.IntPtr GetBriefText(global::System.IntPtr instance);
-
-                    [SuppressUnmanagedCodeSecurity]
-                    [DllImport("CppSharp.CppParser", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
-                        EntryPoint="_ZN8CppSharp9CppParser3AST10RawComment12setBriefTextEPKc")]
-                    internal static extern void SetBriefText(global::System.IntPtr instance, [MarshalAs(UnmanagedType.LPStr)] string s);
                 }
 
                 public global::System.IntPtr __Instance { get; protected set; }
@@ -16640,6 +16629,36 @@ namespace CppSharp
                     }
                 }
 
+                public string Text
+                {
+                    get
+                    {
+                        return global::Std.BasicString.__CreateInstance(((global::CppSharp.Parser.AST.RawComment.__Internal*) __Instance)->text).CStr();
+                    }
+
+                    set
+                    {
+                        var __allocator0 = new global::Std.Allocator();
+                        var __basicString0 = new global::Std.BasicString(value, __allocator0);
+                        ((global::CppSharp.Parser.AST.RawComment.__Internal*) __Instance)->text = *(global::Std.BasicString.__Internal*) __basicString0.__Instance;
+                    }
+                }
+
+                public string BriefText
+                {
+                    get
+                    {
+                        return global::Std.BasicString.__CreateInstance(((global::CppSharp.Parser.AST.RawComment.__Internal*) __Instance)->briefText).CStr();
+                    }
+
+                    set
+                    {
+                        var __allocator0 = new global::Std.Allocator();
+                        var __basicString0 = new global::Std.BasicString(value, __allocator0);
+                        ((global::CppSharp.Parser.AST.RawComment.__Internal*) __Instance)->briefText = *(global::Std.BasicString.__Internal*) __basicString0.__Instance;
+                    }
+                }
+
                 public global::CppSharp.Parser.AST.FullComment FullCommentBlock
                 {
                     get
@@ -16655,34 +16674,6 @@ namespace CppSharp
                     set
                     {
                         ((global::CppSharp.Parser.AST.RawComment.__Internal*) __Instance)->fullCommentBlock = ReferenceEquals(value, null) ? global::System.IntPtr.Zero : value.__Instance;
-                    }
-                }
-
-                public string Text
-                {
-                    get
-                    {
-                        var __ret = __Internal.GetText((__Instance + __PointerAdjustment));
-                        return Marshal.PtrToStringAnsi(__ret);
-                    }
-
-                    set
-                    {
-                        __Internal.SetText((__Instance + __PointerAdjustment), value);
-                    }
-                }
-
-                public string BriefText
-                {
-                    get
-                    {
-                        var __ret = __Internal.GetBriefText((__Instance + __PointerAdjustment));
-                        return Marshal.PtrToStringAnsi(__ret);
-                    }
-
-                    set
-                    {
-                        __Internal.SetBriefText((__Instance + __PointerAdjustment), value);
                     }
                 }
             }
@@ -16944,16 +16935,6 @@ namespace CppSharp
                 [DllImport("CppSharp.CppParser", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
                     EntryPoint="_ZN8CppSharp9CppParser16ParserTargetInfoD2Ev")]
                 internal static extern void dtor_0(global::System.IntPtr instance);
-
-                [SuppressUnmanagedCodeSecurity]
-                [DllImport("CppSharp.CppParser", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
-                    EntryPoint="_ZN8CppSharp9CppParser16ParserTargetInfo6getABIEv")]
-                internal static extern global::System.IntPtr GetABI(global::System.IntPtr instance);
-
-                [SuppressUnmanagedCodeSecurity]
-                [DllImport("CppSharp.CppParser", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
-                    EntryPoint="_ZN8CppSharp9CppParser16ParserTargetInfo6setABIEPKc")]
-                internal static extern void SetABI(global::System.IntPtr instance, [MarshalAs(UnmanagedType.LPStr)] string s);
             }
 
             public global::System.IntPtr __Instance { get; protected set; }
@@ -17030,6 +17011,21 @@ namespace CppSharp
                 if (__ownsNativeInstance)
                     Marshal.FreeHGlobal(__Instance);
                 __Instance = IntPtr.Zero;
+            }
+
+            public string ABI
+            {
+                get
+                {
+                    return global::Std.BasicString.__CreateInstance(((global::CppSharp.Parser.ParserTargetInfo.__Internal*) __Instance)->ABI).CStr();
+                }
+
+                set
+                {
+                    var __allocator0 = new global::Std.Allocator();
+                    var __basicString0 = new global::Std.BasicString(value, __allocator0);
+                    ((global::CppSharp.Parser.ParserTargetInfo.__Internal*) __Instance)->ABI = *(global::Std.BasicString.__Internal*) __basicString0.__Instance;
+                }
             }
 
             public global::CppSharp.Parser.ParserIntType Char16Type
@@ -17551,20 +17547,6 @@ namespace CppSharp
                     ((global::CppSharp.Parser.ParserTargetInfo.__Internal*) __Instance)->float128Width = value;
                 }
             }
-
-            public string ABI
-            {
-                get
-                {
-                    var __ret = __Internal.GetABI((__Instance + __PointerAdjustment));
-                    return Marshal.PtrToStringAnsi(__ret);
-                }
-
-                set
-                {
-                    __Internal.SetABI((__Instance + __PointerAdjustment), value);
-                }
-            }
         }
     }
 }
@@ -17670,7 +17652,7 @@ namespace CppSharp
                 internal global::Std.Vector.__Internal Arguments;
 
                 [FieldOffset(24)]
-                internal global::Std.BasicString.__Internal LibraryFile;
+                internal global::Std.BasicString.__Internal libraryFile;
 
                 [FieldOffset(32)]
                 internal global::Std.Vector.__Internal SourceFiles;
@@ -17697,7 +17679,7 @@ namespace CppSharp
                 internal int toolSetToUse;
 
                 [FieldOffset(192)]
-                internal global::Std.BasicString.__Internal TargetTriple;
+                internal global::Std.BasicString.__Internal targetTriple;
 
                 [FieldOffset(200)]
                 internal global::CppSharp.Parser.AST.CppAbi abi;
@@ -17839,26 +17821,6 @@ namespace CppSharp
                 [DllImport("CppSharp.CppParser", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
                     EntryPoint="_ZN8CppSharp9CppParser16CppParserOptions16clearLibraryDirsEv")]
                 internal static extern void ClearLibraryDirs_0(global::System.IntPtr instance);
-
-                [SuppressUnmanagedCodeSecurity]
-                [DllImport("CppSharp.CppParser", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
-                    EntryPoint="_ZN8CppSharp9CppParser16CppParserOptions14getLibraryFileEv")]
-                internal static extern global::System.IntPtr GetLibraryFile(global::System.IntPtr instance);
-
-                [SuppressUnmanagedCodeSecurity]
-                [DllImport("CppSharp.CppParser", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
-                    EntryPoint="_ZN8CppSharp9CppParser16CppParserOptions14setLibraryFileEPKc")]
-                internal static extern void SetLibraryFile(global::System.IntPtr instance, [MarshalAs(UnmanagedType.LPStr)] string s);
-
-                [SuppressUnmanagedCodeSecurity]
-                [DllImport("CppSharp.CppParser", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
-                    EntryPoint="_ZN8CppSharp9CppParser16CppParserOptions15getTargetTripleEv")]
-                internal static extern global::System.IntPtr GetTargetTriple(global::System.IntPtr instance);
-
-                [SuppressUnmanagedCodeSecurity]
-                [DllImport("CppSharp.CppParser", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
-                    EntryPoint="_ZN8CppSharp9CppParser16CppParserOptions15setTargetTripleEPKc")]
-                internal static extern void SetTargetTriple(global::System.IntPtr instance, [MarshalAs(UnmanagedType.LPStr)] string s);
 
                 [SuppressUnmanagedCodeSecurity]
                 [DllImport("CppSharp.CppParser", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
@@ -18084,6 +18046,21 @@ namespace CppSharp
                 __Internal.ClearLibraryDirs_0((__Instance + __PointerAdjustment));
             }
 
+            public string LibraryFile
+            {
+                get
+                {
+                    return global::Std.BasicString.__CreateInstance(((global::CppSharp.Parser.CppParserOptions.__Internal*) __Instance)->libraryFile).CStr();
+                }
+
+                set
+                {
+                    var __allocator0 = new global::Std.Allocator();
+                    var __basicString0 = new global::Std.BasicString(value, __allocator0);
+                    ((global::CppSharp.Parser.CppParserOptions.__Internal*) __Instance)->libraryFile = *(global::Std.BasicString.__Internal*) __basicString0.__Instance;
+                }
+            }
+
             public global::CppSharp.Parser.AST.ASTContext ASTContext
             {
                 get
@@ -18112,6 +18089,21 @@ namespace CppSharp
                 set
                 {
                     ((global::CppSharp.Parser.CppParserOptions.__Internal*) __Instance)->toolSetToUse = value;
+                }
+            }
+
+            public string TargetTriple
+            {
+                get
+                {
+                    return global::Std.BasicString.__CreateInstance(((global::CppSharp.Parser.CppParserOptions.__Internal*) __Instance)->targetTriple).CStr();
+                }
+
+                set
+                {
+                    var __allocator0 = new global::Std.Allocator();
+                    var __basicString0 = new global::Std.BasicString(value, __allocator0);
+                    ((global::CppSharp.Parser.CppParserOptions.__Internal*) __Instance)->targetTriple = *(global::Std.BasicString.__Internal*) __basicString0.__Instance;
                 }
             }
 
@@ -18211,34 +18203,6 @@ namespace CppSharp
                 }
             }
 
-            public string LibraryFile
-            {
-                get
-                {
-                    var __ret = __Internal.GetLibraryFile((__Instance + __PointerAdjustment));
-                    return Marshal.PtrToStringAnsi(__ret);
-                }
-
-                set
-                {
-                    __Internal.SetLibraryFile((__Instance + __PointerAdjustment), value);
-                }
-            }
-
-            public string TargetTriple
-            {
-                get
-                {
-                    var __ret = __Internal.GetTargetTriple((__Instance + __PointerAdjustment));
-                    return Marshal.PtrToStringAnsi(__ret);
-                }
-
-                set
-                {
-                    __Internal.SetTargetTriple((__Instance + __PointerAdjustment), value);
-                }
-            }
-
             public uint ArgumentsCount
             {
                 get
@@ -18309,10 +18273,10 @@ namespace CppSharp
             public partial struct __Internal
             {
                 [FieldOffset(0)]
-                internal global::Std.BasicString.__Internal FileName;
+                internal global::Std.BasicString.__Internal fileName;
 
                 [FieldOffset(8)]
-                internal global::Std.BasicString.__Internal Message;
+                internal global::Std.BasicString.__Internal message;
 
                 [FieldOffset(16)]
                 internal global::CppSharp.Parser.ParserDiagnosticLevel level;
@@ -18337,26 +18301,6 @@ namespace CppSharp
                 [DllImport("CppSharp.CppParser", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
                     EntryPoint="_ZN8CppSharp9CppParser16ParserDiagnosticD2Ev")]
                 internal static extern void dtor_0(global::System.IntPtr instance);
-
-                [SuppressUnmanagedCodeSecurity]
-                [DllImport("CppSharp.CppParser", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
-                    EntryPoint="_ZN8CppSharp9CppParser16ParserDiagnostic11getFileNameEv")]
-                internal static extern global::System.IntPtr GetFileName(global::System.IntPtr instance);
-
-                [SuppressUnmanagedCodeSecurity]
-                [DllImport("CppSharp.CppParser", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
-                    EntryPoint="_ZN8CppSharp9CppParser16ParserDiagnostic11setFileNameEPKc")]
-                internal static extern void SetFileName(global::System.IntPtr instance, [MarshalAs(UnmanagedType.LPStr)] string s);
-
-                [SuppressUnmanagedCodeSecurity]
-                [DllImport("CppSharp.CppParser", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
-                    EntryPoint="_ZN8CppSharp9CppParser16ParserDiagnostic10getMessageEv")]
-                internal static extern global::System.IntPtr GetMessage(global::System.IntPtr instance);
-
-                [SuppressUnmanagedCodeSecurity]
-                [DllImport("CppSharp.CppParser", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
-                    EntryPoint="_ZN8CppSharp9CppParser16ParserDiagnostic10setMessageEPKc")]
-                internal static extern void SetMessage(global::System.IntPtr instance, [MarshalAs(UnmanagedType.LPStr)] string s);
             }
 
             public global::System.IntPtr __Instance { get; protected set; }
@@ -18435,6 +18379,36 @@ namespace CppSharp
                 __Instance = IntPtr.Zero;
             }
 
+            public string FileName
+            {
+                get
+                {
+                    return global::Std.BasicString.__CreateInstance(((global::CppSharp.Parser.ParserDiagnostic.__Internal*) __Instance)->fileName).CStr();
+                }
+
+                set
+                {
+                    var __allocator0 = new global::Std.Allocator();
+                    var __basicString0 = new global::Std.BasicString(value, __allocator0);
+                    ((global::CppSharp.Parser.ParserDiagnostic.__Internal*) __Instance)->fileName = *(global::Std.BasicString.__Internal*) __basicString0.__Instance;
+                }
+            }
+
+            public string Message
+            {
+                get
+                {
+                    return global::Std.BasicString.__CreateInstance(((global::CppSharp.Parser.ParserDiagnostic.__Internal*) __Instance)->message).CStr();
+                }
+
+                set
+                {
+                    var __allocator0 = new global::Std.Allocator();
+                    var __basicString0 = new global::Std.BasicString(value, __allocator0);
+                    ((global::CppSharp.Parser.ParserDiagnostic.__Internal*) __Instance)->message = *(global::Std.BasicString.__Internal*) __basicString0.__Instance;
+                }
+            }
+
             public global::CppSharp.Parser.ParserDiagnosticLevel Level
             {
                 get
@@ -18471,34 +18445,6 @@ namespace CppSharp
                 set
                 {
                     ((global::CppSharp.Parser.ParserDiagnostic.__Internal*) __Instance)->columnNumber = value;
-                }
-            }
-
-            public string FileName
-            {
-                get
-                {
-                    var __ret = __Internal.GetFileName((__Instance + __PointerAdjustment));
-                    return Marshal.PtrToStringAnsi(__ret);
-                }
-
-                set
-                {
-                    __Internal.SetFileName((__Instance + __PointerAdjustment), value);
-                }
-            }
-
-            public string Message
-            {
-                get
-                {
-                    var __ret = __Internal.GetMessage((__Instance + __PointerAdjustment));
-                    return Marshal.PtrToStringAnsi(__ret);
-                }
-
-                set
-                {
-                    __Internal.SetMessage((__Instance + __PointerAdjustment), value);
                 }
             }
         }

--- a/src/CppParser/Bindings/CSharp/x86_64-linux-gnu/Std.cs
+++ b/src/CppParser/Bindings/CSharp/x86_64-linux-gnu/Std.cs
@@ -330,68 +330,6 @@ public unsafe partial class MbstateT
 
 namespace Std
 {
-    public unsafe partial class CharTraits : IDisposable
-    {
-        [StructLayout(LayoutKind.Explicit, Size = 0)]
-        public unsafe partial struct __Internal
-        {
-        }
-
-        public global::System.IntPtr __Instance { get; protected set; }
-
-        protected int __PointerAdjustment;
-        internal static readonly global::System.Collections.Concurrent.ConcurrentDictionary<IntPtr, global::Std.CharTraits> NativeToManagedMap = new global::System.Collections.Concurrent.ConcurrentDictionary<IntPtr, global::Std.CharTraits>();
-        protected void*[] __OriginalVTables;
-
-        protected bool __ownsNativeInstance;
-
-        internal static global::Std.CharTraits __CreateInstance(global::System.IntPtr native, bool skipVTables = false)
-        {
-            return new global::Std.CharTraits(native.ToPointer(), skipVTables);
-        }
-
-        internal static global::Std.CharTraits __CreateInstance(global::Std.CharTraits.__Internal native, bool skipVTables = false)
-        {
-            return new global::Std.CharTraits(native, skipVTables);
-        }
-
-        private static void* __CopyValue(global::Std.CharTraits.__Internal native)
-        {
-            var ret = Marshal.AllocHGlobal(sizeof(global::Std.CharTraits.__Internal));
-            *(global::Std.CharTraits.__Internal*) ret = native;
-            return ret.ToPointer();
-        }
-
-        private CharTraits(global::Std.CharTraits.__Internal native, bool skipVTables = false)
-            : this(__CopyValue(native), skipVTables)
-        {
-            __ownsNativeInstance = true;
-            NativeToManagedMap[__Instance] = this;
-        }
-
-        protected CharTraits(void* native, bool skipVTables = false)
-        {
-            if (native == null)
-                return;
-            __Instance = new global::System.IntPtr(native);
-        }
-
-        public void Dispose()
-        {
-            Dispose(disposing: true);
-        }
-
-        public virtual void Dispose(bool disposing)
-        {
-            if (__Instance == IntPtr.Zero)
-                return;
-            global::Std.CharTraits __dummy;
-            NativeToManagedMap.TryRemove(__Instance, out __dummy);
-            if (__ownsNativeInstance)
-                Marshal.FreeHGlobal(__Instance);
-            __Instance = IntPtr.Zero;
-        }
-    }
 }
 
 public unsafe partial class Timespec
@@ -624,6 +562,11 @@ namespace Std
 
             [SuppressUnmanagedCodeSecurity]
             [DllImport("Std-symbols", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
+                EntryPoint="_ZNSsC2EPKcRKSaIcE")]
+            internal static extern void ctorc__N_std_S_basic_string__C___N_std_S_char_traits__C___N_std_S_allocator__C_0(global::System.IntPtr instance, [MarshalAs(UnmanagedType.LPStr)] string __s, global::System.IntPtr __a);
+
+            [SuppressUnmanagedCodeSecurity]
+            [DllImport("Std-symbols", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
                 EntryPoint="_ZNSsD2Ev")]
             internal static extern void dtorc__N_std_S_basic_string__C___N_std_S_char_traits__C___N_std_S_allocator__C_0(global::System.IntPtr instance);
 
@@ -712,6 +655,17 @@ namespace Std
             if (native == null)
                 return;
             __Instance = new global::System.IntPtr(native);
+        }
+
+        public BasicString(string __s, global::Std.Allocator __a)
+        {
+            __Instance = Marshal.AllocHGlobal(sizeof(global::Std.BasicString.__Internal));
+            __ownsNativeInstance = true;
+            NativeToManagedMap[__Instance] = this;
+            if (ReferenceEquals(__a, null))
+                throw new global::System.ArgumentNullException("__a", "Cannot be null because it is a C++ reference (&).");
+            var __arg1 = ((global::Std.Allocator) (object) __a).__Instance;
+            global::Std.BasicString.__Internal.ctorc__N_std_S_basic_string__C___N_std_S_char_traits__C___N_std_S_allocator__C_0((__Instance + __PointerAdjustment), __s, __arg1);
         }
 
         public void Dispose()

--- a/src/CppParser/Bindings/CSharp/x86_64-pc-win32-msvc/CppSharp.CppParser.cs
+++ b/src/CppParser/Bindings/CSharp/x86_64-pc-win32-msvc/CppSharp.CppParser.cs
@@ -2589,7 +2589,7 @@ namespace CppSharp
                     internal global::CppSharp.Parser.AST.QualifiedType.__Internal qualifier;
 
                     [FieldOffset(24)]
-                    internal global::Std.BasicString.__Internal Identifier;
+                    internal global::Std.BasicString.__Internal identifier;
 
                     [SuppressUnmanagedCodeSecurity]
                     [DllImport("CppSharp.CppParser.dll", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
@@ -2605,16 +2605,6 @@ namespace CppSharp
                     [DllImport("CppSharp.CppParser.dll", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
                         EntryPoint="??1DependentNameType@AST@CppParser@CppSharp@@QEAA@XZ")]
                     internal static extern void dtor_0(global::System.IntPtr instance, int delete);
-
-                    [SuppressUnmanagedCodeSecurity]
-                    [DllImport("CppSharp.CppParser.dll", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
-                        EntryPoint="?getIdentifier@DependentNameType@AST@CppParser@CppSharp@@QEAAPEBDXZ")]
-                    internal static extern global::System.IntPtr GetIdentifier(global::System.IntPtr instance);
-
-                    [SuppressUnmanagedCodeSecurity]
-                    [DllImport("CppSharp.CppParser.dll", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
-                        EntryPoint="?setIdentifier@DependentNameType@AST@CppParser@CppSharp@@QEAAXPEBD@Z")]
-                    internal static extern void SetIdentifier(global::System.IntPtr instance, [MarshalAs(UnmanagedType.LPStr)] string s);
                 }
 
                 internal static new global::CppSharp.Parser.AST.DependentNameType __CreateInstance(global::System.IntPtr native, bool skipVTables = false)
@@ -2701,13 +2691,14 @@ namespace CppSharp
                 {
                     get
                     {
-                        var __ret = __Internal.GetIdentifier((__Instance + __PointerAdjustment));
-                        return Marshal.PtrToStringAnsi(__ret);
+                        return global::Std.BasicString.__CreateInstance(((global::CppSharp.Parser.AST.DependentNameType.__Internal*) __Instance)->identifier).CStr();
                     }
 
                     set
                     {
-                        __Internal.SetIdentifier((__Instance + __PointerAdjustment), value);
+                        var __allocator0 = new global::Std.Allocator();
+                        var __basicString0 = new global::Std.BasicString(value, __allocator0);
+                        ((global::CppSharp.Parser.AST.DependentNameType.__Internal*) __Instance)->identifier = *(global::Std.BasicString.__Internal*) __basicString0.__Instance;
                     }
                 }
             }
@@ -3562,7 +3553,7 @@ namespace CppSharp
                     internal uint offset;
 
                     [FieldOffset(8)]
-                    internal global::Std.BasicString.__Internal Name;
+                    internal global::Std.BasicString.__Internal name;
 
                     [FieldOffset(40)]
                     internal global::CppSharp.Parser.AST.QualifiedType.__Internal qualifiedType;
@@ -3584,16 +3575,6 @@ namespace CppSharp
                     [DllImport("CppSharp.CppParser.dll", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
                         EntryPoint="??1LayoutField@AST@CppParser@CppSharp@@QEAA@XZ")]
                     internal static extern void dtor_0(global::System.IntPtr instance, int delete);
-
-                    [SuppressUnmanagedCodeSecurity]
-                    [DllImport("CppSharp.CppParser.dll", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
-                        EntryPoint="?getName@LayoutField@AST@CppParser@CppSharp@@QEAAPEBDXZ")]
-                    internal static extern global::System.IntPtr GetName(global::System.IntPtr instance);
-
-                    [SuppressUnmanagedCodeSecurity]
-                    [DllImport("CppSharp.CppParser.dll", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
-                        EntryPoint="?setName@LayoutField@AST@CppParser@CppSharp@@QEAAXPEBD@Z")]
-                    internal static extern void SetName(global::System.IntPtr instance, [MarshalAs(UnmanagedType.LPStr)] string s);
                 }
 
                 public global::System.IntPtr __Instance { get; protected set; }
@@ -3685,6 +3666,21 @@ namespace CppSharp
                     }
                 }
 
+                public string Name
+                {
+                    get
+                    {
+                        return global::Std.BasicString.__CreateInstance(((global::CppSharp.Parser.AST.LayoutField.__Internal*) __Instance)->name).CStr();
+                    }
+
+                    set
+                    {
+                        var __allocator0 = new global::Std.Allocator();
+                        var __basicString0 = new global::Std.BasicString(value, __allocator0);
+                        ((global::CppSharp.Parser.AST.LayoutField.__Internal*) __Instance)->name = *(global::Std.BasicString.__Internal*) __basicString0.__Instance;
+                    }
+                }
+
                 public global::CppSharp.Parser.AST.QualifiedType QualifiedType
                 {
                     get
@@ -3708,20 +3704,6 @@ namespace CppSharp
                     set
                     {
                         ((global::CppSharp.Parser.AST.LayoutField.__Internal*) __Instance)->fieldPtr = (global::System.IntPtr) value;
-                    }
-                }
-
-                public string Name
-                {
-                    get
-                    {
-                        var __ret = __Internal.GetName((__Instance + __PointerAdjustment));
-                        return Marshal.PtrToStringAnsi(__ret);
-                    }
-
-                    set
-                    {
-                        __Internal.SetName((__Instance + __PointerAdjustment), value);
                     }
                 }
             }
@@ -4251,13 +4233,13 @@ namespace CppSharp
                     internal int lineNumberEnd;
 
                     [FieldOffset(32)]
-                    internal global::Std.BasicString.__Internal Name;
+                    internal global::Std.BasicString.__Internal name;
 
                     [FieldOffset(64)]
                     internal global::Std.BasicString.__Internal USR;
 
                     [FieldOffset(96)]
-                    internal global::Std.BasicString.__Internal DebugText;
+                    internal global::Std.BasicString.__Internal debugText;
 
                     [FieldOffset(128)]
                     internal byte isIncomplete;
@@ -4330,36 +4312,6 @@ namespace CppSharp
                     [DllImport("CppSharp.CppParser.dll", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
                         EntryPoint="?clearRedeclarations@Declaration@AST@CppParser@CppSharp@@QEAAXXZ")]
                     internal static extern void ClearRedeclarations_0(global::System.IntPtr instance);
-
-                    [SuppressUnmanagedCodeSecurity]
-                    [DllImport("CppSharp.CppParser.dll", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
-                        EntryPoint="?getName@Declaration@AST@CppParser@CppSharp@@QEAAPEBDXZ")]
-                    internal static extern global::System.IntPtr GetName(global::System.IntPtr instance);
-
-                    [SuppressUnmanagedCodeSecurity]
-                    [DllImport("CppSharp.CppParser.dll", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
-                        EntryPoint="?setName@Declaration@AST@CppParser@CppSharp@@QEAAXPEBD@Z")]
-                    internal static extern void SetName(global::System.IntPtr instance, [MarshalAs(UnmanagedType.LPStr)] string s);
-
-                    [SuppressUnmanagedCodeSecurity]
-                    [DllImport("CppSharp.CppParser.dll", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
-                        EntryPoint="?getUSR@Declaration@AST@CppParser@CppSharp@@QEAAPEBDXZ")]
-                    internal static extern global::System.IntPtr GetUSR(global::System.IntPtr instance);
-
-                    [SuppressUnmanagedCodeSecurity]
-                    [DllImport("CppSharp.CppParser.dll", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
-                        EntryPoint="?setUSR@Declaration@AST@CppParser@CppSharp@@QEAAXPEBD@Z")]
-                    internal static extern void SetUSR(global::System.IntPtr instance, [MarshalAs(UnmanagedType.LPStr)] string s);
-
-                    [SuppressUnmanagedCodeSecurity]
-                    [DllImport("CppSharp.CppParser.dll", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
-                        EntryPoint="?getDebugText@Declaration@AST@CppParser@CppSharp@@QEAAPEBDXZ")]
-                    internal static extern global::System.IntPtr GetDebugText(global::System.IntPtr instance);
-
-                    [SuppressUnmanagedCodeSecurity]
-                    [DllImport("CppSharp.CppParser.dll", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
-                        EntryPoint="?setDebugText@Declaration@AST@CppParser@CppSharp@@QEAAXPEBD@Z")]
-                    internal static extern void SetDebugText(global::System.IntPtr instance, [MarshalAs(UnmanagedType.LPStr)] string s);
 
                     [SuppressUnmanagedCodeSecurity]
                     [DllImport("CppSharp.CppParser.dll", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
@@ -4584,6 +4536,51 @@ namespace CppSharp
                     }
                 }
 
+                public string Name
+                {
+                    get
+                    {
+                        return global::Std.BasicString.__CreateInstance(((global::CppSharp.Parser.AST.Declaration.__Internal*) __Instance)->name).CStr();
+                    }
+
+                    set
+                    {
+                        var __allocator0 = new global::Std.Allocator();
+                        var __basicString0 = new global::Std.BasicString(value, __allocator0);
+                        ((global::CppSharp.Parser.AST.Declaration.__Internal*) __Instance)->name = *(global::Std.BasicString.__Internal*) __basicString0.__Instance;
+                    }
+                }
+
+                public string USR
+                {
+                    get
+                    {
+                        return global::Std.BasicString.__CreateInstance(((global::CppSharp.Parser.AST.Declaration.__Internal*) __Instance)->USR).CStr();
+                    }
+
+                    set
+                    {
+                        var __allocator0 = new global::Std.Allocator();
+                        var __basicString0 = new global::Std.BasicString(value, __allocator0);
+                        ((global::CppSharp.Parser.AST.Declaration.__Internal*) __Instance)->USR = *(global::Std.BasicString.__Internal*) __basicString0.__Instance;
+                    }
+                }
+
+                public string DebugText
+                {
+                    get
+                    {
+                        return global::Std.BasicString.__CreateInstance(((global::CppSharp.Parser.AST.Declaration.__Internal*) __Instance)->debugText).CStr();
+                    }
+
+                    set
+                    {
+                        var __allocator0 = new global::Std.Allocator();
+                        var __basicString0 = new global::Std.BasicString(value, __allocator0);
+                        ((global::CppSharp.Parser.AST.Declaration.__Internal*) __Instance)->debugText = *(global::Std.BasicString.__Internal*) __basicString0.__Instance;
+                    }
+                }
+
                 public bool IsIncomplete
                 {
                     get
@@ -4685,48 +4682,6 @@ namespace CppSharp
                     }
                 }
 
-                public string Name
-                {
-                    get
-                    {
-                        var __ret = __Internal.GetName((__Instance + __PointerAdjustment));
-                        return Marshal.PtrToStringAnsi(__ret);
-                    }
-
-                    set
-                    {
-                        __Internal.SetName((__Instance + __PointerAdjustment), value);
-                    }
-                }
-
-                public string USR
-                {
-                    get
-                    {
-                        var __ret = __Internal.GetUSR((__Instance + __PointerAdjustment));
-                        return Marshal.PtrToStringAnsi(__ret);
-                    }
-
-                    set
-                    {
-                        __Internal.SetUSR((__Instance + __PointerAdjustment), value);
-                    }
-                }
-
-                public string DebugText
-                {
-                    get
-                    {
-                        var __ret = __Internal.GetDebugText((__Instance + __PointerAdjustment));
-                        return Marshal.PtrToStringAnsi(__ret);
-                    }
-
-                    set
-                    {
-                        __Internal.SetDebugText((__Instance + __PointerAdjustment), value);
-                    }
-                }
-
                 public uint PreprocessedEntitiesCount
                 {
                     get
@@ -4770,13 +4725,13 @@ namespace CppSharp
                     internal int lineNumberEnd;
 
                     [FieldOffset(32)]
-                    internal global::Std.BasicString.__Internal Name;
+                    internal global::Std.BasicString.__Internal name;
 
                     [FieldOffset(64)]
                     internal global::Std.BasicString.__Internal USR;
 
                     [FieldOffset(96)]
-                    internal global::Std.BasicString.__Internal DebugText;
+                    internal global::Std.BasicString.__Internal debugText;
 
                     [FieldOffset(128)]
                     internal byte isIncomplete;
@@ -5441,13 +5396,13 @@ namespace CppSharp
                     internal int lineNumberEnd;
 
                     [FieldOffset(32)]
-                    internal global::Std.BasicString.__Internal Name;
+                    internal global::Std.BasicString.__Internal name;
 
                     [FieldOffset(64)]
                     internal global::Std.BasicString.__Internal USR;
 
                     [FieldOffset(96)]
-                    internal global::Std.BasicString.__Internal DebugText;
+                    internal global::Std.BasicString.__Internal debugText;
 
                     [FieldOffset(128)]
                     internal byte isIncomplete;
@@ -5605,13 +5560,13 @@ namespace CppSharp
                     internal int lineNumberEnd;
 
                     [FieldOffset(32)]
-                    internal global::Std.BasicString.__Internal Name;
+                    internal global::Std.BasicString.__Internal name;
 
                     [FieldOffset(64)]
                     internal global::Std.BasicString.__Internal USR;
 
                     [FieldOffset(96)]
-                    internal global::Std.BasicString.__Internal DebugText;
+                    internal global::Std.BasicString.__Internal debugText;
 
                     [FieldOffset(128)]
                     internal byte isIncomplete;
@@ -5751,13 +5706,13 @@ namespace CppSharp
                     internal int lineNumberEnd;
 
                     [FieldOffset(32)]
-                    internal global::Std.BasicString.__Internal Name;
+                    internal global::Std.BasicString.__Internal name;
 
                     [FieldOffset(64)]
                     internal global::Std.BasicString.__Internal USR;
 
                     [FieldOffset(96)]
-                    internal global::Std.BasicString.__Internal DebugText;
+                    internal global::Std.BasicString.__Internal debugText;
 
                     [FieldOffset(128)]
                     internal byte isIncomplete;
@@ -5918,13 +5873,13 @@ namespace CppSharp
                     internal int lineNumberEnd;
 
                     [FieldOffset(32)]
-                    internal global::Std.BasicString.__Internal Name;
+                    internal global::Std.BasicString.__Internal name;
 
                     [FieldOffset(64)]
                     internal global::Std.BasicString.__Internal USR;
 
                     [FieldOffset(96)]
-                    internal global::Std.BasicString.__Internal DebugText;
+                    internal global::Std.BasicString.__Internal debugText;
 
                     [FieldOffset(128)]
                     internal byte isIncomplete;
@@ -6070,27 +6025,22 @@ namespace CppSharp
                     internal global::System.IntPtr decl;
 
                     [FieldOffset(16)]
-                    internal global::Std.BasicString.__Internal String;
+                    internal global::Std.BasicString.__Internal @string;
+
+                    [SuppressUnmanagedCodeSecurity]
+                    [DllImport("CppSharp.CppParser.dll", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
+                        EntryPoint="??0Statement@AST@CppParser@CppSharp@@QEAA@AEBV?$basic_string@DU?$char_traits@D@std@@V?$allocator@D@2@@std@@W4StatementClass@123@PEAVDeclaration@123@@Z")]
+                    internal static extern global::System.IntPtr ctor_0(global::System.IntPtr instance, global::System.IntPtr str, global::CppSharp.Parser.AST.StatementClass Class, global::System.IntPtr decl);
 
                     [SuppressUnmanagedCodeSecurity]
                     [DllImport("CppSharp.CppParser.dll", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
                         EntryPoint="??0Statement@AST@CppParser@CppSharp@@QEAA@AEBV0123@@Z")]
-                    internal static extern global::System.IntPtr cctor_0(global::System.IntPtr instance, global::System.IntPtr _0);
+                    internal static extern global::System.IntPtr cctor_1(global::System.IntPtr instance, global::System.IntPtr _0);
 
                     [SuppressUnmanagedCodeSecurity]
                     [DllImport("CppSharp.CppParser.dll", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
                         EntryPoint="??1Statement@AST@CppParser@CppSharp@@QEAA@XZ")]
                     internal static extern void dtor_0(global::System.IntPtr instance, int delete);
-
-                    [SuppressUnmanagedCodeSecurity]
-                    [DllImport("CppSharp.CppParser.dll", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
-                        EntryPoint="?getString@Statement@AST@CppParser@CppSharp@@QEAAPEBDXZ")]
-                    internal static extern global::System.IntPtr GetString(global::System.IntPtr instance);
-
-                    [SuppressUnmanagedCodeSecurity]
-                    [DllImport("CppSharp.CppParser.dll", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
-                        EntryPoint="?setString@Statement@AST@CppParser@CppSharp@@QEAAXPEBD@Z")]
-                    internal static extern void SetString(global::System.IntPtr instance, [MarshalAs(UnmanagedType.LPStr)] string s);
                 }
 
                 public global::System.IntPtr __Instance { get; protected set; }
@@ -6114,7 +6064,7 @@ namespace CppSharp
                 private static void* __CopyValue(global::CppSharp.Parser.AST.Statement.__Internal native)
                 {
                     var ret = Marshal.AllocHGlobal(sizeof(global::CppSharp.Parser.AST.Statement.__Internal));
-                    global::CppSharp.Parser.AST.Statement.__Internal.cctor_0(ret, new global::System.IntPtr(&native));
+                    global::CppSharp.Parser.AST.Statement.__Internal.cctor_1(ret, new global::System.IntPtr(&native));
                     return ret.ToPointer();
                 }
 
@@ -6132,6 +6082,20 @@ namespace CppSharp
                     __Instance = new global::System.IntPtr(native);
                 }
 
+                public Statement(string str, global::CppSharp.Parser.AST.StatementClass Class, global::CppSharp.Parser.AST.Declaration decl)
+                {
+                    __Instance = Marshal.AllocHGlobal(sizeof(global::CppSharp.Parser.AST.Statement.__Internal));
+                    __ownsNativeInstance = true;
+                    NativeToManagedMap[__Instance] = this;
+                    var __allocator0 = new global::Std.Allocator();
+                    var __basicString0 = new global::Std.BasicString(str, __allocator0);
+                    var __arg0 = __basicString0.__Instance;
+                    var __arg2 = ReferenceEquals(decl, null) ? global::System.IntPtr.Zero : decl.__Instance;
+                    __Internal.ctor_0((__Instance + __PointerAdjustment), __arg0, Class, __arg2);
+                    __basicString0.Dispose(false);
+                    __allocator0.Dispose();
+                }
+
                 public Statement(global::CppSharp.Parser.AST.Statement _0)
                 {
                     __Instance = Marshal.AllocHGlobal(sizeof(global::CppSharp.Parser.AST.Statement.__Internal));
@@ -6140,7 +6104,7 @@ namespace CppSharp
                     if (ReferenceEquals(_0, null))
                         throw new global::System.ArgumentNullException("_0", "Cannot be null because it is a C++ reference (&).");
                     var __arg0 = _0.__Instance;
-                    __Internal.cctor_0((__Instance + __PointerAdjustment), __arg0);
+                    __Internal.cctor_1((__Instance + __PointerAdjustment), __arg0);
                 }
 
                 public void Dispose()
@@ -6196,13 +6160,14 @@ namespace CppSharp
                 {
                     get
                     {
-                        var __ret = __Internal.GetString((__Instance + __PointerAdjustment));
-                        return Marshal.PtrToStringAnsi(__ret);
+                        return global::Std.BasicString.__CreateInstance(((global::CppSharp.Parser.AST.Statement.__Internal*) __Instance)->@string).CStr();
                     }
 
                     set
                     {
-                        __Internal.SetString((__Instance + __PointerAdjustment), value);
+                        var __allocator0 = new global::Std.Allocator();
+                        var __basicString0 = new global::Std.BasicString(value, __allocator0);
+                        ((global::CppSharp.Parser.AST.Statement.__Internal*) __Instance)->@string = *(global::Std.BasicString.__Internal*) __basicString0.__Instance;
                     }
                 }
             }
@@ -6219,12 +6184,17 @@ namespace CppSharp
                     internal global::System.IntPtr decl;
 
                     [FieldOffset(16)]
-                    internal global::Std.BasicString.__Internal String;
+                    internal global::Std.BasicString.__Internal @string;
+
+                    [SuppressUnmanagedCodeSecurity]
+                    [DllImport("CppSharp.CppParser.dll", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
+                        EntryPoint="??0Expression@AST@CppParser@CppSharp@@QEAA@AEBV?$basic_string@DU?$char_traits@D@std@@V?$allocator@D@2@@std@@W4StatementClass@123@PEAVDeclaration@123@@Z")]
+                    internal static extern global::System.IntPtr ctor_0(global::System.IntPtr instance, global::System.IntPtr str, global::CppSharp.Parser.AST.StatementClass Class, global::System.IntPtr decl);
 
                     [SuppressUnmanagedCodeSecurity]
                     [DllImport("CppSharp.CppParser.dll", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
                         EntryPoint="??0Expression@AST@CppParser@CppSharp@@QEAA@AEBV0123@@Z")]
-                    internal static extern global::System.IntPtr cctor_0(global::System.IntPtr instance, global::System.IntPtr _0);
+                    internal static extern global::System.IntPtr cctor_1(global::System.IntPtr instance, global::System.IntPtr _0);
 
                     [SuppressUnmanagedCodeSecurity]
                     [DllImport("CppSharp.CppParser.dll", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
@@ -6245,7 +6215,7 @@ namespace CppSharp
                 private static void* __CopyValue(global::CppSharp.Parser.AST.Expression.__Internal native)
                 {
                     var ret = Marshal.AllocHGlobal(sizeof(global::CppSharp.Parser.AST.Expression.__Internal));
-                    global::CppSharp.Parser.AST.Expression.__Internal.cctor_0(ret, new global::System.IntPtr(&native));
+                    global::CppSharp.Parser.AST.Expression.__Internal.cctor_1(ret, new global::System.IntPtr(&native));
                     return ret.ToPointer();
                 }
 
@@ -6265,6 +6235,21 @@ namespace CppSharp
                     __Instance = new global::System.IntPtr(native);
                 }
 
+                public Expression(string str, global::CppSharp.Parser.AST.StatementClass Class, global::CppSharp.Parser.AST.Declaration decl)
+                    : this((void*) null)
+                {
+                    __Instance = Marshal.AllocHGlobal(sizeof(global::CppSharp.Parser.AST.Expression.__Internal));
+                    __ownsNativeInstance = true;
+                    NativeToManagedMap[__Instance] = this;
+                    var __allocator0 = new global::Std.Allocator();
+                    var __basicString0 = new global::Std.BasicString(str, __allocator0);
+                    var __arg0 = __basicString0.__Instance;
+                    var __arg2 = ReferenceEquals(decl, null) ? global::System.IntPtr.Zero : decl.__Instance;
+                    __Internal.ctor_0((__Instance + __PointerAdjustment), __arg0, Class, __arg2);
+                    __basicString0.Dispose(false);
+                    __allocator0.Dispose();
+                }
+
                 public Expression(global::CppSharp.Parser.AST.Expression _0)
                     : this((void*) null)
                 {
@@ -6274,7 +6259,7 @@ namespace CppSharp
                     if (ReferenceEquals(_0, null))
                         throw new global::System.ArgumentNullException("_0", "Cannot be null because it is a C++ reference (&).");
                     var __arg0 = _0.__Instance;
-                    __Internal.cctor_0((__Instance + __PointerAdjustment), __arg0);
+                    __Internal.cctor_1((__Instance + __PointerAdjustment), __arg0);
                 }
 
                 public override void Dispose(bool disposing)
@@ -6303,7 +6288,7 @@ namespace CppSharp
                     internal global::System.IntPtr decl;
 
                     [FieldOffset(16)]
-                    internal global::Std.BasicString.__Internal String;
+                    internal global::Std.BasicString.__Internal @string;
 
                     [FieldOffset(48)]
                     internal global::System.IntPtr LHS;
@@ -6312,27 +6297,22 @@ namespace CppSharp
                     internal global::System.IntPtr RHS;
 
                     [FieldOffset(64)]
-                    internal global::Std.BasicString.__Internal OpcodeStr;
+                    internal global::Std.BasicString.__Internal opcodeStr;
+
+                    [SuppressUnmanagedCodeSecurity]
+                    [DllImport("CppSharp.CppParser.dll", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
+                        EntryPoint="??0BinaryOperator@AST@CppParser@CppSharp@@QEAA@AEBV?$basic_string@DU?$char_traits@D@std@@V?$allocator@D@2@@std@@PEAVExpression@123@10@Z")]
+                    internal static extern global::System.IntPtr ctor_0(global::System.IntPtr instance, global::System.IntPtr str, global::System.IntPtr lhs, global::System.IntPtr rhs, global::System.IntPtr opcodeStr);
 
                     [SuppressUnmanagedCodeSecurity]
                     [DllImport("CppSharp.CppParser.dll", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
                         EntryPoint="??0BinaryOperator@AST@CppParser@CppSharp@@QEAA@AEBV0123@@Z")]
-                    internal static extern global::System.IntPtr cctor_0(global::System.IntPtr instance, global::System.IntPtr _0);
+                    internal static extern global::System.IntPtr cctor_1(global::System.IntPtr instance, global::System.IntPtr _0);
 
                     [SuppressUnmanagedCodeSecurity]
                     [DllImport("CppSharp.CppParser.dll", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
                         EntryPoint="??1BinaryOperator@AST@CppParser@CppSharp@@QEAA@XZ")]
                     internal static extern void dtor_0(global::System.IntPtr instance, int delete);
-
-                    [SuppressUnmanagedCodeSecurity]
-                    [DllImport("CppSharp.CppParser.dll", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
-                        EntryPoint="?getOpcodeStr@BinaryOperator@AST@CppParser@CppSharp@@QEAAPEBDXZ")]
-                    internal static extern global::System.IntPtr GetOpcodeStr(global::System.IntPtr instance);
-
-                    [SuppressUnmanagedCodeSecurity]
-                    [DllImport("CppSharp.CppParser.dll", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
-                        EntryPoint="?setOpcodeStr@BinaryOperator@AST@CppParser@CppSharp@@QEAAXPEBD@Z")]
-                    internal static extern void SetOpcodeStr(global::System.IntPtr instance, [MarshalAs(UnmanagedType.LPStr)] string s);
                 }
 
                 internal static new global::CppSharp.Parser.AST.BinaryOperator __CreateInstance(global::System.IntPtr native, bool skipVTables = false)
@@ -6348,7 +6328,7 @@ namespace CppSharp
                 private static void* __CopyValue(global::CppSharp.Parser.AST.BinaryOperator.__Internal native)
                 {
                     var ret = Marshal.AllocHGlobal(sizeof(global::CppSharp.Parser.AST.BinaryOperator.__Internal));
-                    global::CppSharp.Parser.AST.BinaryOperator.__Internal.cctor_0(ret, new global::System.IntPtr(&native));
+                    global::CppSharp.Parser.AST.BinaryOperator.__Internal.cctor_1(ret, new global::System.IntPtr(&native));
                     return ret.ToPointer();
                 }
 
@@ -6368,6 +6348,27 @@ namespace CppSharp
                     __Instance = new global::System.IntPtr(native);
                 }
 
+                public BinaryOperator(string str, global::CppSharp.Parser.AST.Expression lhs, global::CppSharp.Parser.AST.Expression rhs, string opcodeStr)
+                    : this((void*) null)
+                {
+                    __Instance = Marshal.AllocHGlobal(sizeof(global::CppSharp.Parser.AST.BinaryOperator.__Internal));
+                    __ownsNativeInstance = true;
+                    NativeToManagedMap[__Instance] = this;
+                    var __allocator0 = new global::Std.Allocator();
+                    var __basicString0 = new global::Std.BasicString(str, __allocator0);
+                    var __arg0 = __basicString0.__Instance;
+                    var __arg1 = ReferenceEquals(lhs, null) ? global::System.IntPtr.Zero : lhs.__Instance;
+                    var __arg2 = ReferenceEquals(rhs, null) ? global::System.IntPtr.Zero : rhs.__Instance;
+                    var __allocator3 = new global::Std.Allocator();
+                    var __basicString3 = new global::Std.BasicString(opcodeStr, __allocator3);
+                    var __arg3 = __basicString3.__Instance;
+                    __Internal.ctor_0((__Instance + __PointerAdjustment), __arg0, __arg1, __arg2, __arg3);
+                    __basicString0.Dispose(false);
+                    __allocator0.Dispose();
+                    __basicString3.Dispose(false);
+                    __allocator3.Dispose();
+                }
+
                 public BinaryOperator(global::CppSharp.Parser.AST.BinaryOperator _0)
                     : this((void*) null)
                 {
@@ -6377,7 +6378,7 @@ namespace CppSharp
                     if (ReferenceEquals(_0, null))
                         throw new global::System.ArgumentNullException("_0", "Cannot be null because it is a C++ reference (&).");
                     var __arg0 = _0.__Instance;
-                    __Internal.cctor_0((__Instance + __PointerAdjustment), __arg0);
+                    __Internal.cctor_1((__Instance + __PointerAdjustment), __arg0);
                 }
 
                 public override void Dispose(bool disposing)
@@ -6433,13 +6434,14 @@ namespace CppSharp
                 {
                     get
                     {
-                        var __ret = __Internal.GetOpcodeStr((__Instance + __PointerAdjustment));
-                        return Marshal.PtrToStringAnsi(__ret);
+                        return global::Std.BasicString.__CreateInstance(((global::CppSharp.Parser.AST.BinaryOperator.__Internal*) __Instance)->opcodeStr).CStr();
                     }
 
                     set
                     {
-                        __Internal.SetOpcodeStr((__Instance + __PointerAdjustment), value);
+                        var __allocator0 = new global::Std.Allocator();
+                        var __basicString0 = new global::Std.BasicString(value, __allocator0);
+                        ((global::CppSharp.Parser.AST.BinaryOperator.__Internal*) __Instance)->opcodeStr = *(global::Std.BasicString.__Internal*) __basicString0.__Instance;
                     }
                 }
             }
@@ -6456,15 +6458,20 @@ namespace CppSharp
                     internal global::System.IntPtr decl;
 
                     [FieldOffset(16)]
-                    internal global::Std.BasicString.__Internal String;
+                    internal global::Std.BasicString.__Internal @string;
 
                     [FieldOffset(48)]
                     internal global::Std.Vector.__Internal Arguments;
 
                     [SuppressUnmanagedCodeSecurity]
                     [DllImport("CppSharp.CppParser.dll", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
+                        EntryPoint="??0CallExpr@AST@CppParser@CppSharp@@QEAA@AEBV?$basic_string@DU?$char_traits@D@std@@V?$allocator@D@2@@std@@PEAVDeclaration@123@@Z")]
+                    internal static extern global::System.IntPtr ctor_0(global::System.IntPtr instance, global::System.IntPtr str, global::System.IntPtr decl);
+
+                    [SuppressUnmanagedCodeSecurity]
+                    [DllImport("CppSharp.CppParser.dll", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
                         EntryPoint="??0CallExpr@AST@CppParser@CppSharp@@QEAA@AEBV0123@@Z")]
-                    internal static extern global::System.IntPtr cctor_0(global::System.IntPtr instance, global::System.IntPtr _0);
+                    internal static extern global::System.IntPtr cctor_1(global::System.IntPtr instance, global::System.IntPtr _0);
 
                     [SuppressUnmanagedCodeSecurity]
                     [DllImport("CppSharp.CppParser.dll", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
@@ -6505,7 +6512,7 @@ namespace CppSharp
                 private static void* __CopyValue(global::CppSharp.Parser.AST.CallExpr.__Internal native)
                 {
                     var ret = Marshal.AllocHGlobal(sizeof(global::CppSharp.Parser.AST.CallExpr.__Internal));
-                    global::CppSharp.Parser.AST.CallExpr.__Internal.cctor_0(ret, new global::System.IntPtr(&native));
+                    global::CppSharp.Parser.AST.CallExpr.__Internal.cctor_1(ret, new global::System.IntPtr(&native));
                     return ret.ToPointer();
                 }
 
@@ -6525,6 +6532,21 @@ namespace CppSharp
                     __Instance = new global::System.IntPtr(native);
                 }
 
+                public CallExpr(string str, global::CppSharp.Parser.AST.Declaration decl)
+                    : this((void*) null)
+                {
+                    __Instance = Marshal.AllocHGlobal(sizeof(global::CppSharp.Parser.AST.CallExpr.__Internal));
+                    __ownsNativeInstance = true;
+                    NativeToManagedMap[__Instance] = this;
+                    var __allocator0 = new global::Std.Allocator();
+                    var __basicString0 = new global::Std.BasicString(str, __allocator0);
+                    var __arg0 = __basicString0.__Instance;
+                    var __arg1 = ReferenceEquals(decl, null) ? global::System.IntPtr.Zero : decl.__Instance;
+                    __Internal.ctor_0((__Instance + __PointerAdjustment), __arg0, __arg1);
+                    __basicString0.Dispose(false);
+                    __allocator0.Dispose();
+                }
+
                 public CallExpr(global::CppSharp.Parser.AST.CallExpr _0)
                     : this((void*) null)
                 {
@@ -6534,7 +6556,7 @@ namespace CppSharp
                     if (ReferenceEquals(_0, null))
                         throw new global::System.ArgumentNullException("_0", "Cannot be null because it is a C++ reference (&).");
                     var __arg0 = _0.__Instance;
-                    __Internal.cctor_0((__Instance + __PointerAdjustment), __arg0);
+                    __Internal.cctor_1((__Instance + __PointerAdjustment), __arg0);
                 }
 
                 public override void Dispose(bool disposing)
@@ -6596,15 +6618,20 @@ namespace CppSharp
                     internal global::System.IntPtr decl;
 
                     [FieldOffset(16)]
-                    internal global::Std.BasicString.__Internal String;
+                    internal global::Std.BasicString.__Internal @string;
 
                     [FieldOffset(48)]
                     internal global::Std.Vector.__Internal Arguments;
 
                     [SuppressUnmanagedCodeSecurity]
                     [DllImport("CppSharp.CppParser.dll", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
+                        EntryPoint="??0CXXConstructExpr@AST@CppParser@CppSharp@@QEAA@AEBV?$basic_string@DU?$char_traits@D@std@@V?$allocator@D@2@@std@@PEAVDeclaration@123@@Z")]
+                    internal static extern global::System.IntPtr ctor_0(global::System.IntPtr instance, global::System.IntPtr str, global::System.IntPtr decl);
+
+                    [SuppressUnmanagedCodeSecurity]
+                    [DllImport("CppSharp.CppParser.dll", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
                         EntryPoint="??0CXXConstructExpr@AST@CppParser@CppSharp@@QEAA@AEBV0123@@Z")]
-                    internal static extern global::System.IntPtr cctor_0(global::System.IntPtr instance, global::System.IntPtr _0);
+                    internal static extern global::System.IntPtr cctor_1(global::System.IntPtr instance, global::System.IntPtr _0);
 
                     [SuppressUnmanagedCodeSecurity]
                     [DllImport("CppSharp.CppParser.dll", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
@@ -6645,7 +6672,7 @@ namespace CppSharp
                 private static void* __CopyValue(global::CppSharp.Parser.AST.CXXConstructExpr.__Internal native)
                 {
                     var ret = Marshal.AllocHGlobal(sizeof(global::CppSharp.Parser.AST.CXXConstructExpr.__Internal));
-                    global::CppSharp.Parser.AST.CXXConstructExpr.__Internal.cctor_0(ret, new global::System.IntPtr(&native));
+                    global::CppSharp.Parser.AST.CXXConstructExpr.__Internal.cctor_1(ret, new global::System.IntPtr(&native));
                     return ret.ToPointer();
                 }
 
@@ -6665,6 +6692,21 @@ namespace CppSharp
                     __Instance = new global::System.IntPtr(native);
                 }
 
+                public CXXConstructExpr(string str, global::CppSharp.Parser.AST.Declaration decl)
+                    : this((void*) null)
+                {
+                    __Instance = Marshal.AllocHGlobal(sizeof(global::CppSharp.Parser.AST.CXXConstructExpr.__Internal));
+                    __ownsNativeInstance = true;
+                    NativeToManagedMap[__Instance] = this;
+                    var __allocator0 = new global::Std.Allocator();
+                    var __basicString0 = new global::Std.BasicString(str, __allocator0);
+                    var __arg0 = __basicString0.__Instance;
+                    var __arg1 = ReferenceEquals(decl, null) ? global::System.IntPtr.Zero : decl.__Instance;
+                    __Internal.ctor_0((__Instance + __PointerAdjustment), __arg0, __arg1);
+                    __basicString0.Dispose(false);
+                    __allocator0.Dispose();
+                }
+
                 public CXXConstructExpr(global::CppSharp.Parser.AST.CXXConstructExpr _0)
                     : this((void*) null)
                 {
@@ -6674,7 +6716,7 @@ namespace CppSharp
                     if (ReferenceEquals(_0, null))
                         throw new global::System.ArgumentNullException("_0", "Cannot be null because it is a C++ reference (&).");
                     var __arg0 = _0.__Instance;
-                    __Internal.cctor_0((__Instance + __PointerAdjustment), __arg0);
+                    __Internal.cctor_1((__Instance + __PointerAdjustment), __arg0);
                 }
 
                 public override void Dispose(bool disposing)
@@ -6748,13 +6790,13 @@ namespace CppSharp
                     internal int lineNumberEnd;
 
                     [FieldOffset(32)]
-                    internal global::Std.BasicString.__Internal Name;
+                    internal global::Std.BasicString.__Internal name;
 
                     [FieldOffset(64)]
                     internal global::Std.BasicString.__Internal USR;
 
                     [FieldOffset(96)]
-                    internal global::Std.BasicString.__Internal DebugText;
+                    internal global::Std.BasicString.__Internal debugText;
 
                     [FieldOffset(128)]
                     internal byte isIncomplete;
@@ -6976,13 +7018,13 @@ namespace CppSharp
                     internal int lineNumberEnd;
 
                     [FieldOffset(32)]
-                    internal global::Std.BasicString.__Internal Name;
+                    internal global::Std.BasicString.__Internal name;
 
                     [FieldOffset(64)]
                     internal global::Std.BasicString.__Internal USR;
 
                     [FieldOffset(96)]
-                    internal global::Std.BasicString.__Internal DebugText;
+                    internal global::Std.BasicString.__Internal debugText;
 
                     [FieldOffset(128)]
                     internal byte isIncomplete;
@@ -7042,13 +7084,13 @@ namespace CppSharp
                     internal global::CppSharp.Parser.AST.CXXOperatorKind operatorKind;
 
                     [FieldOffset(248)]
-                    internal global::Std.BasicString.__Internal Mangled;
+                    internal global::Std.BasicString.__Internal mangled;
 
                     [FieldOffset(280)]
-                    internal global::Std.BasicString.__Internal Signature;
+                    internal global::Std.BasicString.__Internal signature;
 
                     [FieldOffset(312)]
-                    internal global::Std.BasicString.__Internal Body;
+                    internal global::Std.BasicString.__Internal body;
 
                     [FieldOffset(344)]
                     internal global::CppSharp.Parser.AST.CallingConvention callingConvention;
@@ -7094,36 +7136,6 @@ namespace CppSharp
                     [DllImport("CppSharp.CppParser.dll", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
                         EntryPoint="?clearParameters@Function@AST@CppParser@CppSharp@@QEAAXXZ")]
                     internal static extern void ClearParameters_0(global::System.IntPtr instance);
-
-                    [SuppressUnmanagedCodeSecurity]
-                    [DllImport("CppSharp.CppParser.dll", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
-                        EntryPoint="?getMangled@Function@AST@CppParser@CppSharp@@QEAAPEBDXZ")]
-                    internal static extern global::System.IntPtr GetMangled(global::System.IntPtr instance);
-
-                    [SuppressUnmanagedCodeSecurity]
-                    [DllImport("CppSharp.CppParser.dll", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
-                        EntryPoint="?setMangled@Function@AST@CppParser@CppSharp@@QEAAXPEBD@Z")]
-                    internal static extern void SetMangled(global::System.IntPtr instance, [MarshalAs(UnmanagedType.LPStr)] string s);
-
-                    [SuppressUnmanagedCodeSecurity]
-                    [DllImport("CppSharp.CppParser.dll", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
-                        EntryPoint="?getSignature@Function@AST@CppParser@CppSharp@@QEAAPEBDXZ")]
-                    internal static extern global::System.IntPtr GetSignature(global::System.IntPtr instance);
-
-                    [SuppressUnmanagedCodeSecurity]
-                    [DllImport("CppSharp.CppParser.dll", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
-                        EntryPoint="?setSignature@Function@AST@CppParser@CppSharp@@QEAAXPEBD@Z")]
-                    internal static extern void SetSignature(global::System.IntPtr instance, [MarshalAs(UnmanagedType.LPStr)] string s);
-
-                    [SuppressUnmanagedCodeSecurity]
-                    [DllImport("CppSharp.CppParser.dll", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
-                        EntryPoint="?getBody@Function@AST@CppParser@CppSharp@@QEAAPEBDXZ")]
-                    internal static extern global::System.IntPtr GetBody(global::System.IntPtr instance);
-
-                    [SuppressUnmanagedCodeSecurity]
-                    [DllImport("CppSharp.CppParser.dll", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
-                        EntryPoint="?setBody@Function@AST@CppParser@CppSharp@@QEAAXPEBD@Z")]
-                    internal static extern void SetBody(global::System.IntPtr instance, [MarshalAs(UnmanagedType.LPStr)] string s);
 
                     [SuppressUnmanagedCodeSecurity]
                     [DllImport("CppSharp.CppParser.dll", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
@@ -7352,6 +7364,51 @@ namespace CppSharp
                     }
                 }
 
+                public string Mangled
+                {
+                    get
+                    {
+                        return global::Std.BasicString.__CreateInstance(((global::CppSharp.Parser.AST.Function.__Internal*) __Instance)->mangled).CStr();
+                    }
+
+                    set
+                    {
+                        var __allocator0 = new global::Std.Allocator();
+                        var __basicString0 = new global::Std.BasicString(value, __allocator0);
+                        ((global::CppSharp.Parser.AST.Function.__Internal*) __Instance)->mangled = *(global::Std.BasicString.__Internal*) __basicString0.__Instance;
+                    }
+                }
+
+                public string Signature
+                {
+                    get
+                    {
+                        return global::Std.BasicString.__CreateInstance(((global::CppSharp.Parser.AST.Function.__Internal*) __Instance)->signature).CStr();
+                    }
+
+                    set
+                    {
+                        var __allocator0 = new global::Std.Allocator();
+                        var __basicString0 = new global::Std.BasicString(value, __allocator0);
+                        ((global::CppSharp.Parser.AST.Function.__Internal*) __Instance)->signature = *(global::Std.BasicString.__Internal*) __basicString0.__Instance;
+                    }
+                }
+
+                public string Body
+                {
+                    get
+                    {
+                        return global::Std.BasicString.__CreateInstance(((global::CppSharp.Parser.AST.Function.__Internal*) __Instance)->body).CStr();
+                    }
+
+                    set
+                    {
+                        var __allocator0 = new global::Std.Allocator();
+                        var __basicString0 = new global::Std.BasicString(value, __allocator0);
+                        ((global::CppSharp.Parser.AST.Function.__Internal*) __Instance)->body = *(global::Std.BasicString.__Internal*) __basicString0.__Instance;
+                    }
+                }
+
                 public global::CppSharp.Parser.AST.CallingConvention CallingConvention
                 {
                     get
@@ -7414,48 +7471,6 @@ namespace CppSharp
                     }
                 }
 
-                public string Mangled
-                {
-                    get
-                    {
-                        var __ret = __Internal.GetMangled((__Instance + __PointerAdjustment));
-                        return Marshal.PtrToStringAnsi(__ret);
-                    }
-
-                    set
-                    {
-                        __Internal.SetMangled((__Instance + __PointerAdjustment), value);
-                    }
-                }
-
-                public string Signature
-                {
-                    get
-                    {
-                        var __ret = __Internal.GetSignature((__Instance + __PointerAdjustment));
-                        return Marshal.PtrToStringAnsi(__ret);
-                    }
-
-                    set
-                    {
-                        __Internal.SetSignature((__Instance + __PointerAdjustment), value);
-                    }
-                }
-
-                public string Body
-                {
-                    get
-                    {
-                        var __ret = __Internal.GetBody((__Instance + __PointerAdjustment));
-                        return Marshal.PtrToStringAnsi(__ret);
-                    }
-
-                    set
-                    {
-                        __Internal.SetBody((__Instance + __PointerAdjustment), value);
-                    }
-                }
-
                 public uint ParametersCount
                 {
                     get
@@ -7490,13 +7505,13 @@ namespace CppSharp
                     internal int lineNumberEnd;
 
                     [FieldOffset(32)]
-                    internal global::Std.BasicString.__Internal Name;
+                    internal global::Std.BasicString.__Internal name;
 
                     [FieldOffset(64)]
                     internal global::Std.BasicString.__Internal USR;
 
                     [FieldOffset(96)]
-                    internal global::Std.BasicString.__Internal DebugText;
+                    internal global::Std.BasicString.__Internal debugText;
 
                     [FieldOffset(128)]
                     internal byte isIncomplete;
@@ -7556,13 +7571,13 @@ namespace CppSharp
                     internal global::CppSharp.Parser.AST.CXXOperatorKind operatorKind;
 
                     [FieldOffset(248)]
-                    internal global::Std.BasicString.__Internal Mangled;
+                    internal global::Std.BasicString.__Internal mangled;
 
                     [FieldOffset(280)]
-                    internal global::Std.BasicString.__Internal Signature;
+                    internal global::Std.BasicString.__Internal signature;
 
                     [FieldOffset(312)]
-                    internal global::Std.BasicString.__Internal Body;
+                    internal global::Std.BasicString.__Internal body;
 
                     [FieldOffset(344)]
                     internal global::CppSharp.Parser.AST.CallingConvention callingConvention;
@@ -7863,13 +7878,13 @@ namespace CppSharp
                     internal int lineNumberEnd;
 
                     [FieldOffset(32)]
-                    internal global::Std.BasicString.__Internal Name;
+                    internal global::Std.BasicString.__Internal name;
 
                     [FieldOffset(64)]
                     internal global::Std.BasicString.__Internal USR;
 
                     [FieldOffset(96)]
-                    internal global::Std.BasicString.__Internal DebugText;
+                    internal global::Std.BasicString.__Internal debugText;
 
                     [FieldOffset(128)]
                     internal byte isIncomplete;
@@ -7975,6 +7990,11 @@ namespace CppSharp
 
                     [SuppressUnmanagedCodeSecurity]
                     [DllImport("CppSharp.CppParser.dll", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
+                        EntryPoint="?FindItemByName@Enumeration@AST@CppParser@CppSharp@@QEAAPEAVItem@1234@AEBV?$basic_string@DU?$char_traits@D@std@@V?$allocator@D@2@@std@@@Z")]
+                    internal static extern global::System.IntPtr FindItemByName_0(global::System.IntPtr instance, global::System.IntPtr Name);
+
+                    [SuppressUnmanagedCodeSecurity]
+                    [DllImport("CppSharp.CppParser.dll", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
                         EntryPoint="?getItemsCount@Enumeration@AST@CppParser@CppSharp@@QEAAIXZ")]
                     internal static extern uint GetItemsCount(global::System.IntPtr instance);
                 }
@@ -8011,13 +8031,13 @@ namespace CppSharp
                         internal int lineNumberEnd;
 
                         [FieldOffset(32)]
-                        internal global::Std.BasicString.__Internal Name;
+                        internal global::Std.BasicString.__Internal name;
 
                         [FieldOffset(64)]
                         internal global::Std.BasicString.__Internal USR;
 
                         [FieldOffset(96)]
-                        internal global::Std.BasicString.__Internal DebugText;
+                        internal global::Std.BasicString.__Internal debugText;
 
                         [FieldOffset(128)]
                         internal byte isIncomplete;
@@ -8047,7 +8067,7 @@ namespace CppSharp
                         internal global::System.IntPtr comment;
 
                         [FieldOffset(216)]
-                        internal global::Std.BasicString.__Internal Expression;
+                        internal global::Std.BasicString.__Internal expression;
 
                         [FieldOffset(248)]
                         internal ulong value;
@@ -8066,16 +8086,6 @@ namespace CppSharp
                         [DllImport("CppSharp.CppParser.dll", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
                             EntryPoint="??1Item@Enumeration@AST@CppParser@CppSharp@@QEAA@XZ")]
                         internal static extern void dtor_0(global::System.IntPtr instance, int delete);
-
-                        [SuppressUnmanagedCodeSecurity]
-                        [DllImport("CppSharp.CppParser.dll", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
-                            EntryPoint="?getExpression@Item@Enumeration@AST@CppParser@CppSharp@@QEAAPEBDXZ")]
-                        internal static extern global::System.IntPtr GetExpression(global::System.IntPtr instance);
-
-                        [SuppressUnmanagedCodeSecurity]
-                        [DllImport("CppSharp.CppParser.dll", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
-                            EntryPoint="?setExpression@Item@Enumeration@AST@CppParser@CppSharp@@QEAAXPEBD@Z")]
-                        internal static extern void SetExpression(global::System.IntPtr instance, [MarshalAs(UnmanagedType.LPStr)] string s);
                     }
 
                     internal static new global::CppSharp.Parser.AST.Enumeration.Item __CreateInstance(global::System.IntPtr native, bool skipVTables = false)
@@ -8145,6 +8155,21 @@ namespace CppSharp
                         __Instance = IntPtr.Zero;
                     }
 
+                    public string Expression
+                    {
+                        get
+                        {
+                            return global::Std.BasicString.__CreateInstance(((global::CppSharp.Parser.AST.Enumeration.Item.__Internal*) __Instance)->expression).CStr();
+                        }
+
+                        set
+                        {
+                            var __allocator0 = new global::Std.Allocator();
+                            var __basicString0 = new global::Std.BasicString(value, __allocator0);
+                            ((global::CppSharp.Parser.AST.Enumeration.Item.__Internal*) __Instance)->expression = *(global::Std.BasicString.__Internal*) __basicString0.__Instance;
+                        }
+                    }
+
                     public ulong Value
                     {
                         get
@@ -8155,20 +8180,6 @@ namespace CppSharp
                         set
                         {
                             ((global::CppSharp.Parser.AST.Enumeration.Item.__Internal*) __Instance)->value = value;
-                        }
-                    }
-
-                    public string Expression
-                    {
-                        get
-                        {
-                            var __ret = __Internal.GetExpression((__Instance + __PointerAdjustment));
-                            return Marshal.PtrToStringAnsi(__ret);
-                        }
-
-                        set
-                        {
-                            __Internal.SetExpression((__Instance + __PointerAdjustment), value);
                         }
                     }
                 }
@@ -8264,6 +8275,22 @@ namespace CppSharp
                     __Internal.ClearItems_0((__Instance + __PointerAdjustment));
                 }
 
+                public global::CppSharp.Parser.AST.Enumeration.Item FindItemByName(string Name)
+                {
+                    var __allocator0 = new global::Std.Allocator();
+                    var __basicString0 = new global::Std.BasicString(Name, __allocator0);
+                    var __arg0 = __basicString0.__Instance;
+                    var __ret = __Internal.FindItemByName_0((__Instance + __PointerAdjustment), __arg0);
+                    __basicString0.Dispose(false);
+                    __allocator0.Dispose();
+                    global::CppSharp.Parser.AST.Enumeration.Item __result0;
+                    if (__ret == IntPtr.Zero) __result0 = null;
+                    else if (global::CppSharp.Parser.AST.Enumeration.Item.NativeToManagedMap.ContainsKey(__ret))
+                        __result0 = (global::CppSharp.Parser.AST.Enumeration.Item) global::CppSharp.Parser.AST.Enumeration.Item.NativeToManagedMap[__ret];
+                    else __result0 = global::CppSharp.Parser.AST.Enumeration.Item.__CreateInstance(__ret);
+                    return __result0;
+                }
+
                 public global::CppSharp.Parser.AST.Enumeration.EnumModifiers Modifiers
                 {
                     get
@@ -8347,13 +8374,13 @@ namespace CppSharp
                     internal int lineNumberEnd;
 
                     [FieldOffset(32)]
-                    internal global::Std.BasicString.__Internal Name;
+                    internal global::Std.BasicString.__Internal name;
 
                     [FieldOffset(64)]
                     internal global::Std.BasicString.__Internal USR;
 
                     [FieldOffset(96)]
-                    internal global::Std.BasicString.__Internal DebugText;
+                    internal global::Std.BasicString.__Internal debugText;
 
                     [FieldOffset(128)]
                     internal byte isIncomplete;
@@ -8383,7 +8410,7 @@ namespace CppSharp
                     internal global::System.IntPtr comment;
 
                     [FieldOffset(216)]
-                    internal global::Std.BasicString.__Internal Mangled;
+                    internal global::Std.BasicString.__Internal mangled;
 
                     [FieldOffset(248)]
                     internal global::CppSharp.Parser.AST.QualifiedType.__Internal qualifiedType;
@@ -8402,16 +8429,6 @@ namespace CppSharp
                     [DllImport("CppSharp.CppParser.dll", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
                         EntryPoint="??1Variable@AST@CppParser@CppSharp@@QEAA@XZ")]
                     internal static extern void dtor_0(global::System.IntPtr instance, int delete);
-
-                    [SuppressUnmanagedCodeSecurity]
-                    [DllImport("CppSharp.CppParser.dll", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
-                        EntryPoint="?getMangled@Variable@AST@CppParser@CppSharp@@QEAAPEBDXZ")]
-                    internal static extern global::System.IntPtr GetMangled(global::System.IntPtr instance);
-
-                    [SuppressUnmanagedCodeSecurity]
-                    [DllImport("CppSharp.CppParser.dll", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
-                        EntryPoint="?setMangled@Variable@AST@CppParser@CppSharp@@QEAAXPEBD@Z")]
-                    internal static extern void SetMangled(global::System.IntPtr instance, [MarshalAs(UnmanagedType.LPStr)] string s);
                 }
 
                 internal static new global::CppSharp.Parser.AST.Variable __CreateInstance(global::System.IntPtr native, bool skipVTables = false)
@@ -8481,6 +8498,21 @@ namespace CppSharp
                     __Instance = IntPtr.Zero;
                 }
 
+                public string Mangled
+                {
+                    get
+                    {
+                        return global::Std.BasicString.__CreateInstance(((global::CppSharp.Parser.AST.Variable.__Internal*) __Instance)->mangled).CStr();
+                    }
+
+                    set
+                    {
+                        var __allocator0 = new global::Std.Allocator();
+                        var __basicString0 = new global::Std.BasicString(value, __allocator0);
+                        ((global::CppSharp.Parser.AST.Variable.__Internal*) __Instance)->mangled = *(global::Std.BasicString.__Internal*) __basicString0.__Instance;
+                    }
+                }
+
                 public global::CppSharp.Parser.AST.QualifiedType QualifiedType
                 {
                     get
@@ -8491,20 +8523,6 @@ namespace CppSharp
                     set
                     {
                         ((global::CppSharp.Parser.AST.Variable.__Internal*) __Instance)->qualifiedType = ReferenceEquals(value, null) ? new global::CppSharp.Parser.AST.QualifiedType.__Internal() : *(global::CppSharp.Parser.AST.QualifiedType.__Internal*) value.__Instance;
-                    }
-                }
-
-                public string Mangled
-                {
-                    get
-                    {
-                        var __ret = __Internal.GetMangled((__Instance + __PointerAdjustment));
-                        return Marshal.PtrToStringAnsi(__ret);
-                    }
-
-                    set
-                    {
-                        __Internal.SetMangled((__Instance + __PointerAdjustment), value);
                     }
                 }
             }
@@ -8690,13 +8708,13 @@ namespace CppSharp
                     internal int lineNumberEnd;
 
                     [FieldOffset(32)]
-                    internal global::Std.BasicString.__Internal Name;
+                    internal global::Std.BasicString.__Internal name;
 
                     [FieldOffset(64)]
                     internal global::Std.BasicString.__Internal USR;
 
                     [FieldOffset(96)]
-                    internal global::Std.BasicString.__Internal DebugText;
+                    internal global::Std.BasicString.__Internal debugText;
 
                     [FieldOffset(128)]
                     internal byte isIncomplete;
@@ -8902,13 +8920,13 @@ namespace CppSharp
                     internal int lineNumberEnd;
 
                     [FieldOffset(32)]
-                    internal global::Std.BasicString.__Internal Name;
+                    internal global::Std.BasicString.__Internal name;
 
                     [FieldOffset(64)]
                     internal global::Std.BasicString.__Internal USR;
 
                     [FieldOffset(96)]
-                    internal global::Std.BasicString.__Internal DebugText;
+                    internal global::Std.BasicString.__Internal debugText;
 
                     [FieldOffset(128)]
                     internal byte isIncomplete;
@@ -9045,13 +9063,13 @@ namespace CppSharp
                     internal int lineNumberEnd;
 
                     [FieldOffset(32)]
-                    internal global::Std.BasicString.__Internal Name;
+                    internal global::Std.BasicString.__Internal name;
 
                     [FieldOffset(64)]
                     internal global::Std.BasicString.__Internal USR;
 
                     [FieldOffset(96)]
-                    internal global::Std.BasicString.__Internal DebugText;
+                    internal global::Std.BasicString.__Internal debugText;
 
                     [FieldOffset(128)]
                     internal byte isIncomplete;
@@ -9626,13 +9644,13 @@ namespace CppSharp
                     internal int lineNumberEnd;
 
                     [FieldOffset(32)]
-                    internal global::Std.BasicString.__Internal Name;
+                    internal global::Std.BasicString.__Internal name;
 
                     [FieldOffset(64)]
                     internal global::Std.BasicString.__Internal USR;
 
                     [FieldOffset(96)]
-                    internal global::Std.BasicString.__Internal DebugText;
+                    internal global::Std.BasicString.__Internal debugText;
 
                     [FieldOffset(128)]
                     internal byte isIncomplete;
@@ -9865,13 +9883,13 @@ namespace CppSharp
                     internal int lineNumberEnd;
 
                     [FieldOffset(32)]
-                    internal global::Std.BasicString.__Internal Name;
+                    internal global::Std.BasicString.__Internal name;
 
                     [FieldOffset(64)]
                     internal global::Std.BasicString.__Internal USR;
 
                     [FieldOffset(96)]
-                    internal global::Std.BasicString.__Internal DebugText;
+                    internal global::Std.BasicString.__Internal debugText;
 
                     [FieldOffset(128)]
                     internal byte isIncomplete;
@@ -10014,13 +10032,13 @@ namespace CppSharp
                     internal int lineNumberEnd;
 
                     [FieldOffset(32)]
-                    internal global::Std.BasicString.__Internal Name;
+                    internal global::Std.BasicString.__Internal name;
 
                     [FieldOffset(64)]
                     internal global::Std.BasicString.__Internal USR;
 
                     [FieldOffset(96)]
-                    internal global::Std.BasicString.__Internal DebugText;
+                    internal global::Std.BasicString.__Internal debugText;
 
                     [FieldOffset(128)]
                     internal byte isIncomplete;
@@ -10210,13 +10228,13 @@ namespace CppSharp
                     internal int lineNumberEnd;
 
                     [FieldOffset(32)]
-                    internal global::Std.BasicString.__Internal Name;
+                    internal global::Std.BasicString.__Internal name;
 
                     [FieldOffset(64)]
                     internal global::Std.BasicString.__Internal USR;
 
                     [FieldOffset(96)]
-                    internal global::Std.BasicString.__Internal DebugText;
+                    internal global::Std.BasicString.__Internal debugText;
 
                     [FieldOffset(128)]
                     internal byte isIncomplete;
@@ -10407,13 +10425,13 @@ namespace CppSharp
                     internal int lineNumberEnd;
 
                     [FieldOffset(32)]
-                    internal global::Std.BasicString.__Internal Name;
+                    internal global::Std.BasicString.__Internal name;
 
                     [FieldOffset(64)]
                     internal global::Std.BasicString.__Internal USR;
 
                     [FieldOffset(96)]
-                    internal global::Std.BasicString.__Internal DebugText;
+                    internal global::Std.BasicString.__Internal debugText;
 
                     [FieldOffset(128)]
                     internal byte isIncomplete;
@@ -10575,13 +10593,13 @@ namespace CppSharp
                     internal int lineNumberEnd;
 
                     [FieldOffset(32)]
-                    internal global::Std.BasicString.__Internal Name;
+                    internal global::Std.BasicString.__Internal name;
 
                     [FieldOffset(64)]
                     internal global::Std.BasicString.__Internal USR;
 
                     [FieldOffset(96)]
-                    internal global::Std.BasicString.__Internal DebugText;
+                    internal global::Std.BasicString.__Internal debugText;
 
                     [FieldOffset(128)]
                     internal byte isIncomplete;
@@ -10796,13 +10814,13 @@ namespace CppSharp
                     internal int lineNumberEnd;
 
                     [FieldOffset(32)]
-                    internal global::Std.BasicString.__Internal Name;
+                    internal global::Std.BasicString.__Internal name;
 
                     [FieldOffset(64)]
                     internal global::Std.BasicString.__Internal USR;
 
                     [FieldOffset(96)]
-                    internal global::Std.BasicString.__Internal DebugText;
+                    internal global::Std.BasicString.__Internal debugText;
 
                     [FieldOffset(128)]
                     internal byte isIncomplete;
@@ -10869,6 +10887,16 @@ namespace CppSharp
                     [DllImport("CppSharp.CppParser.dll", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
                         EntryPoint="?clearSpecializations@ClassTemplate@AST@CppParser@CppSharp@@QEAAXXZ")]
                     internal static extern void ClearSpecializations_0(global::System.IntPtr instance);
+
+                    [SuppressUnmanagedCodeSecurity]
+                    [DllImport("CppSharp.CppParser.dll", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
+                        EntryPoint="?FindSpecialization@ClassTemplate@AST@CppParser@CppSharp@@QEAAPEAVClassTemplateSpecialization@234@AEBV?$basic_string@DU?$char_traits@D@std@@V?$allocator@D@2@@std@@@Z")]
+                    internal static extern global::System.IntPtr FindSpecialization_0(global::System.IntPtr instance, global::System.IntPtr usr);
+
+                    [SuppressUnmanagedCodeSecurity]
+                    [DllImport("CppSharp.CppParser.dll", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
+                        EntryPoint="?FindPartialSpecialization@ClassTemplate@AST@CppParser@CppSharp@@QEAAPEAVClassTemplatePartialSpecialization@234@AEBV?$basic_string@DU?$char_traits@D@std@@V?$allocator@D@2@@std@@@Z")]
+                    internal static extern global::System.IntPtr FindPartialSpecialization_0(global::System.IntPtr instance, global::System.IntPtr usr);
 
                     [SuppressUnmanagedCodeSecurity]
                     [DllImport("CppSharp.CppParser.dll", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
@@ -10967,6 +10995,38 @@ namespace CppSharp
                     __Internal.ClearSpecializations_0((__Instance + __PointerAdjustment));
                 }
 
+                public global::CppSharp.Parser.AST.ClassTemplateSpecialization FindSpecialization(string usr)
+                {
+                    var __allocator0 = new global::Std.Allocator();
+                    var __basicString0 = new global::Std.BasicString(usr, __allocator0);
+                    var __arg0 = __basicString0.__Instance;
+                    var __ret = __Internal.FindSpecialization_0((__Instance + __PointerAdjustment), __arg0);
+                    __basicString0.Dispose(false);
+                    __allocator0.Dispose();
+                    global::CppSharp.Parser.AST.ClassTemplateSpecialization __result0;
+                    if (__ret == IntPtr.Zero) __result0 = null;
+                    else if (global::CppSharp.Parser.AST.ClassTemplateSpecialization.NativeToManagedMap.ContainsKey(__ret))
+                        __result0 = (global::CppSharp.Parser.AST.ClassTemplateSpecialization) global::CppSharp.Parser.AST.ClassTemplateSpecialization.NativeToManagedMap[__ret];
+                    else __result0 = global::CppSharp.Parser.AST.ClassTemplateSpecialization.__CreateInstance(__ret);
+                    return __result0;
+                }
+
+                public global::CppSharp.Parser.AST.ClassTemplatePartialSpecialization FindPartialSpecialization(string usr)
+                {
+                    var __allocator0 = new global::Std.Allocator();
+                    var __basicString0 = new global::Std.BasicString(usr, __allocator0);
+                    var __arg0 = __basicString0.__Instance;
+                    var __ret = __Internal.FindPartialSpecialization_0((__Instance + __PointerAdjustment), __arg0);
+                    __basicString0.Dispose(false);
+                    __allocator0.Dispose();
+                    global::CppSharp.Parser.AST.ClassTemplatePartialSpecialization __result0;
+                    if (__ret == IntPtr.Zero) __result0 = null;
+                    else if (global::CppSharp.Parser.AST.ClassTemplatePartialSpecialization.NativeToManagedMap.ContainsKey(__ret))
+                        __result0 = (global::CppSharp.Parser.AST.ClassTemplatePartialSpecialization) global::CppSharp.Parser.AST.ClassTemplatePartialSpecialization.NativeToManagedMap[__ret];
+                    else __result0 = global::CppSharp.Parser.AST.ClassTemplatePartialSpecialization.__CreateInstance(__ret);
+                    return __result0;
+                }
+
                 public uint SpecializationsCount
                 {
                     get
@@ -11001,13 +11061,13 @@ namespace CppSharp
                     internal int lineNumberEnd;
 
                     [FieldOffset(32)]
-                    internal global::Std.BasicString.__Internal Name;
+                    internal global::Std.BasicString.__Internal name;
 
                     [FieldOffset(64)]
                     internal global::Std.BasicString.__Internal USR;
 
                     [FieldOffset(96)]
-                    internal global::Std.BasicString.__Internal DebugText;
+                    internal global::Std.BasicString.__Internal debugText;
 
                     [FieldOffset(128)]
                     internal byte isIncomplete;
@@ -11311,13 +11371,13 @@ namespace CppSharp
                     internal int lineNumberEnd;
 
                     [FieldOffset(32)]
-                    internal global::Std.BasicString.__Internal Name;
+                    internal global::Std.BasicString.__Internal name;
 
                     [FieldOffset(64)]
                     internal global::Std.BasicString.__Internal USR;
 
                     [FieldOffset(96)]
-                    internal global::Std.BasicString.__Internal DebugText;
+                    internal global::Std.BasicString.__Internal debugText;
 
                     [FieldOffset(128)]
                     internal byte isIncomplete;
@@ -11541,13 +11601,13 @@ namespace CppSharp
                     internal int lineNumberEnd;
 
                     [FieldOffset(32)]
-                    internal global::Std.BasicString.__Internal Name;
+                    internal global::Std.BasicString.__Internal name;
 
                     [FieldOffset(64)]
                     internal global::Std.BasicString.__Internal USR;
 
                     [FieldOffset(96)]
-                    internal global::Std.BasicString.__Internal DebugText;
+                    internal global::Std.BasicString.__Internal debugText;
 
                     [FieldOffset(128)]
                     internal byte isIncomplete;
@@ -11614,6 +11674,11 @@ namespace CppSharp
                     [DllImport("CppSharp.CppParser.dll", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
                         EntryPoint="?clearSpecializations@FunctionTemplate@AST@CppParser@CppSharp@@QEAAXXZ")]
                     internal static extern void ClearSpecializations_0(global::System.IntPtr instance);
+
+                    [SuppressUnmanagedCodeSecurity]
+                    [DllImport("CppSharp.CppParser.dll", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
+                        EntryPoint="?FindSpecialization@FunctionTemplate@AST@CppParser@CppSharp@@QEAAPEAVFunctionTemplateSpecialization@234@AEBV?$basic_string@DU?$char_traits@D@std@@V?$allocator@D@2@@std@@@Z")]
+                    internal static extern global::System.IntPtr FindSpecialization_0(global::System.IntPtr instance, global::System.IntPtr usr);
 
                     [SuppressUnmanagedCodeSecurity]
                     [DllImport("CppSharp.CppParser.dll", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
@@ -11710,6 +11775,22 @@ namespace CppSharp
                 public void ClearSpecializations()
                 {
                     __Internal.ClearSpecializations_0((__Instance + __PointerAdjustment));
+                }
+
+                public global::CppSharp.Parser.AST.FunctionTemplateSpecialization FindSpecialization(string usr)
+                {
+                    var __allocator0 = new global::Std.Allocator();
+                    var __basicString0 = new global::Std.BasicString(usr, __allocator0);
+                    var __arg0 = __basicString0.__Instance;
+                    var __ret = __Internal.FindSpecialization_0((__Instance + __PointerAdjustment), __arg0);
+                    __basicString0.Dispose(false);
+                    __allocator0.Dispose();
+                    global::CppSharp.Parser.AST.FunctionTemplateSpecialization __result0;
+                    if (__ret == IntPtr.Zero) __result0 = null;
+                    else if (global::CppSharp.Parser.AST.FunctionTemplateSpecialization.NativeToManagedMap.ContainsKey(__ret))
+                        __result0 = (global::CppSharp.Parser.AST.FunctionTemplateSpecialization) global::CppSharp.Parser.AST.FunctionTemplateSpecialization.NativeToManagedMap[__ret];
+                    else __result0 = global::CppSharp.Parser.AST.FunctionTemplateSpecialization.__CreateInstance(__ret);
+                    return __result0;
                 }
 
                 public uint SpecializationsCount
@@ -11954,13 +12035,13 @@ namespace CppSharp
                     internal int lineNumberEnd;
 
                     [FieldOffset(32)]
-                    internal global::Std.BasicString.__Internal Name;
+                    internal global::Std.BasicString.__Internal name;
 
                     [FieldOffset(64)]
                     internal global::Std.BasicString.__Internal USR;
 
                     [FieldOffset(96)]
-                    internal global::Std.BasicString.__Internal DebugText;
+                    internal global::Std.BasicString.__Internal debugText;
 
                     [FieldOffset(128)]
                     internal byte isIncomplete;
@@ -12027,6 +12108,16 @@ namespace CppSharp
                     [DllImport("CppSharp.CppParser.dll", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
                         EntryPoint="?clearSpecializations@VarTemplate@AST@CppParser@CppSharp@@QEAAXXZ")]
                     internal static extern void ClearSpecializations_0(global::System.IntPtr instance);
+
+                    [SuppressUnmanagedCodeSecurity]
+                    [DllImport("CppSharp.CppParser.dll", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
+                        EntryPoint="?FindSpecialization@VarTemplate@AST@CppParser@CppSharp@@QEAAPEAVVarTemplateSpecialization@234@AEBV?$basic_string@DU?$char_traits@D@std@@V?$allocator@D@2@@std@@@Z")]
+                    internal static extern global::System.IntPtr FindSpecialization_0(global::System.IntPtr instance, global::System.IntPtr usr);
+
+                    [SuppressUnmanagedCodeSecurity]
+                    [DllImport("CppSharp.CppParser.dll", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
+                        EntryPoint="?FindPartialSpecialization@VarTemplate@AST@CppParser@CppSharp@@QEAAPEAVVarTemplatePartialSpecialization@234@AEBV?$basic_string@DU?$char_traits@D@std@@V?$allocator@D@2@@std@@@Z")]
+                    internal static extern global::System.IntPtr FindPartialSpecialization_0(global::System.IntPtr instance, global::System.IntPtr usr);
 
                     [SuppressUnmanagedCodeSecurity]
                     [DllImport("CppSharp.CppParser.dll", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
@@ -12125,6 +12216,38 @@ namespace CppSharp
                     __Internal.ClearSpecializations_0((__Instance + __PointerAdjustment));
                 }
 
+                public global::CppSharp.Parser.AST.VarTemplateSpecialization FindSpecialization(string usr)
+                {
+                    var __allocator0 = new global::Std.Allocator();
+                    var __basicString0 = new global::Std.BasicString(usr, __allocator0);
+                    var __arg0 = __basicString0.__Instance;
+                    var __ret = __Internal.FindSpecialization_0((__Instance + __PointerAdjustment), __arg0);
+                    __basicString0.Dispose(false);
+                    __allocator0.Dispose();
+                    global::CppSharp.Parser.AST.VarTemplateSpecialization __result0;
+                    if (__ret == IntPtr.Zero) __result0 = null;
+                    else if (global::CppSharp.Parser.AST.VarTemplateSpecialization.NativeToManagedMap.ContainsKey(__ret))
+                        __result0 = (global::CppSharp.Parser.AST.VarTemplateSpecialization) global::CppSharp.Parser.AST.VarTemplateSpecialization.NativeToManagedMap[__ret];
+                    else __result0 = global::CppSharp.Parser.AST.VarTemplateSpecialization.__CreateInstance(__ret);
+                    return __result0;
+                }
+
+                public global::CppSharp.Parser.AST.VarTemplatePartialSpecialization FindPartialSpecialization(string usr)
+                {
+                    var __allocator0 = new global::Std.Allocator();
+                    var __basicString0 = new global::Std.BasicString(usr, __allocator0);
+                    var __arg0 = __basicString0.__Instance;
+                    var __ret = __Internal.FindPartialSpecialization_0((__Instance + __PointerAdjustment), __arg0);
+                    __basicString0.Dispose(false);
+                    __allocator0.Dispose();
+                    global::CppSharp.Parser.AST.VarTemplatePartialSpecialization __result0;
+                    if (__ret == IntPtr.Zero) __result0 = null;
+                    else if (global::CppSharp.Parser.AST.VarTemplatePartialSpecialization.NativeToManagedMap.ContainsKey(__ret))
+                        __result0 = (global::CppSharp.Parser.AST.VarTemplatePartialSpecialization) global::CppSharp.Parser.AST.VarTemplatePartialSpecialization.NativeToManagedMap[__ret];
+                    else __result0 = global::CppSharp.Parser.AST.VarTemplatePartialSpecialization.__CreateInstance(__ret);
+                    return __result0;
+                }
+
                 public uint SpecializationsCount
                 {
                     get
@@ -12159,13 +12282,13 @@ namespace CppSharp
                     internal int lineNumberEnd;
 
                     [FieldOffset(32)]
-                    internal global::Std.BasicString.__Internal Name;
+                    internal global::Std.BasicString.__Internal name;
 
                     [FieldOffset(64)]
                     internal global::Std.BasicString.__Internal USR;
 
                     [FieldOffset(96)]
-                    internal global::Std.BasicString.__Internal DebugText;
+                    internal global::Std.BasicString.__Internal debugText;
 
                     [FieldOffset(128)]
                     internal byte isIncomplete;
@@ -12195,7 +12318,7 @@ namespace CppSharp
                     internal global::System.IntPtr comment;
 
                     [FieldOffset(216)]
-                    internal global::Std.BasicString.__Internal Mangled;
+                    internal global::Std.BasicString.__Internal mangled;
 
                     [FieldOffset(248)]
                     internal global::CppSharp.Parser.AST.QualifiedType.__Internal qualifiedType;
@@ -12397,13 +12520,13 @@ namespace CppSharp
                     internal int lineNumberEnd;
 
                     [FieldOffset(32)]
-                    internal global::Std.BasicString.__Internal Name;
+                    internal global::Std.BasicString.__Internal name;
 
                     [FieldOffset(64)]
                     internal global::Std.BasicString.__Internal USR;
 
                     [FieldOffset(96)]
-                    internal global::Std.BasicString.__Internal DebugText;
+                    internal global::Std.BasicString.__Internal debugText;
 
                     [FieldOffset(128)]
                     internal byte isIncomplete;
@@ -12433,7 +12556,7 @@ namespace CppSharp
                     internal global::System.IntPtr comment;
 
                     [FieldOffset(216)]
-                    internal global::Std.BasicString.__Internal Mangled;
+                    internal global::Std.BasicString.__Internal mangled;
 
                     [FieldOffset(248)]
                     internal global::CppSharp.Parser.AST.QualifiedType.__Internal qualifiedType;
@@ -12555,13 +12678,13 @@ namespace CppSharp
                     internal int lineNumberEnd;
 
                     [FieldOffset(32)]
-                    internal global::Std.BasicString.__Internal Name;
+                    internal global::Std.BasicString.__Internal name;
 
                     [FieldOffset(64)]
                     internal global::Std.BasicString.__Internal USR;
 
                     [FieldOffset(96)]
-                    internal global::Std.BasicString.__Internal DebugText;
+                    internal global::Std.BasicString.__Internal debugText;
 
                     [FieldOffset(128)]
                     internal byte isIncomplete;
@@ -12874,10 +12997,10 @@ namespace CppSharp
                     internal global::CppSharp.Parser.AST.DeclarationKind kind;
 
                     [FieldOffset(24)]
-                    internal global::Std.BasicString.__Internal Name;
+                    internal global::Std.BasicString.__Internal name;
 
                     [FieldOffset(56)]
-                    internal global::Std.BasicString.__Internal Expression;
+                    internal global::Std.BasicString.__Internal expression;
 
                     [FieldOffset(88)]
                     internal int lineNumberStart;
@@ -12899,26 +13022,6 @@ namespace CppSharp
                     [DllImport("CppSharp.CppParser.dll", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
                         EntryPoint="??1MacroDefinition@AST@CppParser@CppSharp@@QEAA@XZ")]
                     internal static extern void dtor_0(global::System.IntPtr instance, int delete);
-
-                    [SuppressUnmanagedCodeSecurity]
-                    [DllImport("CppSharp.CppParser.dll", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
-                        EntryPoint="?getName@MacroDefinition@AST@CppParser@CppSharp@@QEAAPEBDXZ")]
-                    internal static extern global::System.IntPtr GetName(global::System.IntPtr instance);
-
-                    [SuppressUnmanagedCodeSecurity]
-                    [DllImport("CppSharp.CppParser.dll", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
-                        EntryPoint="?setName@MacroDefinition@AST@CppParser@CppSharp@@QEAAXPEBD@Z")]
-                    internal static extern void SetName(global::System.IntPtr instance, [MarshalAs(UnmanagedType.LPStr)] string s);
-
-                    [SuppressUnmanagedCodeSecurity]
-                    [DllImport("CppSharp.CppParser.dll", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
-                        EntryPoint="?getExpression@MacroDefinition@AST@CppParser@CppSharp@@QEAAPEBDXZ")]
-                    internal static extern global::System.IntPtr GetExpression(global::System.IntPtr instance);
-
-                    [SuppressUnmanagedCodeSecurity]
-                    [DllImport("CppSharp.CppParser.dll", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
-                        EntryPoint="?setExpression@MacroDefinition@AST@CppParser@CppSharp@@QEAAXPEBD@Z")]
-                    internal static extern void SetExpression(global::System.IntPtr instance, [MarshalAs(UnmanagedType.LPStr)] string s);
                 }
 
                 internal static new global::CppSharp.Parser.AST.MacroDefinition __CreateInstance(global::System.IntPtr native, bool skipVTables = false)
@@ -12988,6 +13091,36 @@ namespace CppSharp
                     __Instance = IntPtr.Zero;
                 }
 
+                public string Name
+                {
+                    get
+                    {
+                        return global::Std.BasicString.__CreateInstance(((global::CppSharp.Parser.AST.MacroDefinition.__Internal*) __Instance)->name).CStr();
+                    }
+
+                    set
+                    {
+                        var __allocator0 = new global::Std.Allocator();
+                        var __basicString0 = new global::Std.BasicString(value, __allocator0);
+                        ((global::CppSharp.Parser.AST.MacroDefinition.__Internal*) __Instance)->name = *(global::Std.BasicString.__Internal*) __basicString0.__Instance;
+                    }
+                }
+
+                public string Expression
+                {
+                    get
+                    {
+                        return global::Std.BasicString.__CreateInstance(((global::CppSharp.Parser.AST.MacroDefinition.__Internal*) __Instance)->expression).CStr();
+                    }
+
+                    set
+                    {
+                        var __allocator0 = new global::Std.Allocator();
+                        var __basicString0 = new global::Std.BasicString(value, __allocator0);
+                        ((global::CppSharp.Parser.AST.MacroDefinition.__Internal*) __Instance)->expression = *(global::Std.BasicString.__Internal*) __basicString0.__Instance;
+                    }
+                }
+
                 public int LineNumberStart
                 {
                     get
@@ -13013,34 +13146,6 @@ namespace CppSharp
                         ((global::CppSharp.Parser.AST.MacroDefinition.__Internal*) __Instance)->lineNumberEnd = value;
                     }
                 }
-
-                public string Name
-                {
-                    get
-                    {
-                        var __ret = __Internal.GetName((__Instance + __PointerAdjustment));
-                        return Marshal.PtrToStringAnsi(__ret);
-                    }
-
-                    set
-                    {
-                        __Internal.SetName((__Instance + __PointerAdjustment), value);
-                    }
-                }
-
-                public string Expression
-                {
-                    get
-                    {
-                        var __ret = __Internal.GetExpression((__Instance + __PointerAdjustment));
-                        return Marshal.PtrToStringAnsi(__ret);
-                    }
-
-                    set
-                    {
-                        __Internal.SetExpression((__Instance + __PointerAdjustment), value);
-                    }
-                }
             }
 
             public unsafe partial class MacroExpansion : global::CppSharp.Parser.AST.PreprocessedEntity, IDisposable
@@ -13058,10 +13163,10 @@ namespace CppSharp
                     internal global::CppSharp.Parser.AST.DeclarationKind kind;
 
                     [FieldOffset(24)]
-                    internal global::Std.BasicString.__Internal Name;
+                    internal global::Std.BasicString.__Internal name;
 
                     [FieldOffset(56)]
-                    internal global::Std.BasicString.__Internal Text;
+                    internal global::Std.BasicString.__Internal text;
 
                     [FieldOffset(88)]
                     internal global::System.IntPtr definition;
@@ -13080,26 +13185,6 @@ namespace CppSharp
                     [DllImport("CppSharp.CppParser.dll", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
                         EntryPoint="??1MacroExpansion@AST@CppParser@CppSharp@@QEAA@XZ")]
                     internal static extern void dtor_0(global::System.IntPtr instance, int delete);
-
-                    [SuppressUnmanagedCodeSecurity]
-                    [DllImport("CppSharp.CppParser.dll", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
-                        EntryPoint="?getName@MacroExpansion@AST@CppParser@CppSharp@@QEAAPEBDXZ")]
-                    internal static extern global::System.IntPtr GetName(global::System.IntPtr instance);
-
-                    [SuppressUnmanagedCodeSecurity]
-                    [DllImport("CppSharp.CppParser.dll", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
-                        EntryPoint="?setName@MacroExpansion@AST@CppParser@CppSharp@@QEAAXPEBD@Z")]
-                    internal static extern void SetName(global::System.IntPtr instance, [MarshalAs(UnmanagedType.LPStr)] string s);
-
-                    [SuppressUnmanagedCodeSecurity]
-                    [DllImport("CppSharp.CppParser.dll", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
-                        EntryPoint="?getText@MacroExpansion@AST@CppParser@CppSharp@@QEAAPEBDXZ")]
-                    internal static extern global::System.IntPtr GetText(global::System.IntPtr instance);
-
-                    [SuppressUnmanagedCodeSecurity]
-                    [DllImport("CppSharp.CppParser.dll", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
-                        EntryPoint="?setText@MacroExpansion@AST@CppParser@CppSharp@@QEAAXPEBD@Z")]
-                    internal static extern void SetText(global::System.IntPtr instance, [MarshalAs(UnmanagedType.LPStr)] string s);
                 }
 
                 internal static new global::CppSharp.Parser.AST.MacroExpansion __CreateInstance(global::System.IntPtr native, bool skipVTables = false)
@@ -13169,6 +13254,36 @@ namespace CppSharp
                     __Instance = IntPtr.Zero;
                 }
 
+                public string Name
+                {
+                    get
+                    {
+                        return global::Std.BasicString.__CreateInstance(((global::CppSharp.Parser.AST.MacroExpansion.__Internal*) __Instance)->name).CStr();
+                    }
+
+                    set
+                    {
+                        var __allocator0 = new global::Std.Allocator();
+                        var __basicString0 = new global::Std.BasicString(value, __allocator0);
+                        ((global::CppSharp.Parser.AST.MacroExpansion.__Internal*) __Instance)->name = *(global::Std.BasicString.__Internal*) __basicString0.__Instance;
+                    }
+                }
+
+                public string Text
+                {
+                    get
+                    {
+                        return global::Std.BasicString.__CreateInstance(((global::CppSharp.Parser.AST.MacroExpansion.__Internal*) __Instance)->text).CStr();
+                    }
+
+                    set
+                    {
+                        var __allocator0 = new global::Std.Allocator();
+                        var __basicString0 = new global::Std.BasicString(value, __allocator0);
+                        ((global::CppSharp.Parser.AST.MacroExpansion.__Internal*) __Instance)->text = *(global::Std.BasicString.__Internal*) __basicString0.__Instance;
+                    }
+                }
+
                 public global::CppSharp.Parser.AST.MacroDefinition Definition
                 {
                     get
@@ -13184,34 +13299,6 @@ namespace CppSharp
                     set
                     {
                         ((global::CppSharp.Parser.AST.MacroExpansion.__Internal*) __Instance)->definition = ReferenceEquals(value, null) ? global::System.IntPtr.Zero : value.__Instance;
-                    }
-                }
-
-                public string Name
-                {
-                    get
-                    {
-                        var __ret = __Internal.GetName((__Instance + __PointerAdjustment));
-                        return Marshal.PtrToStringAnsi(__ret);
-                    }
-
-                    set
-                    {
-                        __Internal.SetName((__Instance + __PointerAdjustment), value);
-                    }
-                }
-
-                public string Text
-                {
-                    get
-                    {
-                        var __ret = __Internal.GetText((__Instance + __PointerAdjustment));
-                        return Marshal.PtrToStringAnsi(__ret);
-                    }
-
-                    set
-                    {
-                        __Internal.SetText((__Instance + __PointerAdjustment), value);
                     }
                 }
             }
@@ -13240,13 +13327,13 @@ namespace CppSharp
                     internal int lineNumberEnd;
 
                     [FieldOffset(32)]
-                    internal global::Std.BasicString.__Internal Name;
+                    internal global::Std.BasicString.__Internal name;
 
                     [FieldOffset(64)]
                     internal global::Std.BasicString.__Internal USR;
 
                     [FieldOffset(96)]
-                    internal global::Std.BasicString.__Internal DebugText;
+                    internal global::Std.BasicString.__Internal debugText;
 
                     [FieldOffset(128)]
                     internal byte isIncomplete;
@@ -13312,7 +13399,7 @@ namespace CppSharp
                     internal byte isInline;
 
                     [FieldOffset(464)]
-                    internal global::Std.BasicString.__Internal FileName;
+                    internal global::Std.BasicString.__Internal fileName;
 
                     [FieldOffset(496)]
                     internal byte isSystemHeader;
@@ -13349,16 +13436,6 @@ namespace CppSharp
                     [DllImport("CppSharp.CppParser.dll", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
                         EntryPoint="?clearMacros@TranslationUnit@AST@CppParser@CppSharp@@QEAAXXZ")]
                     internal static extern void ClearMacros_0(global::System.IntPtr instance);
-
-                    [SuppressUnmanagedCodeSecurity]
-                    [DllImport("CppSharp.CppParser.dll", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
-                        EntryPoint="?getFileName@TranslationUnit@AST@CppParser@CppSharp@@QEAAPEBDXZ")]
-                    internal static extern global::System.IntPtr GetFileName(global::System.IntPtr instance);
-
-                    [SuppressUnmanagedCodeSecurity]
-                    [DllImport("CppSharp.CppParser.dll", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
-                        EntryPoint="?setFileName@TranslationUnit@AST@CppParser@CppSharp@@QEAAXPEBD@Z")]
-                    internal static extern void SetFileName(global::System.IntPtr instance, [MarshalAs(UnmanagedType.LPStr)] string s);
 
                     [SuppressUnmanagedCodeSecurity]
                     [DllImport("CppSharp.CppParser.dll", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
@@ -13457,6 +13534,21 @@ namespace CppSharp
                     __Internal.ClearMacros_0((__Instance + __PointerAdjustment));
                 }
 
+                public string FileName
+                {
+                    get
+                    {
+                        return global::Std.BasicString.__CreateInstance(((global::CppSharp.Parser.AST.TranslationUnit.__Internal*) __Instance)->fileName).CStr();
+                    }
+
+                    set
+                    {
+                        var __allocator0 = new global::Std.Allocator();
+                        var __basicString0 = new global::Std.BasicString(value, __allocator0);
+                        ((global::CppSharp.Parser.AST.TranslationUnit.__Internal*) __Instance)->fileName = *(global::Std.BasicString.__Internal*) __basicString0.__Instance;
+                    }
+                }
+
                 public bool IsSystemHeader
                 {
                     get
@@ -13467,20 +13559,6 @@ namespace CppSharp
                     set
                     {
                         ((global::CppSharp.Parser.AST.TranslationUnit.__Internal*) __Instance)->isSystemHeader = (byte) (value ? 1 : 0);
-                    }
-                }
-
-                public string FileName
-                {
-                    get
-                    {
-                        var __ret = __Internal.GetFileName((__Instance + __PointerAdjustment));
-                        return Marshal.PtrToStringAnsi(__ret);
-                    }
-
-                    set
-                    {
-                        __Internal.SetFileName((__Instance + __PointerAdjustment), value);
                     }
                 }
 
@@ -13500,7 +13578,7 @@ namespace CppSharp
                 public partial struct __Internal
                 {
                     [FieldOffset(0)]
-                    internal global::Std.BasicString.__Internal FileName;
+                    internal global::Std.BasicString.__Internal fileName;
 
                     [FieldOffset(32)]
                     internal global::CppSharp.Parser.AST.ArchType archType;
@@ -13555,16 +13633,6 @@ namespace CppSharp
                     [DllImport("CppSharp.CppParser.dll", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
                         EntryPoint="?clearDependencies@NativeLibrary@AST@CppParser@CppSharp@@QEAAXXZ")]
                     internal static extern void ClearDependencies_0(global::System.IntPtr instance);
-
-                    [SuppressUnmanagedCodeSecurity]
-                    [DllImport("CppSharp.CppParser.dll", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
-                        EntryPoint="?getFileName@NativeLibrary@AST@CppParser@CppSharp@@QEAAPEBDXZ")]
-                    internal static extern global::System.IntPtr GetFileName(global::System.IntPtr instance);
-
-                    [SuppressUnmanagedCodeSecurity]
-                    [DllImport("CppSharp.CppParser.dll", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
-                        EntryPoint="?setFileName@NativeLibrary@AST@CppParser@CppSharp@@QEAAXPEBD@Z")]
-                    internal static extern void SetFileName(global::System.IntPtr instance, [MarshalAs(UnmanagedType.LPStr)] string s);
 
                     [SuppressUnmanagedCodeSecurity]
                     [DllImport("CppSharp.CppParser.dll", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
@@ -13685,6 +13753,21 @@ namespace CppSharp
                     __Internal.ClearDependencies_0((__Instance + __PointerAdjustment));
                 }
 
+                public string FileName
+                {
+                    get
+                    {
+                        return global::Std.BasicString.__CreateInstance(((global::CppSharp.Parser.AST.NativeLibrary.__Internal*) __Instance)->fileName).CStr();
+                    }
+
+                    set
+                    {
+                        var __allocator0 = new global::Std.Allocator();
+                        var __basicString0 = new global::Std.BasicString(value, __allocator0);
+                        ((global::CppSharp.Parser.AST.NativeLibrary.__Internal*) __Instance)->fileName = *(global::Std.BasicString.__Internal*) __basicString0.__Instance;
+                    }
+                }
+
                 public global::CppSharp.Parser.AST.ArchType ArchType
                 {
                     get
@@ -13695,20 +13778,6 @@ namespace CppSharp
                     set
                     {
                         ((global::CppSharp.Parser.AST.NativeLibrary.__Internal*) __Instance)->archType = value;
-                    }
-                }
-
-                public string FileName
-                {
-                    get
-                    {
-                        var __ret = __Internal.GetFileName((__Instance + __PointerAdjustment));
-                        return Marshal.PtrToStringAnsi(__ret);
-                    }
-
-                    set
-                    {
-                        __Internal.SetFileName((__Instance + __PointerAdjustment), value);
                     }
                 }
 
@@ -13753,6 +13822,11 @@ namespace CppSharp
                     [DllImport("CppSharp.CppParser.dll", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
                         EntryPoint="??1ASTContext@AST@CppParser@CppSharp@@QEAA@XZ")]
                     internal static extern void dtor_0(global::System.IntPtr instance, int delete);
+
+                    [SuppressUnmanagedCodeSecurity]
+                    [DllImport("CppSharp.CppParser.dll", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
+                        EntryPoint="?FindOrCreateModule@ASTContext@AST@CppParser@CppSharp@@QEAAPEAVTranslationUnit@234@V?$basic_string@DU?$char_traits@D@std@@V?$allocator@D@2@@std@@@Z")]
+                    internal static extern global::System.IntPtr FindOrCreateModule_0(global::System.IntPtr instance, global::Std.BasicString.__Internal File);
 
                     [SuppressUnmanagedCodeSecurity]
                     [DllImport("CppSharp.CppParser.dll", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
@@ -13849,6 +13923,22 @@ namespace CppSharp
                     if (__ownsNativeInstance)
                         Marshal.FreeHGlobal(__Instance);
                     __Instance = IntPtr.Zero;
+                }
+
+                public global::CppSharp.Parser.AST.TranslationUnit FindOrCreateModule(string File)
+                {
+                    var __allocator0 = new global::Std.Allocator();
+                    var __basicString0 = new global::Std.BasicString(File, __allocator0);
+                    var __arg0 = *(global::Std.BasicString.__Internal*) __basicString0.__Instance;
+                    var __ret = __Internal.FindOrCreateModule_0((__Instance + __PointerAdjustment), __arg0);
+                    __basicString0.Dispose(false);
+                    __allocator0.Dispose();
+                    global::CppSharp.Parser.AST.TranslationUnit __result0;
+                    if (__ret == IntPtr.Zero) __result0 = null;
+                    else if (global::CppSharp.Parser.AST.TranslationUnit.NativeToManagedMap.ContainsKey(__ret))
+                        __result0 = (global::CppSharp.Parser.AST.TranslationUnit) global::CppSharp.Parser.AST.TranslationUnit.NativeToManagedMap[__ret];
+                    else __result0 = global::CppSharp.Parser.AST.TranslationUnit.__CreateInstance(__ret);
+                    return __result0;
                 }
 
                 public global::CppSharp.Parser.AST.TranslationUnit GetTranslationUnits(uint i)
@@ -14566,7 +14656,7 @@ namespace CppSharp
                     public partial struct __Internal
                     {
                         [FieldOffset(0)]
-                        internal global::Std.BasicString.__Internal Text;
+                        internal global::Std.BasicString.__Internal text;
 
                         [SuppressUnmanagedCodeSecurity]
                         [DllImport("CppSharp.CppParser.dll", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
@@ -14582,16 +14672,6 @@ namespace CppSharp
                         [DllImport("CppSharp.CppParser.dll", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
                             EntryPoint="??1Argument@BlockCommandComment@AST@CppParser@CppSharp@@QEAA@XZ")]
                         internal static extern void dtor_0(global::System.IntPtr instance, int delete);
-
-                        [SuppressUnmanagedCodeSecurity]
-                        [DllImport("CppSharp.CppParser.dll", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
-                            EntryPoint="?getText@Argument@BlockCommandComment@AST@CppParser@CppSharp@@QEAAPEBDXZ")]
-                        internal static extern global::System.IntPtr GetText(global::System.IntPtr instance);
-
-                        [SuppressUnmanagedCodeSecurity]
-                        [DllImport("CppSharp.CppParser.dll", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
-                            EntryPoint="?setText@Argument@BlockCommandComment@AST@CppParser@CppSharp@@QEAAXPEBD@Z")]
-                        internal static extern void SetText(global::System.IntPtr instance, [MarshalAs(UnmanagedType.LPStr)] string s);
                     }
 
                     public global::System.IntPtr __Instance { get; protected set; }
@@ -14674,13 +14754,14 @@ namespace CppSharp
                     {
                         get
                         {
-                            var __ret = __Internal.GetText((__Instance + __PointerAdjustment));
-                            return Marshal.PtrToStringAnsi(__ret);
+                            return global::Std.BasicString.__CreateInstance(((global::CppSharp.Parser.AST.BlockCommandComment.Argument.__Internal*) __Instance)->text).CStr();
                         }
 
                         set
                         {
-                            __Internal.SetText((__Instance + __PointerAdjustment), value);
+                            var __allocator0 = new global::Std.Allocator();
+                            var __basicString0 = new global::Std.BasicString(value, __allocator0);
+                            ((global::CppSharp.Parser.AST.BlockCommandComment.Argument.__Internal*) __Instance)->text = *(global::Std.BasicString.__Internal*) __basicString0.__Instance;
                         }
                     }
                 }
@@ -15129,7 +15210,7 @@ namespace CppSharp
                     internal global::CppSharp.Parser.AST.CommentKind kind;
 
                     [FieldOffset(8)]
-                    internal global::Std.BasicString.__Internal Text;
+                    internal global::Std.BasicString.__Internal text;
 
                     [SuppressUnmanagedCodeSecurity]
                     [DllImport("CppSharp.CppParser.dll", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
@@ -15145,16 +15226,6 @@ namespace CppSharp
                     [DllImport("CppSharp.CppParser.dll", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
                         EntryPoint="??1VerbatimBlockLineComment@AST@CppParser@CppSharp@@QEAA@XZ")]
                     internal static extern void dtor_0(global::System.IntPtr instance, int delete);
-
-                    [SuppressUnmanagedCodeSecurity]
-                    [DllImport("CppSharp.CppParser.dll", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
-                        EntryPoint="?getText@VerbatimBlockLineComment@AST@CppParser@CppSharp@@QEAAPEBDXZ")]
-                    internal static extern global::System.IntPtr GetText(global::System.IntPtr instance);
-
-                    [SuppressUnmanagedCodeSecurity]
-                    [DllImport("CppSharp.CppParser.dll", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
-                        EntryPoint="?setText@VerbatimBlockLineComment@AST@CppParser@CppSharp@@QEAAXPEBD@Z")]
-                    internal static extern void SetText(global::System.IntPtr instance, [MarshalAs(UnmanagedType.LPStr)] string s);
                 }
 
                 internal static new global::CppSharp.Parser.AST.VerbatimBlockLineComment __CreateInstance(global::System.IntPtr native, bool skipVTables = false)
@@ -15228,13 +15299,14 @@ namespace CppSharp
                 {
                     get
                     {
-                        var __ret = __Internal.GetText((__Instance + __PointerAdjustment));
-                        return Marshal.PtrToStringAnsi(__ret);
+                        return global::Std.BasicString.__CreateInstance(((global::CppSharp.Parser.AST.VerbatimBlockLineComment.__Internal*) __Instance)->text).CStr();
                     }
 
                     set
                     {
-                        __Internal.SetText((__Instance + __PointerAdjustment), value);
+                        var __allocator0 = new global::Std.Allocator();
+                        var __basicString0 = new global::Std.BasicString(value, __allocator0);
+                        ((global::CppSharp.Parser.AST.VerbatimBlockLineComment.__Internal*) __Instance)->text = *(global::Std.BasicString.__Internal*) __basicString0.__Instance;
                     }
                 }
             }
@@ -15414,7 +15486,7 @@ namespace CppSharp
                     internal global::Std.Vector.__Internal Arguments;
 
                     [FieldOffset(40)]
-                    internal global::Std.BasicString.__Internal Text;
+                    internal global::Std.BasicString.__Internal text;
 
                     [SuppressUnmanagedCodeSecurity]
                     [DllImport("CppSharp.CppParser.dll", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
@@ -15430,16 +15502,6 @@ namespace CppSharp
                     [DllImport("CppSharp.CppParser.dll", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
                         EntryPoint="??1VerbatimLineComment@AST@CppParser@CppSharp@@QEAA@XZ")]
                     internal static extern void dtor_0(global::System.IntPtr instance, int delete);
-
-                    [SuppressUnmanagedCodeSecurity]
-                    [DllImport("CppSharp.CppParser.dll", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
-                        EntryPoint="?getText@VerbatimLineComment@AST@CppParser@CppSharp@@QEAAPEBDXZ")]
-                    internal static extern global::System.IntPtr GetText(global::System.IntPtr instance);
-
-                    [SuppressUnmanagedCodeSecurity]
-                    [DllImport("CppSharp.CppParser.dll", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
-                        EntryPoint="?setText@VerbatimLineComment@AST@CppParser@CppSharp@@QEAAXPEBD@Z")]
-                    internal static extern void SetText(global::System.IntPtr instance, [MarshalAs(UnmanagedType.LPStr)] string s);
                 }
 
                 internal static new global::CppSharp.Parser.AST.VerbatimLineComment __CreateInstance(global::System.IntPtr native, bool skipVTables = false)
@@ -15513,13 +15575,14 @@ namespace CppSharp
                 {
                     get
                     {
-                        var __ret = __Internal.GetText((__Instance + __PointerAdjustment));
-                        return Marshal.PtrToStringAnsi(__ret);
+                        return global::Std.BasicString.__CreateInstance(((global::CppSharp.Parser.AST.VerbatimLineComment.__Internal*) __Instance)->text).CStr();
                     }
 
                     set
                     {
-                        __Internal.SetText((__Instance + __PointerAdjustment), value);
+                        var __allocator0 = new global::Std.Allocator();
+                        var __basicString0 = new global::Std.BasicString(value, __allocator0);
+                        ((global::CppSharp.Parser.AST.VerbatimLineComment.__Internal*) __Instance)->text = *(global::Std.BasicString.__Internal*) __basicString0.__Instance;
                     }
                 }
             }
@@ -15594,7 +15657,7 @@ namespace CppSharp
                     public partial struct __Internal
                     {
                         [FieldOffset(0)]
-                        internal global::Std.BasicString.__Internal Text;
+                        internal global::Std.BasicString.__Internal text;
 
                         [SuppressUnmanagedCodeSecurity]
                         [DllImport("CppSharp.CppParser.dll", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
@@ -15610,16 +15673,6 @@ namespace CppSharp
                         [DllImport("CppSharp.CppParser.dll", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
                             EntryPoint="??1Argument@InlineCommandComment@AST@CppParser@CppSharp@@QEAA@XZ")]
                         internal static extern void dtor_0(global::System.IntPtr instance, int delete);
-
-                        [SuppressUnmanagedCodeSecurity]
-                        [DllImport("CppSharp.CppParser.dll", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
-                            EntryPoint="?getText@Argument@InlineCommandComment@AST@CppParser@CppSharp@@QEAAPEBDXZ")]
-                        internal static extern global::System.IntPtr GetText(global::System.IntPtr instance);
-
-                        [SuppressUnmanagedCodeSecurity]
-                        [DllImport("CppSharp.CppParser.dll", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
-                            EntryPoint="?setText@Argument@InlineCommandComment@AST@CppParser@CppSharp@@QEAAXPEBD@Z")]
-                        internal static extern void SetText(global::System.IntPtr instance, [MarshalAs(UnmanagedType.LPStr)] string s);
                     }
 
                     public global::System.IntPtr __Instance { get; protected set; }
@@ -15702,13 +15755,14 @@ namespace CppSharp
                     {
                         get
                         {
-                            var __ret = __Internal.GetText((__Instance + __PointerAdjustment));
-                            return Marshal.PtrToStringAnsi(__ret);
+                            return global::Std.BasicString.__CreateInstance(((global::CppSharp.Parser.AST.InlineCommandComment.Argument.__Internal*) __Instance)->text).CStr();
                         }
 
                         set
                         {
-                            __Internal.SetText((__Instance + __PointerAdjustment), value);
+                            var __allocator0 = new global::Std.Allocator();
+                            var __basicString0 = new global::Std.BasicString(value, __allocator0);
+                            ((global::CppSharp.Parser.AST.InlineCommandComment.Argument.__Internal*) __Instance)->text = *(global::Std.BasicString.__Internal*) __basicString0.__Instance;
                         }
                     }
                 }
@@ -15941,7 +15995,7 @@ namespace CppSharp
                     internal byte hasTrailingNewline;
 
                     [FieldOffset(8)]
-                    internal global::Std.BasicString.__Internal TagName;
+                    internal global::Std.BasicString.__Internal tagName;
 
                     [FieldOffset(40)]
                     internal global::Std.Vector.__Internal Attributes;
@@ -15978,16 +16032,6 @@ namespace CppSharp
 
                     [SuppressUnmanagedCodeSecurity]
                     [DllImport("CppSharp.CppParser.dll", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
-                        EntryPoint="?getTagName@HTMLStartTagComment@AST@CppParser@CppSharp@@QEAAPEBDXZ")]
-                    internal static extern global::System.IntPtr GetTagName(global::System.IntPtr instance);
-
-                    [SuppressUnmanagedCodeSecurity]
-                    [DllImport("CppSharp.CppParser.dll", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
-                        EntryPoint="?setTagName@HTMLStartTagComment@AST@CppParser@CppSharp@@QEAAXPEBD@Z")]
-                    internal static extern void SetTagName(global::System.IntPtr instance, [MarshalAs(UnmanagedType.LPStr)] string s);
-
-                    [SuppressUnmanagedCodeSecurity]
-                    [DllImport("CppSharp.CppParser.dll", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
                         EntryPoint="?getAttributesCount@HTMLStartTagComment@AST@CppParser@CppSharp@@QEAAIXZ")]
                     internal static extern uint GetAttributesCount(global::System.IntPtr instance);
                 }
@@ -15998,10 +16042,10 @@ namespace CppSharp
                     public partial struct __Internal
                     {
                         [FieldOffset(0)]
-                        internal global::Std.BasicString.__Internal Name;
+                        internal global::Std.BasicString.__Internal name;
 
                         [FieldOffset(32)]
-                        internal global::Std.BasicString.__Internal Value;
+                        internal global::Std.BasicString.__Internal value;
 
                         [SuppressUnmanagedCodeSecurity]
                         [DllImport("CppSharp.CppParser.dll", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
@@ -16017,26 +16061,6 @@ namespace CppSharp
                         [DllImport("CppSharp.CppParser.dll", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
                             EntryPoint="??1Attribute@HTMLStartTagComment@AST@CppParser@CppSharp@@QEAA@XZ")]
                         internal static extern void dtor_0(global::System.IntPtr instance, int delete);
-
-                        [SuppressUnmanagedCodeSecurity]
-                        [DllImport("CppSharp.CppParser.dll", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
-                            EntryPoint="?getName@Attribute@HTMLStartTagComment@AST@CppParser@CppSharp@@QEAAPEBDXZ")]
-                        internal static extern global::System.IntPtr GetName(global::System.IntPtr instance);
-
-                        [SuppressUnmanagedCodeSecurity]
-                        [DllImport("CppSharp.CppParser.dll", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
-                            EntryPoint="?setName@Attribute@HTMLStartTagComment@AST@CppParser@CppSharp@@QEAAXPEBD@Z")]
-                        internal static extern void SetName(global::System.IntPtr instance, [MarshalAs(UnmanagedType.LPStr)] string s);
-
-                        [SuppressUnmanagedCodeSecurity]
-                        [DllImport("CppSharp.CppParser.dll", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
-                            EntryPoint="?getValue@Attribute@HTMLStartTagComment@AST@CppParser@CppSharp@@QEAAPEBDXZ")]
-                        internal static extern global::System.IntPtr GetValue(global::System.IntPtr instance);
-
-                        [SuppressUnmanagedCodeSecurity]
-                        [DllImport("CppSharp.CppParser.dll", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
-                            EntryPoint="?setValue@Attribute@HTMLStartTagComment@AST@CppParser@CppSharp@@QEAAXPEBD@Z")]
-                        internal static extern void SetValue(global::System.IntPtr instance, [MarshalAs(UnmanagedType.LPStr)] string s);
                     }
 
                     public global::System.IntPtr __Instance { get; protected set; }
@@ -16119,13 +16143,14 @@ namespace CppSharp
                     {
                         get
                         {
-                            var __ret = __Internal.GetName((__Instance + __PointerAdjustment));
-                            return Marshal.PtrToStringAnsi(__ret);
+                            return global::Std.BasicString.__CreateInstance(((global::CppSharp.Parser.AST.HTMLStartTagComment.Attribute.__Internal*) __Instance)->name).CStr();
                         }
 
                         set
                         {
-                            __Internal.SetName((__Instance + __PointerAdjustment), value);
+                            var __allocator0 = new global::Std.Allocator();
+                            var __basicString0 = new global::Std.BasicString(value, __allocator0);
+                            ((global::CppSharp.Parser.AST.HTMLStartTagComment.Attribute.__Internal*) __Instance)->name = *(global::Std.BasicString.__Internal*) __basicString0.__Instance;
                         }
                     }
 
@@ -16133,13 +16158,14 @@ namespace CppSharp
                     {
                         get
                         {
-                            var __ret = __Internal.GetValue((__Instance + __PointerAdjustment));
-                            return Marshal.PtrToStringAnsi(__ret);
+                            return global::Std.BasicString.__CreateInstance(((global::CppSharp.Parser.AST.HTMLStartTagComment.Attribute.__Internal*) __Instance)->value).CStr();
                         }
 
                         set
                         {
-                            __Internal.SetValue((__Instance + __PointerAdjustment), value);
+                            var __allocator0 = new global::Std.Allocator();
+                            var __basicString0 = new global::Std.BasicString(value, __allocator0);
+                            ((global::CppSharp.Parser.AST.HTMLStartTagComment.Attribute.__Internal*) __Instance)->value = *(global::Std.BasicString.__Internal*) __basicString0.__Instance;
                         }
                     }
                 }
@@ -16235,13 +16261,14 @@ namespace CppSharp
                 {
                     get
                     {
-                        var __ret = __Internal.GetTagName((__Instance + __PointerAdjustment));
-                        return Marshal.PtrToStringAnsi(__ret);
+                        return global::Std.BasicString.__CreateInstance(((global::CppSharp.Parser.AST.HTMLStartTagComment.__Internal*) __Instance)->tagName).CStr();
                     }
 
                     set
                     {
-                        __Internal.SetTagName((__Instance + __PointerAdjustment), value);
+                        var __allocator0 = new global::Std.Allocator();
+                        var __basicString0 = new global::Std.BasicString(value, __allocator0);
+                        ((global::CppSharp.Parser.AST.HTMLStartTagComment.__Internal*) __Instance)->tagName = *(global::Std.BasicString.__Internal*) __basicString0.__Instance;
                     }
                 }
 
@@ -16267,7 +16294,7 @@ namespace CppSharp
                     internal byte hasTrailingNewline;
 
                     [FieldOffset(8)]
-                    internal global::Std.BasicString.__Internal TagName;
+                    internal global::Std.BasicString.__Internal tagName;
 
                     [SuppressUnmanagedCodeSecurity]
                     [DllImport("CppSharp.CppParser.dll", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
@@ -16283,16 +16310,6 @@ namespace CppSharp
                     [DllImport("CppSharp.CppParser.dll", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
                         EntryPoint="??1HTMLEndTagComment@AST@CppParser@CppSharp@@QEAA@XZ")]
                     internal static extern void dtor_0(global::System.IntPtr instance, int delete);
-
-                    [SuppressUnmanagedCodeSecurity]
-                    [DllImport("CppSharp.CppParser.dll", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
-                        EntryPoint="?getTagName@HTMLEndTagComment@AST@CppParser@CppSharp@@QEAAPEBDXZ")]
-                    internal static extern global::System.IntPtr GetTagName(global::System.IntPtr instance);
-
-                    [SuppressUnmanagedCodeSecurity]
-                    [DllImport("CppSharp.CppParser.dll", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
-                        EntryPoint="?setTagName@HTMLEndTagComment@AST@CppParser@CppSharp@@QEAAXPEBD@Z")]
-                    internal static extern void SetTagName(global::System.IntPtr instance, [MarshalAs(UnmanagedType.LPStr)] string s);
                 }
 
                 internal static new global::CppSharp.Parser.AST.HTMLEndTagComment __CreateInstance(global::System.IntPtr native, bool skipVTables = false)
@@ -16366,13 +16383,14 @@ namespace CppSharp
                 {
                     get
                     {
-                        var __ret = __Internal.GetTagName((__Instance + __PointerAdjustment));
-                        return Marshal.PtrToStringAnsi(__ret);
+                        return global::Std.BasicString.__CreateInstance(((global::CppSharp.Parser.AST.HTMLEndTagComment.__Internal*) __Instance)->tagName).CStr();
                     }
 
                     set
                     {
-                        __Internal.SetTagName((__Instance + __PointerAdjustment), value);
+                        var __allocator0 = new global::Std.Allocator();
+                        var __basicString0 = new global::Std.BasicString(value, __allocator0);
+                        ((global::CppSharp.Parser.AST.HTMLEndTagComment.__Internal*) __Instance)->tagName = *(global::Std.BasicString.__Internal*) __basicString0.__Instance;
                     }
                 }
             }
@@ -16389,7 +16407,7 @@ namespace CppSharp
                     internal byte hasTrailingNewline;
 
                     [FieldOffset(8)]
-                    internal global::Std.BasicString.__Internal Text;
+                    internal global::Std.BasicString.__Internal text;
 
                     [SuppressUnmanagedCodeSecurity]
                     [DllImport("CppSharp.CppParser.dll", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
@@ -16405,16 +16423,6 @@ namespace CppSharp
                     [DllImport("CppSharp.CppParser.dll", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
                         EntryPoint="??1TextComment@AST@CppParser@CppSharp@@QEAA@XZ")]
                     internal static extern void dtor_0(global::System.IntPtr instance, int delete);
-
-                    [SuppressUnmanagedCodeSecurity]
-                    [DllImport("CppSharp.CppParser.dll", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
-                        EntryPoint="?getText@TextComment@AST@CppParser@CppSharp@@QEAAPEBDXZ")]
-                    internal static extern global::System.IntPtr GetText(global::System.IntPtr instance);
-
-                    [SuppressUnmanagedCodeSecurity]
-                    [DllImport("CppSharp.CppParser.dll", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
-                        EntryPoint="?setText@TextComment@AST@CppParser@CppSharp@@QEAAXPEBD@Z")]
-                    internal static extern void SetText(global::System.IntPtr instance, [MarshalAs(UnmanagedType.LPStr)] string s);
                 }
 
                 internal static new global::CppSharp.Parser.AST.TextComment __CreateInstance(global::System.IntPtr native, bool skipVTables = false)
@@ -16488,13 +16496,14 @@ namespace CppSharp
                 {
                     get
                     {
-                        var __ret = __Internal.GetText((__Instance + __PointerAdjustment));
-                        return Marshal.PtrToStringAnsi(__ret);
+                        return global::Std.BasicString.__CreateInstance(((global::CppSharp.Parser.AST.TextComment.__Internal*) __Instance)->text).CStr();
                     }
 
                     set
                     {
-                        __Internal.SetText((__Instance + __PointerAdjustment), value);
+                        var __allocator0 = new global::Std.Allocator();
+                        var __basicString0 = new global::Std.BasicString(value, __allocator0);
+                        ((global::CppSharp.Parser.AST.TextComment.__Internal*) __Instance)->text = *(global::Std.BasicString.__Internal*) __basicString0.__Instance;
                     }
                 }
             }
@@ -16508,10 +16517,10 @@ namespace CppSharp
                     internal global::CppSharp.Parser.AST.RawCommentKind kind;
 
                     [FieldOffset(8)]
-                    internal global::Std.BasicString.__Internal Text;
+                    internal global::Std.BasicString.__Internal text;
 
                     [FieldOffset(40)]
-                    internal global::Std.BasicString.__Internal BriefText;
+                    internal global::Std.BasicString.__Internal briefText;
 
                     [FieldOffset(72)]
                     internal global::System.IntPtr fullCommentBlock;
@@ -16530,26 +16539,6 @@ namespace CppSharp
                     [DllImport("CppSharp.CppParser.dll", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
                         EntryPoint="??1RawComment@AST@CppParser@CppSharp@@QEAA@XZ")]
                     internal static extern void dtor_0(global::System.IntPtr instance, int delete);
-
-                    [SuppressUnmanagedCodeSecurity]
-                    [DllImport("CppSharp.CppParser.dll", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
-                        EntryPoint="?getText@RawComment@AST@CppParser@CppSharp@@QEAAPEBDXZ")]
-                    internal static extern global::System.IntPtr GetText(global::System.IntPtr instance);
-
-                    [SuppressUnmanagedCodeSecurity]
-                    [DllImport("CppSharp.CppParser.dll", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
-                        EntryPoint="?setText@RawComment@AST@CppParser@CppSharp@@QEAAXPEBD@Z")]
-                    internal static extern void SetText(global::System.IntPtr instance, [MarshalAs(UnmanagedType.LPStr)] string s);
-
-                    [SuppressUnmanagedCodeSecurity]
-                    [DllImport("CppSharp.CppParser.dll", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
-                        EntryPoint="?getBriefText@RawComment@AST@CppParser@CppSharp@@QEAAPEBDXZ")]
-                    internal static extern global::System.IntPtr GetBriefText(global::System.IntPtr instance);
-
-                    [SuppressUnmanagedCodeSecurity]
-                    [DllImport("CppSharp.CppParser.dll", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
-                        EntryPoint="?setBriefText@RawComment@AST@CppParser@CppSharp@@QEAAXPEBD@Z")]
-                    internal static extern void SetBriefText(global::System.IntPtr instance, [MarshalAs(UnmanagedType.LPStr)] string s);
                 }
 
                 public global::System.IntPtr __Instance { get; protected set; }
@@ -16641,6 +16630,36 @@ namespace CppSharp
                     }
                 }
 
+                public string Text
+                {
+                    get
+                    {
+                        return global::Std.BasicString.__CreateInstance(((global::CppSharp.Parser.AST.RawComment.__Internal*) __Instance)->text).CStr();
+                    }
+
+                    set
+                    {
+                        var __allocator0 = new global::Std.Allocator();
+                        var __basicString0 = new global::Std.BasicString(value, __allocator0);
+                        ((global::CppSharp.Parser.AST.RawComment.__Internal*) __Instance)->text = *(global::Std.BasicString.__Internal*) __basicString0.__Instance;
+                    }
+                }
+
+                public string BriefText
+                {
+                    get
+                    {
+                        return global::Std.BasicString.__CreateInstance(((global::CppSharp.Parser.AST.RawComment.__Internal*) __Instance)->briefText).CStr();
+                    }
+
+                    set
+                    {
+                        var __allocator0 = new global::Std.Allocator();
+                        var __basicString0 = new global::Std.BasicString(value, __allocator0);
+                        ((global::CppSharp.Parser.AST.RawComment.__Internal*) __Instance)->briefText = *(global::Std.BasicString.__Internal*) __basicString0.__Instance;
+                    }
+                }
+
                 public global::CppSharp.Parser.AST.FullComment FullCommentBlock
                 {
                     get
@@ -16656,34 +16675,6 @@ namespace CppSharp
                     set
                     {
                         ((global::CppSharp.Parser.AST.RawComment.__Internal*) __Instance)->fullCommentBlock = ReferenceEquals(value, null) ? global::System.IntPtr.Zero : value.__Instance;
-                    }
-                }
-
-                public string Text
-                {
-                    get
-                    {
-                        var __ret = __Internal.GetText((__Instance + __PointerAdjustment));
-                        return Marshal.PtrToStringAnsi(__ret);
-                    }
-
-                    set
-                    {
-                        __Internal.SetText((__Instance + __PointerAdjustment), value);
-                    }
-                }
-
-                public string BriefText
-                {
-                    get
-                    {
-                        var __ret = __Internal.GetBriefText((__Instance + __PointerAdjustment));
-                        return Marshal.PtrToStringAnsi(__ret);
-                    }
-
-                    set
-                    {
-                        __Internal.SetBriefText((__Instance + __PointerAdjustment), value);
                     }
                 }
             }
@@ -16945,16 +16936,6 @@ namespace CppSharp
                 [DllImport("CppSharp.CppParser.dll", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
                     EntryPoint="??1ParserTargetInfo@CppParser@CppSharp@@QEAA@XZ")]
                 internal static extern void dtor_0(global::System.IntPtr instance, int delete);
-
-                [SuppressUnmanagedCodeSecurity]
-                [DllImport("CppSharp.CppParser.dll", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
-                    EntryPoint="?getABI@ParserTargetInfo@CppParser@CppSharp@@QEAAPEBDXZ")]
-                internal static extern global::System.IntPtr GetABI(global::System.IntPtr instance);
-
-                [SuppressUnmanagedCodeSecurity]
-                [DllImport("CppSharp.CppParser.dll", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
-                    EntryPoint="?setABI@ParserTargetInfo@CppParser@CppSharp@@QEAAXPEBD@Z")]
-                internal static extern void SetABI(global::System.IntPtr instance, [MarshalAs(UnmanagedType.LPStr)] string s);
             }
 
             public global::System.IntPtr __Instance { get; protected set; }
@@ -17031,6 +17012,21 @@ namespace CppSharp
                 if (__ownsNativeInstance)
                     Marshal.FreeHGlobal(__Instance);
                 __Instance = IntPtr.Zero;
+            }
+
+            public string ABI
+            {
+                get
+                {
+                    return global::Std.BasicString.__CreateInstance(((global::CppSharp.Parser.ParserTargetInfo.__Internal*) __Instance)->ABI).CStr();
+                }
+
+                set
+                {
+                    var __allocator0 = new global::Std.Allocator();
+                    var __basicString0 = new global::Std.BasicString(value, __allocator0);
+                    ((global::CppSharp.Parser.ParserTargetInfo.__Internal*) __Instance)->ABI = *(global::Std.BasicString.__Internal*) __basicString0.__Instance;
+                }
             }
 
             public global::CppSharp.Parser.ParserIntType Char16Type
@@ -17552,20 +17548,6 @@ namespace CppSharp
                     ((global::CppSharp.Parser.ParserTargetInfo.__Internal*) __Instance)->float128Width = value;
                 }
             }
-
-            public string ABI
-            {
-                get
-                {
-                    var __ret = __Internal.GetABI((__Instance + __PointerAdjustment));
-                    return Marshal.PtrToStringAnsi(__ret);
-                }
-
-                set
-                {
-                    __Internal.SetABI((__Instance + __PointerAdjustment), value);
-                }
-            }
         }
     }
 }
@@ -17671,7 +17653,7 @@ namespace CppSharp
                 internal global::Std.Vector.__Internal Arguments;
 
                 [FieldOffset(24)]
-                internal global::Std.BasicString.__Internal LibraryFile;
+                internal global::Std.BasicString.__Internal libraryFile;
 
                 [FieldOffset(56)]
                 internal global::Std.Vector.__Internal SourceFiles;
@@ -17698,7 +17680,7 @@ namespace CppSharp
                 internal int toolSetToUse;
 
                 [FieldOffset(216)]
-                internal global::Std.BasicString.__Internal TargetTriple;
+                internal global::Std.BasicString.__Internal targetTriple;
 
                 [FieldOffset(248)]
                 internal global::CppSharp.Parser.AST.CppAbi abi;
@@ -17840,26 +17822,6 @@ namespace CppSharp
                 [DllImport("CppSharp.CppParser.dll", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
                     EntryPoint="?clearLibraryDirs@CppParserOptions@CppParser@CppSharp@@QEAAXXZ")]
                 internal static extern void ClearLibraryDirs_0(global::System.IntPtr instance);
-
-                [SuppressUnmanagedCodeSecurity]
-                [DllImport("CppSharp.CppParser.dll", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
-                    EntryPoint="?getLibraryFile@CppParserOptions@CppParser@CppSharp@@QEAAPEBDXZ")]
-                internal static extern global::System.IntPtr GetLibraryFile(global::System.IntPtr instance);
-
-                [SuppressUnmanagedCodeSecurity]
-                [DllImport("CppSharp.CppParser.dll", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
-                    EntryPoint="?setLibraryFile@CppParserOptions@CppParser@CppSharp@@QEAAXPEBD@Z")]
-                internal static extern void SetLibraryFile(global::System.IntPtr instance, [MarshalAs(UnmanagedType.LPStr)] string s);
-
-                [SuppressUnmanagedCodeSecurity]
-                [DllImport("CppSharp.CppParser.dll", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
-                    EntryPoint="?getTargetTriple@CppParserOptions@CppParser@CppSharp@@QEAAPEBDXZ")]
-                internal static extern global::System.IntPtr GetTargetTriple(global::System.IntPtr instance);
-
-                [SuppressUnmanagedCodeSecurity]
-                [DllImport("CppSharp.CppParser.dll", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
-                    EntryPoint="?setTargetTriple@CppParserOptions@CppParser@CppSharp@@QEAAXPEBD@Z")]
-                internal static extern void SetTargetTriple(global::System.IntPtr instance, [MarshalAs(UnmanagedType.LPStr)] string s);
 
                 [SuppressUnmanagedCodeSecurity]
                 [DllImport("CppSharp.CppParser.dll", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
@@ -18085,6 +18047,21 @@ namespace CppSharp
                 __Internal.ClearLibraryDirs_0((__Instance + __PointerAdjustment));
             }
 
+            public string LibraryFile
+            {
+                get
+                {
+                    return global::Std.BasicString.__CreateInstance(((global::CppSharp.Parser.CppParserOptions.__Internal*) __Instance)->libraryFile).CStr();
+                }
+
+                set
+                {
+                    var __allocator0 = new global::Std.Allocator();
+                    var __basicString0 = new global::Std.BasicString(value, __allocator0);
+                    ((global::CppSharp.Parser.CppParserOptions.__Internal*) __Instance)->libraryFile = *(global::Std.BasicString.__Internal*) __basicString0.__Instance;
+                }
+            }
+
             public global::CppSharp.Parser.AST.ASTContext ASTContext
             {
                 get
@@ -18113,6 +18090,21 @@ namespace CppSharp
                 set
                 {
                     ((global::CppSharp.Parser.CppParserOptions.__Internal*) __Instance)->toolSetToUse = value;
+                }
+            }
+
+            public string TargetTriple
+            {
+                get
+                {
+                    return global::Std.BasicString.__CreateInstance(((global::CppSharp.Parser.CppParserOptions.__Internal*) __Instance)->targetTriple).CStr();
+                }
+
+                set
+                {
+                    var __allocator0 = new global::Std.Allocator();
+                    var __basicString0 = new global::Std.BasicString(value, __allocator0);
+                    ((global::CppSharp.Parser.CppParserOptions.__Internal*) __Instance)->targetTriple = *(global::Std.BasicString.__Internal*) __basicString0.__Instance;
                 }
             }
 
@@ -18212,34 +18204,6 @@ namespace CppSharp
                 }
             }
 
-            public string LibraryFile
-            {
-                get
-                {
-                    var __ret = __Internal.GetLibraryFile((__Instance + __PointerAdjustment));
-                    return Marshal.PtrToStringAnsi(__ret);
-                }
-
-                set
-                {
-                    __Internal.SetLibraryFile((__Instance + __PointerAdjustment), value);
-                }
-            }
-
-            public string TargetTriple
-            {
-                get
-                {
-                    var __ret = __Internal.GetTargetTriple((__Instance + __PointerAdjustment));
-                    return Marshal.PtrToStringAnsi(__ret);
-                }
-
-                set
-                {
-                    __Internal.SetTargetTriple((__Instance + __PointerAdjustment), value);
-                }
-            }
-
             public uint ArgumentsCount
             {
                 get
@@ -18310,10 +18274,10 @@ namespace CppSharp
             public partial struct __Internal
             {
                 [FieldOffset(0)]
-                internal global::Std.BasicString.__Internal FileName;
+                internal global::Std.BasicString.__Internal fileName;
 
                 [FieldOffset(32)]
-                internal global::Std.BasicString.__Internal Message;
+                internal global::Std.BasicString.__Internal message;
 
                 [FieldOffset(64)]
                 internal global::CppSharp.Parser.ParserDiagnosticLevel level;
@@ -18338,26 +18302,6 @@ namespace CppSharp
                 [DllImport("CppSharp.CppParser.dll", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
                     EntryPoint="??1ParserDiagnostic@CppParser@CppSharp@@QEAA@XZ")]
                 internal static extern void dtor_0(global::System.IntPtr instance, int delete);
-
-                [SuppressUnmanagedCodeSecurity]
-                [DllImport("CppSharp.CppParser.dll", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
-                    EntryPoint="?getFileName@ParserDiagnostic@CppParser@CppSharp@@QEAAPEBDXZ")]
-                internal static extern global::System.IntPtr GetFileName(global::System.IntPtr instance);
-
-                [SuppressUnmanagedCodeSecurity]
-                [DllImport("CppSharp.CppParser.dll", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
-                    EntryPoint="?setFileName@ParserDiagnostic@CppParser@CppSharp@@QEAAXPEBD@Z")]
-                internal static extern void SetFileName(global::System.IntPtr instance, [MarshalAs(UnmanagedType.LPStr)] string s);
-
-                [SuppressUnmanagedCodeSecurity]
-                [DllImport("CppSharp.CppParser.dll", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
-                    EntryPoint="?getMessage@ParserDiagnostic@CppParser@CppSharp@@QEAAPEBDXZ")]
-                internal static extern global::System.IntPtr GetMessage(global::System.IntPtr instance);
-
-                [SuppressUnmanagedCodeSecurity]
-                [DllImport("CppSharp.CppParser.dll", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
-                    EntryPoint="?setMessage@ParserDiagnostic@CppParser@CppSharp@@QEAAXPEBD@Z")]
-                internal static extern void SetMessage(global::System.IntPtr instance, [MarshalAs(UnmanagedType.LPStr)] string s);
             }
 
             public global::System.IntPtr __Instance { get; protected set; }
@@ -18436,6 +18380,36 @@ namespace CppSharp
                 __Instance = IntPtr.Zero;
             }
 
+            public string FileName
+            {
+                get
+                {
+                    return global::Std.BasicString.__CreateInstance(((global::CppSharp.Parser.ParserDiagnostic.__Internal*) __Instance)->fileName).CStr();
+                }
+
+                set
+                {
+                    var __allocator0 = new global::Std.Allocator();
+                    var __basicString0 = new global::Std.BasicString(value, __allocator0);
+                    ((global::CppSharp.Parser.ParserDiagnostic.__Internal*) __Instance)->fileName = *(global::Std.BasicString.__Internal*) __basicString0.__Instance;
+                }
+            }
+
+            public string Message
+            {
+                get
+                {
+                    return global::Std.BasicString.__CreateInstance(((global::CppSharp.Parser.ParserDiagnostic.__Internal*) __Instance)->message).CStr();
+                }
+
+                set
+                {
+                    var __allocator0 = new global::Std.Allocator();
+                    var __basicString0 = new global::Std.BasicString(value, __allocator0);
+                    ((global::CppSharp.Parser.ParserDiagnostic.__Internal*) __Instance)->message = *(global::Std.BasicString.__Internal*) __basicString0.__Instance;
+                }
+            }
+
             public global::CppSharp.Parser.ParserDiagnosticLevel Level
             {
                 get
@@ -18472,34 +18446,6 @@ namespace CppSharp
                 set
                 {
                     ((global::CppSharp.Parser.ParserDiagnostic.__Internal*) __Instance)->columnNumber = value;
-                }
-            }
-
-            public string FileName
-            {
-                get
-                {
-                    var __ret = __Internal.GetFileName((__Instance + __PointerAdjustment));
-                    return Marshal.PtrToStringAnsi(__ret);
-                }
-
-                set
-                {
-                    __Internal.SetFileName((__Instance + __PointerAdjustment), value);
-                }
-            }
-
-            public string Message
-            {
-                get
-                {
-                    var __ret = __Internal.GetMessage((__Instance + __PointerAdjustment));
-                    return Marshal.PtrToStringAnsi(__ret);
-                }
-
-                set
-                {
-                    __Internal.SetMessage((__Instance + __PointerAdjustment), value);
                 }
             }
         }

--- a/src/CppParser/Bindings/CSharp/x86_64-pc-win32-msvc/Std.cs
+++ b/src/CppParser/Bindings/CSharp/x86_64-pc-win32-msvc/Std.cs
@@ -57,68 +57,6 @@ public unsafe partial class StdExceptionData
 
 namespace Std
 {
-    public unsafe partial class CharTraits : IDisposable
-    {
-        [StructLayout(LayoutKind.Explicit, Size = 0)]
-        public unsafe partial struct __Internal
-        {
-        }
-
-        public global::System.IntPtr __Instance { get; protected set; }
-
-        protected int __PointerAdjustment;
-        internal static readonly global::System.Collections.Concurrent.ConcurrentDictionary<IntPtr, global::Std.CharTraits> NativeToManagedMap = new global::System.Collections.Concurrent.ConcurrentDictionary<IntPtr, global::Std.CharTraits>();
-        protected void*[] __OriginalVTables;
-
-        protected bool __ownsNativeInstance;
-
-        internal static global::Std.CharTraits __CreateInstance(global::System.IntPtr native, bool skipVTables = false)
-        {
-            return new global::Std.CharTraits(native.ToPointer(), skipVTables);
-        }
-
-        internal static global::Std.CharTraits __CreateInstance(global::Std.CharTraits.__Internal native, bool skipVTables = false)
-        {
-            return new global::Std.CharTraits(native, skipVTables);
-        }
-
-        private static void* __CopyValue(global::Std.CharTraits.__Internal native)
-        {
-            var ret = Marshal.AllocHGlobal(sizeof(global::Std.CharTraits.__Internal));
-            *(global::Std.CharTraits.__Internal*) ret = native;
-            return ret.ToPointer();
-        }
-
-        private CharTraits(global::Std.CharTraits.__Internal native, bool skipVTables = false)
-            : this(__CopyValue(native), skipVTables)
-        {
-            __ownsNativeInstance = true;
-            NativeToManagedMap[__Instance] = this;
-        }
-
-        protected CharTraits(void* native, bool skipVTables = false)
-        {
-            if (native == null)
-                return;
-            __Instance = new global::System.IntPtr(native);
-        }
-
-        public void Dispose()
-        {
-            Dispose(disposing: true);
-        }
-
-        public virtual void Dispose(bool disposing)
-        {
-            if (__Instance == IntPtr.Zero)
-                return;
-            global::Std.CharTraits __dummy;
-            NativeToManagedMap.TryRemove(__Instance, out __dummy);
-            if (__ownsNativeInstance)
-                Marshal.FreeHGlobal(__Instance);
-            __Instance = IntPtr.Zero;
-        }
-    }
 }
 
 namespace Std
@@ -568,6 +506,11 @@ namespace Std
 
             [SuppressUnmanagedCodeSecurity]
             [DllImport("Std-symbols", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
+                EntryPoint="??0?$basic_string@DU?$char_traits@D@std@@V?$allocator@D@2@@std@@QEAA@PEBDAEBV?$allocator@D@1@@Z")]
+            internal static extern global::System.IntPtr ctorc__N_std_S_basic_string__C___N_std_S_char_traits__C___N_std_S_allocator__C_0(global::System.IntPtr instance, [MarshalAs(UnmanagedType.LPStr)] string _Ptr, global::System.IntPtr _Al);
+
+            [SuppressUnmanagedCodeSecurity]
+            [DllImport("Std-symbols", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
                 EntryPoint="??1?$basic_string@DU?$char_traits@D@std@@V?$allocator@D@2@@std@@QEAA@XZ")]
             internal static extern void dtorc__N_std_S_basic_string__C___N_std_S_char_traits__C___N_std_S_allocator__C_0(global::System.IntPtr instance, int delete);
 
@@ -614,6 +557,17 @@ namespace Std
             if (native == null)
                 return;
             __Instance = new global::System.IntPtr(native);
+        }
+
+        public BasicString(string _Ptr, global::Std.Allocator _Al)
+        {
+            __Instance = Marshal.AllocHGlobal(sizeof(global::Std.BasicString.__Internal));
+            __ownsNativeInstance = true;
+            NativeToManagedMap[__Instance] = this;
+            if (ReferenceEquals(_Al, null))
+                throw new global::System.ArgumentNullException("_Al", "Cannot be null because it is a C++ reference (&).");
+            var __arg1 = ((global::Std.Allocator) (object) _Al).__Instance;
+            global::Std.BasicString.__Internal.ctorc__N_std_S_basic_string__C___N_std_S_char_traits__C___N_std_S_allocator__C_0((__Instance + __PointerAdjustment), _Ptr, __arg1);
         }
 
         public void Dispose()

--- a/src/CppParser/Comments.cpp
+++ b/src/CppParser/Comments.cpp
@@ -41,8 +41,8 @@ RawComment* Parser::WalkRawComment(const clang::RawComment* RC)
     auto& SM = c->getSourceManager();
     auto Comment = new RawComment();
     Comment->kind = ConvertRawCommentKind(RC->getKind());
-    Comment->Text = RC->getRawText(SM);
-    Comment->BriefText = RC->getBriefText(*AST);
+    Comment->text = RC->getRawText(SM);
+    Comment->briefText = RC->getBriefText(*AST);
 
     return Comment;
 }
@@ -94,7 +94,7 @@ static void HandleBlockCommand(const clang::comments::BlockCommandComment *CK,
     for (unsigned I = 0, E = CK->getNumArgs(); I != E; ++I)
     {
         auto Arg = BlockCommandComment::Argument();
-        Arg.Text = CK->getArgText(I);
+        Arg.text = CK->getArgText(I);
         BC->Arguments.push_back(Arg);
     }
 }
@@ -172,7 +172,7 @@ static Comment* ConvertCommentBlock(clang::comments::Comment* C)
         auto CK = cast<clang::comments::VerbatimLineComment>(C);
         auto VL = new VerbatimLineComment();
         _Comment = VL;
-        VL->Text = CK->getText();
+        VL->text = CK->getText();
         break;
     }
     case Comment::ParagraphCommentKind:
@@ -194,13 +194,13 @@ static Comment* ConvertCommentBlock(clang::comments::Comment* C)
         auto TC = new HTMLStartTagComment();
         _Comment = TC;
         HandleInlineContent(CK, TC);
-        TC->TagName = CK->getTagName();
+        TC->tagName = CK->getTagName();
         for (unsigned I = 0, E = CK->getNumAttrs(); I != E; ++I)
         {
             auto A = CK->getAttr(I);
             auto Attr = HTMLStartTagComment::Attribute();
-            Attr.Name = A.Name;
-            Attr.Value = A.Value;
+            Attr.name = A.Name;
+            Attr.value = A.Value;
             TC->Attributes.push_back(Attr);
         }
         break;
@@ -211,7 +211,7 @@ static Comment* ConvertCommentBlock(clang::comments::Comment* C)
         auto TC = new HTMLEndTagComment();
         _Comment = TC;
         HandleInlineContent(CK, TC);
-        TC->TagName = CK->getTagName();
+        TC->tagName = CK->getTagName();
         break;
     }
     case Comment::TextCommentKind:
@@ -220,7 +220,7 @@ static Comment* ConvertCommentBlock(clang::comments::Comment* C)
         auto TC = new TextComment();
         _Comment = TC;
         HandleInlineContent(CK, TC);
-        TC->Text = CK->getText();
+        TC->text = CK->getText();
         break;
     }
     case Comment::InlineCommandCommentKind:
@@ -234,7 +234,7 @@ static Comment* ConvertCommentBlock(clang::comments::Comment* C)
         for (unsigned I = 0, E = CK->getNumArgs(); I != E; ++I)
         {
             auto Arg = InlineCommandComment::Argument();
-            Arg.Text = CK->getArgText(I);
+            Arg.text = CK->getArgText(I);
             IC->Arguments.push_back(Arg);
         }       
         break;
@@ -244,7 +244,7 @@ static Comment* ConvertCommentBlock(clang::comments::Comment* C)
         auto CK = cast<clang::comments::VerbatimBlockLineComment>(C);
         auto VL = new VerbatimBlockLineComment();
         _Comment = VL;
-        VL->Text = CK->getText();
+        VL->text = CK->getText();
         break;
     }
     case Comment::NoCommentKind: return nullptr;

--- a/src/CppParser/CppParser.cpp
+++ b/src/CppParser/CppParser.cpp
@@ -26,15 +26,12 @@ CppParserOptions::CppParserOptions()
 CppParserOptions::~CppParserOptions() {}
 
 DEF_VECTOR_STRING(CppParserOptions, Arguments)
-DEF_STRING(CppParserOptions, LibraryFile)
 DEF_VECTOR_STRING(CppParserOptions, SourceFiles)
 DEF_VECTOR_STRING(CppParserOptions, IncludeDirs)
 DEF_VECTOR_STRING(CppParserOptions, SystemIncludeDirs)
 DEF_VECTOR_STRING(CppParserOptions, Defines)
 DEF_VECTOR_STRING(CppParserOptions, Undefines)
 DEF_VECTOR_STRING(CppParserOptions, LibraryDirs)
-DEF_STRING(CppParserOptions, TargetTriple)
-DEF_STRING(ParserTargetInfo, ABI)
 
 ParserResult::ParserResult()
     : ASTContext(0)
@@ -59,16 +56,11 @@ ParserResult::~ParserResult()
 ParserDiagnostic::ParserDiagnostic() {}
 
 ParserDiagnostic::ParserDiagnostic(const ParserDiagnostic& rhs)
-    : FileName(rhs.FileName)
-    , Message(rhs.Message)
+    : fileName(rhs.fileName)
+    , message(rhs.message)
     , level(rhs.level)
     , lineNumber(rhs.lineNumber)
     , columnNumber(rhs.columnNumber)
 {}
-
-DEF_STRING(ParserDiagnostic, FileName)
-DEF_STRING(ParserDiagnostic, Message)
-
 DEF_VECTOR(ParserResult, ParserDiagnostic, Diagnostics)
-
 } }

--- a/src/CppParser/CppParser.h
+++ b/src/CppParser/CppParser.h
@@ -49,8 +49,7 @@ struct CS_API CppParserOptions
     ~CppParserOptions();
 
     VECTOR_STRING(Arguments)
-
-    STRING(LibraryFile)
+    std::string libraryFile;
     // C/C++ header file names.
     VECTOR_STRING(SourceFiles)
 
@@ -64,7 +63,7 @@ struct CS_API CppParserOptions
     CppSharp::CppParser::AST::ASTContext* ASTContext;
 
     int toolSetToUse;
-    STRING(TargetTriple)
+    std::string targetTriple;
     CppAbi abi;
 
     bool noStandardIncludes;
@@ -89,9 +88,8 @@ struct CS_API ParserDiagnostic
 {
     ParserDiagnostic();
     ParserDiagnostic(const ParserDiagnostic&);
-
-    STRING(FileName)
-    STRING(Message)
+    std::string fileName;
+    std::string message;
     ParserDiagnosticLevel level;
     int lineNumber;
     int columnNumber;

--- a/src/CppParser/Helpers.h
+++ b/src/CppParser/Helpers.h
@@ -53,13 +53,3 @@
     void klass::add##name (const char* s) { return name.push_back(std::string(s)); } \
     unsigned klass::get##name##Count () { return name.size(); } \
     void klass::clear##name() { name.clear(); }
-
-#define STRING(name) \
-    std::string name; \
-    const char* get##name(); \
-    void set##name(const char* s);
-
-#define DEF_STRING(klass, name) \
-    const char* klass::get##name() { return name.c_str(); } \
-    void klass::set##name(const char* s) { name = s; }
-

--- a/src/CppParser/Parser.cpp
+++ b/src/CppParser/Parser.cpp
@@ -88,7 +88,7 @@ LayoutField Parser::WalkVTablePointer(Class* Class,
 {
     LayoutField LayoutField;
     LayoutField.offset = Offset.getQuantity();
-    LayoutField.Name = prefix + "_" + Class->Name;
+    LayoutField.name = prefix + "_" + Class->name;
     LayoutField.qualifiedType = GetQualifiedType(c->getASTContext().VoidPtrTy);
     return LayoutField;
 }
@@ -171,7 +171,7 @@ void Parser::ReadClassLayout(Class* Class, const clang::RecordDecl* RD,
         auto F = WalkFieldCXX(Field, Parent);
         LayoutField LayoutField;
         LayoutField.offset = FieldOffset.getQuantity();
-        LayoutField.Name = F->Name;
+        LayoutField.name = F->name;
         LayoutField.qualifiedType = GetQualifiedType(Field->getType());
         LayoutField.fieldPtr = (void*)Field;
         Class->layout->Fields.push_back(LayoutField);
@@ -301,17 +301,17 @@ void Parser::SetupHeader()
     auto& TO = Inv->TargetOpts;
     targetABI = ConvertToClangTargetCXXABI(opts->abi);
 
-    if (opts->TargetTriple.empty())
-        opts->TargetTriple = llvm::sys::getDefaultTargetTriple();
-    TO->Triple = llvm::Triple::normalize(opts->TargetTriple);
+    if (opts->targetTriple.empty())
+        opts->targetTriple = llvm::sys::getDefaultTargetTriple();
+    TO->Triple = llvm::Triple::normalize(opts->targetTriple);
 
     TargetInfo* TI = TargetInfo::CreateTargetInfo(c->getDiagnostics(), TO);
     if (!TI)
     {
         // We might have no target info due to an invalid user-provided triple.
         // Try again with the default triple.
-        opts->TargetTriple = llvm::sys::getDefaultTargetTriple();
-        TO->Triple = llvm::Triple::normalize(opts->TargetTriple);
+        opts->targetTriple = llvm::sys::getDefaultTargetTriple();
+        TO->Triple = llvm::Triple::normalize(opts->targetTriple);
         TI = TargetInfo::CreateTargetInfo(c->getDiagnostics(), TO);
     }
 
@@ -1061,7 +1061,7 @@ Parser::WalkClassTemplateSpecialization(const clang::ClassTemplateSpecialization
     auto NS = GetNamespace(CTS);
     assert(NS && "Expected a valid namespace");
     TS->_namespace = NS;
-    TS->Name = CTS->getName();
+    TS->name = CTS->getName();
     TS->templatedDecl = CT;
     TS->specializationKind = WalkTemplateSpecializationKind(CTS->getSpecializationKind());
     CT->Specializations.push_back(TS);
@@ -1116,7 +1116,7 @@ Parser::WalkClassTemplatePartialSpecialization(const clang::ClassTemplatePartial
     auto NS = GetNamespace(CTS);
     assert(NS && "Expected a valid namespace");
     TS->_namespace = NS;
-    TS->Name = CTS->getName();
+    TS->name = CTS->getName();
     TS->templatedDecl = CT;
     TS->specializationKind = WalkTemplateSpecializationKind(CTS->getSpecializationKind());
     CT->Specializations.push_back(TS);
@@ -1178,7 +1178,7 @@ ClassTemplate* Parser::WalkClassTemplate(const clang::ClassTemplateDecl* TD)
     CT = new ClassTemplate();
     HandleDeclaration(TD, CT);
 
-    CT->Name = GetDeclName(TD);
+    CT->name = GetDeclName(TD);
     CT->_namespace = NS;
     NS->Templates.push_back(CT);
 
@@ -1226,7 +1226,7 @@ TypeTemplateParameter* Parser::WalkTypeTemplateParameter(const clang::TemplateTy
         return TP;
 
     TP = new CppSharp::CppParser::TypeTemplateParameter();
-    TP->Name = GetDeclName(TTPD);
+    TP->name = GetDeclName(TTPD);
     HandleDeclaration(TTPD, TP);
     if (TTPD->hasDefaultArgument())
         TP->defaultArgument = GetQualifiedType(TTPD->getDefaultArgument());
@@ -1246,7 +1246,7 @@ NonTypeTemplateParameter* Parser::WalkNonTypeTemplateParameter(const clang::NonT
         return NTP;
 
     NTP = new CppSharp::CppParser::NonTypeTemplateParameter();
-    NTP->Name = GetDeclName(NTTPD);
+    NTP->name = GetDeclName(NTTPD);
     HandleDeclaration(NTTPD, NTP);
     if (NTTPD->hasDefaultArgument())
         NTP->defaultArgument = WalkExpression(NTTPD->getDefaultArgument());
@@ -1386,7 +1386,7 @@ TypeAliasTemplate* Parser::WalkTypeAliasTemplate(
     TA = new TypeAliasTemplate();
     HandleDeclaration(TD, TA);
 
-    TA->Name = GetDeclName(TD);
+    TA->name = GetDeclName(TD);
     TA->TemplatedDecl = WalkDeclaration(TD->getTemplatedDecl());
     TA->Parameters = WalkTemplateParameterList(TD->getTemplateParameters());
 
@@ -1421,7 +1421,7 @@ FunctionTemplate* Parser::WalkFunctionTemplate(const clang::FunctionTemplateDecl
     FT = new FunctionTemplate();
     HandleDeclaration(TD, FT);
 
-    FT->Name = GetDeclName(TD);
+    FT->name = GetDeclName(TD);
     FT->_namespace = NS;
     FT->TemplatedDecl = Function;
     FT->Parameters = WalkTemplateParameterList(TD->getTemplateParameters());
@@ -1475,7 +1475,7 @@ VarTemplate* Parser::WalkVarTemplate(const clang::VarTemplateDecl* TD)
     VT = new VarTemplate();
     HandleDeclaration(TD, VT);
 
-    VT->Name = GetDeclName(TD);
+    VT->name = GetDeclName(TD);
     VT->_namespace = NS;
     NS->Templates.push_back(VT);
 
@@ -1503,7 +1503,7 @@ Parser::WalkVarTemplateSpecialization(const clang::VarTemplateSpecializationDecl
     auto NS = GetNamespace(VTS);
     assert(NS && "Expected a valid namespace");
     TS->_namespace = NS;
-    TS->Name = VTS->getName();
+    TS->name = VTS->getName();
     TS->templatedDecl = VT;
     TS->specializationKind = WalkTemplateSpecializationKind(VTS->getSpecializationKind());
     VT->Specializations.push_back(TS);
@@ -1543,7 +1543,7 @@ Parser::WalkVarTemplatePartialSpecialization(const clang::VarTemplatePartialSpec
     auto NS = GetNamespace(VTS);
     assert(NS && "Expected a valid namespace");
     TS->_namespace = NS;
-    TS->Name = VTS->getName();
+    TS->name = VTS->getName();
     TS->templatedDecl = VT;
     TS->specializationKind = WalkTemplateSpecializationKind(VTS->getSpecializationKind());
     VT->Specializations.push_back(TS);
@@ -1712,7 +1712,7 @@ Field* Parser::WalkFieldCXX(const clang::FieldDecl* FD, Class* Class)
     HandleDeclaration(FD, F);
 
     F->_namespace = Class;
-    F->Name = FD->getName();
+    F->name = FD->getName();
     auto TL = FD->getTypeSourceInfo()->getTypeLoc();
     F->qualifiedType = GetQualifiedType(FD->getType(), &TL);
     F->access = ConvertToAccess(FD->getAccess());
@@ -2376,7 +2376,7 @@ Type* Parser::WalkType(clang::QualType QualType, const clang::TypeLoc* TL,
             {
                 auto FA = new Parameter();
                 auto Arg = FP->getParamType(i);
-                FA->Name = "";
+                FA->name = "";
                 FA->qualifiedType = GetQualifiedType(Arg);
 
                 // In this case we have no valid value to use as a pointer so
@@ -2513,7 +2513,7 @@ Type* Parser::WalkType(clang::QualType QualType, const clang::TypeLoc* TL,
         auto TPT = new CppSharp::CppParser::TemplateParameterType();
 
         if (auto Ident = TP->getIdentifier())
-            TPT->parameter->Name = Ident->getName();
+            TPT->parameter->name = Ident->getName();
 
         TypeLoc UTL, ETL, ITL, Next;
 
@@ -2611,7 +2611,7 @@ Type* Parser::WalkType(clang::QualType QualType, const clang::TypeLoc* TL,
             }
             break;
         }
-        DNT->Identifier = DN->getIdentifier()->getName();
+        DNT->identifier = DN->getIdentifier()->getName();
 
         Ty = DNT;
         break;
@@ -2744,7 +2744,7 @@ Enumeration* Parser::WalkEnum(const clang::EnumDecl* ED)
         else
         {
             E = new Enumeration();
-            E->Name = Name;
+            E->name = Name;
             E->_namespace = NS;
             NS->Enums.push_back(E);
         }
@@ -2781,7 +2781,7 @@ Enumeration::Item* Parser::WalkEnumItem(clang::EnumConstantDecl* ECD)
     auto EnumItem = new Enumeration::Item();
     HandleDeclaration(ECD, EnumItem);
 
-    EnumItem->Name = ECD->getNameAsString();
+    EnumItem->name = ECD->getNameAsString();
     auto Value = ECD->getInitVal();
     EnumItem->value = Value.isSigned() ? Value.getSExtValue()
         : Value.getZExtValue();
@@ -2789,7 +2789,7 @@ Enumeration::Item* Parser::WalkEnumItem(clang::EnumConstantDecl* ECD)
 
     std::string Text;
     if (GetDeclText(ECD->getSourceRange(), Text))
-        EnumItem->Expression = Text;
+        EnumItem->expression = Text;
 
     return EnumItem;
 }
@@ -2859,7 +2859,7 @@ Parameter* Parser::WalkParameter(const clang::ParmVarDecl* PVD,
     const clang::SourceLocation& ParamStartLoc)
 {
     auto P = new Parameter();
-    P->Name = PVD->getNameAsString();
+    P->name = PVD->getNameAsString();
 
     clang::TypeLoc PTL;
     if (auto TSI = PVD->getTypeSourceInfo())
@@ -2887,16 +2887,16 @@ Parameter* Parser::WalkParameter(const clang::ParmVarDecl* PVD,
 
 void Parser::SetBody(const clang::FunctionDecl* FD, Function* F)
 {
-    F->Body = GetFunctionBody(FD);
+    F->body = GetFunctionBody(FD);
     F->isInline = FD->isInlined();
-    if (!F->Body.empty() && F->isInline)
+    if (!F->body.empty() && F->isInline)
         return;
     for (const auto& R : FD->redecls())
     {
-        if (F->Body.empty())
-            F->Body = GetFunctionBody(R);
+        if (F->body.empty())
+            F->body = GetFunctionBody(R);
         F->isInline |= R->isInlined();
-        if (!F->Body.empty() && F->isInline)
+        if (!F->body.empty() && F->isInline)
             break;
     }
 }
@@ -2912,7 +2912,7 @@ void Parser::WalkFunction(const clang::FunctionDecl* FD, Function* F,
     auto NS = GetNamespace(FD);
     assert(NS && "Expected a valid namespace");
 
-    F->Name = FD->getNameAsString();
+    F->name = FD->getNameAsString();
     F->_namespace = NS;
     F->isConstExpr = FD->isConstexpr();
     F->isVariadic = FD->isVariadic();
@@ -2958,10 +2958,10 @@ void Parser::WalkFunction(const clang::FunctionDecl* FD, Function* F,
     F->returnType = GetQualifiedType(FD->getReturnType(), &RTL);
 
     const auto& Mangled = GetDeclMangledName(FD);
-    F->Mangled = Mangled;
+    F->mangled = Mangled;
 
     const auto& Body = GetFunctionBody(FD);
-    F->Body = Body;
+    F->body = Body;
 
     clang::SourceLocation ParamStartLoc = FD->getLocStart();
     clang::SourceLocation ResultLoc;
@@ -2991,7 +2991,7 @@ void Parser::WalkFunction(const clang::FunctionDecl* FD, Function* F,
 
     std::string Sig;
     if (GetDeclText(Range, Sig))
-        F->Signature = Sig;
+        F->signature = Sig;
 
     for (const auto& VD : FD->parameters())
     {
@@ -3120,14 +3120,14 @@ void Parser::WalkVariable(const clang::VarDecl* VD, Variable* Var)
 {
     HandleDeclaration(VD, Var);
 
-    Var->Name = VD->getName();
+    Var->name = VD->getName();
     Var->access = ConvertToAccess(VD->getAccess());
 
     auto TL = VD->getTypeSourceInfo()->getTypeLoc();
     Var->qualifiedType = GetQualifiedType(VD->getType(), &TL);
 
     auto Mangled = GetDeclMangledName(VD);
-    Var->Mangled = Mangled;
+    Var->mangled = Mangled;
 }
 
 Variable* Parser::WalkVariable(const clang::VarDecl *VD)
@@ -3230,7 +3230,7 @@ PreprocessedEntity* Parser::WalkPreprocessedEntity(
         std::string Text;
         GetDeclText(PPEntity->getSourceRange(), Text);
 
-        static_cast<MacroExpansion*>(Entity)->Text = Text;
+        static_cast<MacroExpansion*>(Entity)->text = Text;
         break;
     }
     case clang::PreprocessedEntity::MacroDefinitionKind:
@@ -3274,8 +3274,8 @@ PreprocessedEntity* Parser::WalkPreprocessedEntity(
         Definition->lineNumberEnd = SM.getExpansionLineNumber(MD->getLocation());
         Entity = Definition;
 
-        Definition->Name = II->getName().trim();
-        Definition->Expression = Expression.trim();
+        Definition->name = II->getName().trim();
+        Definition->expression = Expression.trim();
     }
     case clang::PreprocessedEntity::InclusionDirectiveKind:
         // nothing to be done for InclusionDirectiveKind
@@ -3464,7 +3464,7 @@ void Parser::HandleOriginalText(const clang::Decl* D, Declaration* Decl)
     auto DeclText = clang::Lexer::getSourceText(Range, SM, LangOpts, &Invalid);
     
     if (!Invalid)
-        Decl->DebugText = DeclText;
+        Decl->debugText = DeclText;
 }
 
 void Parser::HandleDeclaration(const clang::Decl* D, Declaration* Decl)
@@ -3877,8 +3877,8 @@ void Parser::HandleDiagnostics(ParserResult* res)
         auto FileName = Source.getFilename(Source.getFileLoc(Diag.Location));
 
         auto PDiag = ParserDiagnostic();
-        PDiag.FileName = FileName.str();
-        PDiag.Message = Diag.Message.str();
+        PDiag.fileName = FileName.str();
+        PDiag.message = Diag.Message.str();
         PDiag.lineNumber = 0;
         PDiag.columnNumber = 0;
 
@@ -4028,7 +4028,7 @@ ParserResultKind Parser::ParseArchive(llvm::StringRef File,
 {
     auto LibName = File;
     NativeLib = new NativeLibrary();
-    NativeLib->FileName = LibName;
+    NativeLib->fileName = LibName;
 
     for(auto it = Archive->symbol_begin(); it != Archive->symbol_end(); ++it)
     {
@@ -4065,7 +4065,7 @@ ParserResultKind Parser::ParseSharedLib(llvm::StringRef File,
 {
     auto LibName = File;
     NativeLib = new NativeLibrary();
-    NativeLib->FileName = LibName;
+    NativeLib->fileName = LibName;
     NativeLib->archType = ConvertArchType(ObjectFile->getArch());
 
     if (ObjectFile->isELF())
@@ -4154,7 +4154,7 @@ ParserResultKind Parser::ReadSymbols(llvm::StringRef File,
 {
     auto LibName = File;
     NativeLib = new NativeLibrary();
-    NativeLib->FileName = LibName;
+    NativeLib->fileName = LibName;
 
     for (auto it = Begin; it != End; ++it)
     {
@@ -4238,7 +4238,7 @@ ParserResult* ClangParser::ParseLibrary(CppParserOptions* Opts)
 
     auto res = new ParserResult();
     res->codeParser = new Parser(Opts);
-    return res->codeParser->ParseLibrary(Opts->LibraryFile, res);
+    return res->codeParser->ParseLibrary(Opts->libraryFile, res);
 }
 
 ParserTargetInfo* ClangParser::GetTargetInfo(CppParserOptions* Opts)

--- a/src/CppParser/ParserGen/ParserGen.cs
+++ b/src/CppParser/ParserGen/ParserGen.cs
@@ -157,7 +157,6 @@ namespace CppSharp
 
         public void SetupPasses(Driver driver)
         {
-            driver.AddTranslationUnitPass(new IgnoreStdFieldsPass());
         }
 
         public void Preprocess(Driver driver, ASTContext ctx)
@@ -235,42 +234,6 @@ namespace CppSharp
                      CppAbi.Itanium, isGnuCpp11Abi: true));
                 Console.WriteLine();
             }
-        }
-    }
-
-    public class IgnoreStdFieldsPass : TranslationUnitPass
-    {
-        public override bool VisitFieldDecl(Field field)
-        {
-            if (!field.IsGenerated)
-                return false;
-
-            if (!IsStdType(field.QualifiedType)) return false;
-
-            field.ExplicitlyIgnore();
-            return true;
-        }
-
-        public override bool VisitFunctionDecl(Function function)
-        {
-            if (function.GenerationKind == GenerationKind.None)
-                return false;
-
-            if (function.Parameters.Any(param => IsStdType(param.QualifiedType)))
-            {
-                function.ExplicitlyIgnore();
-                return false;
-            }
-
-            return true;
-        }
-
-        private bool IsStdType(QualifiedType type)
-        {
-            var typePrinter = new CppTypePrinter();
-            var typeName = type.Visit(typePrinter);
-
-            return typeName.Contains("std::");
         }
     }
 }

--- a/src/CppParser/Target.h
+++ b/src/CppParser/Target.h
@@ -30,8 +30,7 @@ struct CS_API ParserTargetInfo
 {
     ParserTargetInfo();
     ~ParserTargetInfo();
-
-    STRING(ABI);
+    std::string ABI;
 
     ParserIntType char16Type;
     ParserIntType char32Type;


### PR DESCRIPTION
Fixes #852 