### PR TITLE
Linux toolchain can be supplied in the same spirit in path probing on Mac.

### DIFF
--- a/src/Core/Toolchains/ManagedToolchain.cs
+++ b/src/Core/Toolchains/ManagedToolchain.cs
@@ -13,8 +13,8 @@ namespace CppSharp
                 return @"C:\Program Files (x86)\Mono";
             else if (Platform.IsMacOS)
                 return "/Library/Frameworks/Mono.framework/Versions/Current";
-
-            throw new NotImplementedException();
+            else
+                return "/usr";
         }
 
         public static string FindCSharpCompilerDir()


### PR DESCRIPTION
i.e. just assume "/usr" here.