### PR TITLE
Improved indexers

### DIFF
--- a/src/Generator/Passes/CheckOperatorsOverloads.cs
+++ b/src/Generator/Passes/CheckOperatorsOverloads.cs
@@ -110,6 +110,12 @@ namespace CppSharp.Passes
                 if (!qualifiedPointee.Qualifiers.IsConst)
                     property.SetMethod = @operator;
             }
+            // Non-primitive indexers can set if they are not const
+            else if (!returnType.IsPrimitiveType())
+            {
+                if (!@operator.ReturnType.Qualifiers.IsConst)
+                    property.SetMethod = @operator;
+            }
             
             // If we've a setter use the pointee as the type of the property.
             var pointerType = property.Type as PointerType;

--- a/src/Generator/Passes/GetterSetterToPropertyPass.cs
+++ b/src/Generator/Passes/GetterSetterToPropertyPass.cs
@@ -256,6 +256,14 @@ namespace CppSharp.Passes
                         setters.Add(method);
                     else if (method.Parameters.Count > 1)
                         setMethods.Add(method);
+
+                    // If the set function returns a bool, still allow access to the set method
+                    // directly in order to get the return value.
+                    if (method.Parameters.Count == 1 &&
+                        returnType.IsPrimitiveType(PrimitiveType.Bool))
+                    {
+                        setMethods.Add(method);
+                    }
                 }
                 else
                 {


### PR DESCRIPTION
This enables the ability to use the subscript operator from C# in a (contrived) case like:

Original C++ code:
```
int GlobalVariable1 = 10;
int GlobalVariable2 = 20;

struct MyIndexerStruct
{
   MyIndexerStruct(bool b) : _Variable(b ? GlobalVariable1 : GlobalVariable2) {}

   MyIndexerStruct& operator=(const MyIndexerStruct& other)
   {
      _Variable = other._Variable;
      return *this;
   }

   int& _Variable;
};

struct MyStruct
{
   MyIndexerStruct operator[](int) { return MyIndexerStruct(true); }
};

int main()
{
   MyStruct s;
   // Valid C++. It changes GlobalVariable1 to 20.
   s[0] = MyIndexerStruct(false);
   MyIndexerStruct i = s[0];
}
```

User C# code:
```
class Program
{
   static void Main()
   {
      MyStruct s = new MyStruct();
      s[0] = new MyIndexerStruct(false); // shouldn't be an error, but it currently is (set is disabled)
      MyIndexerStruct i = s[0];
   }
}
```