### PR TITLE
Fix the typo in LLVM.lua

### DIFF
--- a/build/LLVM.lua
+++ b/build/LLVM.lua
@@ -114,7 +114,7 @@ function SetupLLVMLibs()
     filter { "configurations:Debug", "action:vs*" }
       libdirs { path.join(LLVMBuildDir, "Debug/lib") }
 
-    filter { "configurations:Release", "actoin:vs*" }
+    filter { "configurations:Release", "action:vs*" }
       libdirs { path.join(LLVMBuildDir, "RelWithDebInfo/lib") }
   end
 


### PR DESCRIPTION
Prevented projects from being generated using GenerateProjects.bat