### PR TITLE
Implementation of GenerateRawCBinding option

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,6 +35,7 @@ src/generator/generator
 *DesignTime*
 *TemporaryGeneratedFile*
 *FileListAbsolute*
+/build
 /build/scripts/llvm*
 /build/scripts/.vagrant
 /build/vs2012
@@ -48,3 +49,10 @@ src/generator/generator
 /site
 /wip
 /.vs
+build/LLVM.lua
+build/LLVM.lua
+*.lua
+build/LLVM.lua
+build/vs2017/.vs/CppSharp/v15/ipch/AutoPCH/4b59b3a7203c7562/PARSER.ipch
+build/vs2017/obj/Release_x86/x86/Release/CppSharp.Parser.CLI/CppSharp.C75EB680.tlog/link.read.1.tlog
+build/vs2017/obj/Release_x86/x86/Release/CppSharp.Parser.CLI/CppSharp.C75EB680.tlog/metagen.read.1.tlog

--- a/build/LLVM.lua
+++ b/build/LLVM.lua
@@ -1,5 +1,5 @@
 -- Setup the LLVM dependency directories
-
+depsdir = "D:/gamedev/NuklearSharp/CppSharp/deps"
 LLVMRootDir = depsdir .. "/llvm/"
 
 local LLVMDirPerConfiguration = false

--- a/build/scripts/LLVM.lua
+++ b/build/scripts/LLVM.lua
@@ -7,7 +7,7 @@ local llvm = path.getabsolute(basedir .. "/../deps/llvm")
 -- If we are inside vagrant then clone and build LLVM outside the shared folder,
 -- otherwise file I/O performance will be terrible.
 if is_vagrant() then
-	llvm = os.getenv("HOME") .. "/llvm"
+	--llvm = os.getenv("HOME") .. "/llvm"
 end
 
 function get_llvm_rev()

--- a/src/Generator/Driver.cs
+++ b/src/Generator/Driver.cs
@@ -339,9 +339,9 @@ namespace CppSharp
 
             TranslationUnitPasses.AddPass(new MarkUsedClassInternalsPass());
 
-            if ((Options.GeneratorKind == GeneratorKind.CLI ||
-                Options.GeneratorKind == GeneratorKind.CSharp) && !Options.GenerateRawCBindings)
-                TranslationUnitPasses.RenameDeclsUpperCase(RenameTargets.Any &~ RenameTargets.Parameter);
+            //if ((Options.GeneratorKind == GeneratorKind.CLI ||
+            //    Options.GeneratorKind == GeneratorKind.CSharp))
+            TranslationUnitPasses.RenameDeclsUpperCase(RenameTargets.Enum | RenameTargets.EnumItem);
         }
 
         public void ProcessCode()
@@ -403,13 +403,13 @@ namespace CppSharp
             compilerOptions.Append(" /unsafe");
 
             var compilerParameters = new CompilerParameters
-                {
-                    GenerateExecutable = false,
-                    TreatWarningsAsErrors = false,
-                    OutputAssembly = assemblyFile,
-                    GenerateInMemory = false,
-                    CompilerOptions = compilerOptions.ToString()
-                };
+            {
+                GenerateExecutable = false,
+                TreatWarningsAsErrors = false,
+                OutputAssembly = assemblyFile,
+                GenerateInMemory = false,
+                CompilerOptions = compilerOptions.ToString()
+            };
 
             if (module != Options.SystemModule)
                 compilerParameters.ReferencedAssemblies.Add(
@@ -475,7 +475,7 @@ namespace CppSharp
 
             driver.Setup();
 
-            if(driver.Options.Verbose)
+            if (driver.Options.Verbose)
                 Diagnostics.Level = DiagnosticKind.Debug;
 
             if (!options.Quiet)

--- a/src/Generator/Driver.cs
+++ b/src/Generator/Driver.cs
@@ -339,8 +339,8 @@ namespace CppSharp
 
             TranslationUnitPasses.AddPass(new MarkUsedClassInternalsPass());
 
-            if (Options.GeneratorKind == GeneratorKind.CLI ||
-                Options.GeneratorKind == GeneratorKind.CSharp)
+            if ((Options.GeneratorKind == GeneratorKind.CLI ||
+                Options.GeneratorKind == GeneratorKind.CSharp) && !Options.GenerateRawCBindings)
                 TranslationUnitPasses.RenameDeclsUpperCase(RenameTargets.Any &~ RenameTargets.Parameter);
         }
 

--- a/src/Generator/Generators/CSharp/CSharpGenerator.cs
+++ b/src/Generator/Generators/CSharp/CSharpGenerator.cs
@@ -30,7 +30,7 @@ namespace CppSharp.Generators.CSharp
             // CheckAbiParameters runs last because hidden structure parameters
             // should always occur first.
 
-            Context.TranslationUnitPasses.AddPass(new CheckAbiParameters());
+            //Context.TranslationUnitPasses.AddPass(new CheckAbiParameters());
 
             return true;
         }

--- a/src/Generator/Generators/CSharp/CSharpSources.cs
+++ b/src/Generator/Generators/CSharp/CSharpSources.cs
@@ -197,7 +197,7 @@ namespace CppSharp.Generators.CSharp
 
             GenerateNamespaceFunctionsAndVariables(context);
 
-            foreach(var childNamespace in context.Namespaces)
+            foreach (var childNamespace in context.Namespaces)
                 childNamespace.Visit(this);
 
             return true;
@@ -216,10 +216,12 @@ namespace CppSharp.Generators.CSharp
             WriteLine("public unsafe partial class {0}", parentName);
             WriteStartBraceIndent();
 
-            PushBlock(BlockKind.InternalsClass);
-            GenerateClassInternalHead();
-            WriteStartBraceIndent();
-
+            if (!Context.Options.GenerateRawCBindings)
+            {
+                PushBlock(BlockKind.InternalsClass);
+                GenerateClassInternalHead();
+                WriteStartBraceIndent();
+            }
             // Generate all the internal function declarations.
             foreach (var function in context.Functions)
             {
@@ -229,20 +231,23 @@ namespace CppSharp.Generators.CSharp
                 GenerateInternalFunction(function);
             }
 
-            WriteCloseBraceIndent();
-            PopBlock(NewLineKind.BeforeNextBlock);
 
-            foreach (var function in context.Functions)
+            if (!Context.Options.GenerateRawCBindings)
             {
-                if (!function.IsGenerated) continue;
+                WriteCloseBraceIndent();
+                PopBlock(NewLineKind.BeforeNextBlock);
 
-                GenerateFunction(function, parentName);
+                foreach (var function in context.Functions)
+                {
+                    if (!function.IsGenerated) continue;
+
+                    GenerateFunction(function, parentName);
+                }
+
+                foreach (var variable in context.Variables.Where(
+                    v => v.IsGenerated && v.Access == AccessSpecifier.Public))
+                    GenerateVariable(null, variable);
             }
-
-            foreach (var variable in context.Variables.Where(
-                v => v.IsGenerated && v.Access == AccessSpecifier.Public))
-                GenerateVariable(null, variable);
-
             WriteCloseBraceIndent();
             PopBlock(NewLineKind.BeforeNextBlock);
         }
@@ -327,6 +332,16 @@ namespace CppSharp.Generators.CSharp
 
         public override bool VisitClassDecl(Class @class)
         {
+            if (Context.Options.GenerateRawCBindings)
+            {
+                GenerateClassInternals(@class, @class.OriginalName);
+                return true;
+            }
+            else return GenerateClass(@class);
+        }
+
+        private bool GenerateClass(Class @class)
+        {
             if ((@class.IsIncomplete && !@class.IsOpaque) || @class.Ignore)
                 return false;
 
@@ -373,10 +388,17 @@ namespace CppSharp.Generators.CSharp
                 PushBlock(BlockKind.Field);
                 if (@class.IsValueType)
                 {
-                    WriteLine("private {0}.{1} {2};", @class.Name, Helpers.InternalStruct,
-                        Helpers.InstanceField);
-                    WriteLine("internal {0}.{1} {2} {{ get {{ return {3}; }} }}", @class.Name,
-                        Helpers.InternalStruct, Helpers.InstanceIdentifier, Helpers.InstanceField);
+                    if (Context.Options.GenerateRawCBindings)
+                    {
+                        WriteLine("internal {0} {1};", @class.Name, Helpers.InstanceField);
+                    }
+                    else
+                    {
+                        WriteLine("private {0}.{1} {2};", @class.Name, Helpers.InternalStruct,
+                         Helpers.InstanceField);
+                        WriteLine("internal {0}.{1} {2} {{ get {{ return {3}; }} }}", @class.Name,
+                            Helpers.InternalStruct, Helpers.InstanceIdentifier, Helpers.InstanceField);
+                    }
                 }
                 else
                 {
@@ -409,7 +431,7 @@ namespace CppSharp.Generators.CSharp
 
             if (@class.IsDynamic)
                 GenerateVTable(@class);
-        exit:
+            exit:
             WriteCloseBraceIndent();
             PopBlock(NewLineKind.BeforeNextBlock);
 
@@ -453,7 +475,7 @@ namespace CppSharp.Generators.CSharp
                 PushBlock(BlockKind.Property);
                 var type = prop.Type;
                 if (prop.Parameters.Count > 0 && prop.Type.IsPointerToPrimitiveType())
-                    type = ((PointerType) prop.Type).Pointee;
+                    type = ((PointerType)prop.Type).Pointee;
                 GenerateDeclarationCommon(prop);
                 Write("{0} {1} {{ ", type, GetPropertyName(prop));
                 if (prop.HasGetter)
@@ -469,7 +491,7 @@ namespace CppSharp.Generators.CSharp
             PopBlock(NewLineKind.BeforeNextBlock);
         }
 
-        public void GenerateClassInternals(Class @class)
+        public void GenerateClassInternals(Class @class, string internalClassName = null)
         {
             PushBlock(BlockKind.InternalsClass);
             if (!Options.GenerateSequentialLayout || @class.IsUnion)
@@ -477,14 +499,14 @@ namespace CppSharp.Generators.CSharp
             else if (@class.MaxFieldAlignment > 0)
                 WriteLine($"[StructLayout(LayoutKind.Sequential, Pack = {@class.MaxFieldAlignment})]");
 
-            GenerateClassInternalHead(@class);
+            GenerateClassInternalHead(@class, internalClassName);
             WriteStartBraceIndent();
 
             TypePrinter.PushContext(TypePrinterContextKind.Native);
 
             foreach (var field in @class.Layout.Fields)
                 GenerateClassInternalsField(field, @class);
-            if (@class.IsGenerated)
+            if (@class.IsGenerated && !@class.IsExternCContext)
             {
                 var functions = GatherClassInternalFunctions(@class);
 
@@ -593,16 +615,26 @@ namespace CppSharp.Generators.CSharp
             return @params;
         }
 
-        private void GenerateClassInternalHead(Class @class = null)
+        private void GenerateClassInternalHead(Class @class = null, string internalClassName = null)
         {
+            var internalName = internalClassName == null ? Helpers.InternalStruct : internalClassName;
+
+            if (Context.Options.GenerateRawCBindings)
+            {
+                WriteLine($"internal unsafe struct {internalName}");
+                return;
+            }
+
             Write("public ");
 
             var isSpecialization = @class is ClassTemplateSpecialization;
             if (@class != null && @class.NeedsBase && !@class.BaseClass.IsInterface & !isSpecialization)
                 Write("new ");
 
-            WriteLine($@"{(isSpecialization ? "unsafe " : string.Empty)}partial struct {
-                Helpers.InternalStruct}{Helpers.GetSuffixForInternal(@class)}");
+
+
+
+            WriteLine($@"{(isSpecialization ? "unsafe " : string.Empty)}partial struct { internalName}{Helpers.GetSuffixForInternal(@class)}");
         }
 
         public static bool ShouldGenerateClassNativeField(Class @class)
@@ -665,8 +697,38 @@ namespace CppSharp.Generators.CSharp
 
         private void GenerateClassInternalsField(LayoutField field, Class @class)
         {
+            //Here a GenerateRawCBinding only behavior,
+            //Workaround C# limitation on Fixed Sized Buffers which allows only primitive types, by spliting the fixed array field into multiple regular fields
+            var shouldExpandFixedSizedBuffer = Context.Options.GenerateRawCBindings && field.QualifiedType.Type is ArrayType;
+
+            if (shouldExpandFixedSizedBuffer
+                && (((ArrayType)field.QualifiedType.Type).QualifiedType.Type is TagType || ((ArrayType)field.QualifiedType.Type).QualifiedType.Type is PointerType) )
+            {
+
+                var arrayType = ((ArrayType)field.QualifiedType.Type);
+                var fieldQualifiedType = arrayType.QualifiedType;
+                var offset = field.Offset;
+
+                var offsetIncr = fieldQualifiedType.Type is TagType ? ((Class)((TagType)fieldQualifiedType.Type).Declaration).Layout.Size : IntPtr.Size;
+
+                for (int i = 0; i < arrayType.Size; i++)
+                {
+                    GenerateClassInternalsFieldImpl(new LayoutField { QualifiedType = fieldQualifiedType, Name = $"{field.Name}{i}", Offset = offset, Expression = field.Expression, FieldPtr = field.FieldPtr }, @class);
+                    offset += (uint)offsetIncr;// ((CppSharp.AST.TagType)fieldQualifiedType.Type).Declaration.la;// (uint)fieldQualifiedType.;
+                }
+
+            }
+            else
+            {
+                GenerateClassInternalsFieldImpl(field, @class);
+            }
+
+        }
+
+        private void GenerateClassInternalsFieldImpl(LayoutField field, Class @class)
+        {
             TypePrinterResult retType = TypePrinter.VisitFieldDecl(
-                new Field { Name = field.Name, QualifiedType = field.QualifiedType });
+            new Field { Name = field.Name, QualifiedType = field.QualifiedType });
 
             PushBlock(BlockKind.Field);
 
@@ -900,7 +962,7 @@ namespace CppSharp.Generators.CSharp
             else
                 type = originalType.ToString();
 
-            var name = ((Class) field.Namespace).Layout.Fields.First(
+            var name = ((Class)field.Namespace).Layout.Fields.First(
                 f => f.FieldPtr == field.OriginalPtr).Name;
             WriteLine(string.Format("fixed ({0} {1} = {2}.{3})",
                 type, arrPtr, Helpers.InstanceField, SafeIdentifier(name)));
@@ -976,7 +1038,7 @@ namespace CppSharp.Generators.CSharp
             {
                 NewLine();
                 WriteStartBraceIndent();
-                var to = ((Class) property.OriginalNamespace).OriginalClass;
+                var to = ((Class)property.OriginalNamespace).OriginalClass;
                 var baseOffset = GetOffsetToBase(@class, to);
                 WriteLine("return {0} + {1};", Helpers.InstanceIdentifier, baseOffset);
                 WriteCloseBraceIndent();
@@ -1148,9 +1210,9 @@ namespace CppSharp.Generators.CSharp
                     (!final.IsPrimitiveType(PrimitiveType.Char) &&
                      !final.IsPrimitiveType(PrimitiveType.WideChar) ||
                      (!Context.Options.MarshalCharAsManagedChar &&
-                      !((PointerType) field.Type).QualifiedPointee.Qualifiers.IsConst)))
+                      !((PointerType)field.Type).QualifiedPointee.Qualifiers.IsConst)))
                     @return = string.Format("({0}*) {1}", field.Type.GetPointee().Desugar(), @return);
-                if (!((PointerType) field.Type).QualifiedPointee.Qualifiers.IsConst &&
+                if (!((PointerType)field.Type).QualifiedPointee.Qualifiers.IsConst &&
                     final.IsPrimitiveType(PrimitiveType.WideChar))
                     @return = string.Format("({0}*) {1}", field.Type.GetPointee().Desugar(), @return);
             }
@@ -1185,7 +1247,7 @@ namespace CppSharp.Generators.CSharp
             if (methods.Count == 0)
                 return;
 
-            var @class = (Class) methods[0].Namespace;
+            var @class = (Class)methods[0].Namespace;
 
             if (@class.IsValueType)
                 foreach (var @base in @class.Bases.Where(b => b.IsClass && !b.Class.Ignore))
@@ -1322,7 +1384,8 @@ namespace CppSharp.Generators.CSharp
             if (!isIndexer)
                 return SafeIdentifier(prop.Name);
 
-            var @params = prop.Parameters.Select(param => {
+            var @params = prop.Parameters.Select(param =>
+            {
                 var p = new Parameter(param);
                 p.Usage = ParameterUsage.In;
                 return p;
@@ -1380,7 +1443,7 @@ namespace CppSharp.Generators.CSharp
             // Generate a delegate type for each method.
             foreach (var method in wrappedEntries.Select(e => e.Method))
                 GenerateVTableMethodDelegates(containingClass, method.Namespace.IsDependent ?
-                   (Method) method.InstantiatedFrom : method);
+                   (Method)method.InstantiatedFrom : method);
 
             WriteLine("private static void*[] __ManagedVTables;");
             if (wrappedEntries.Any(e => e.Method.IsDestructor))
@@ -1618,7 +1681,7 @@ namespace CppSharp.Generators.CSharp
 
             bool isVoid = method.OriginalReturnType.Type.Desugar().IsPrimitiveType(
                 PrimitiveType.Void);
-            var property = ((Class) method.Namespace).Properties.Find(
+            var property = ((Class)method.Namespace).Properties.Find(
                 p => p.GetMethod == method || p.SetMethod == method);
             bool isSetter = property != null && property.SetMethod == method;
             var hasReturn = !isVoid && !isSetter;
@@ -1881,7 +1944,7 @@ namespace CppSharp.Generators.CSharp
                     // virtual destructors in abstract classes may lack a pointer in the v-table
                     // so they have to be called by symbol; thus we need an explicit Dispose override
                     @class.IsAbstract)
-                    if(!@class.IsOpaque)GenerateDisposeMethods(@class);
+                    if (!@class.IsOpaque) GenerateDisposeMethods(@class);
             }
         }
 
@@ -1994,7 +2057,7 @@ namespace CppSharp.Generators.CSharp
 
         private void GenerateDestructorCall(Method dtor)
         {
-            var @class = (Class) dtor.Namespace;
+            var @class = (Class)dtor.Namespace;
             GenerateVirtualFunctionCall(dtor, @class, true);
             if (@class.IsAbstract)
             {
@@ -2368,7 +2431,7 @@ namespace CppSharp.Generators.CSharp
             Class @class;
             return p.Type.IsPointerToPrimitiveType() && p.Usage == ParameterUsage.InOut && p.HasDefaultValue
                 ? "ref param" + index++
-                : (( p.Type.TryGetClass(out @class) && @class.IsInterface) ? "param" + index++
+                : ((p.Type.TryGetClass(out @class) && @class.IsInterface) ? "param" + index++
                      : ExpressionPrinter.VisitParameter(p));
         }
 
@@ -2382,7 +2445,7 @@ namespace CppSharp.Generators.CSharp
                     parameter.Type.IsPointerToPrimitiveType(out primitiveType) &&
                     parameter.Usage == ParameterUsage.InOut && parameter.HasDefaultValue)
                 {
-                    var pointeeType = ((PointerType) parameter.Type).Pointee.ToString();
+                    var pointeeType = ((PointerType)parameter.Type).Pointee.ToString();
                     WriteLine("{0} param{1} = {2};", pointeeType, j++,
                         primitiveType == PrimitiveType.Bool ? "false" : "0");
                 }
@@ -2391,7 +2454,7 @@ namespace CppSharp.Generators.CSharp
                     parameter.Type.Desugar().TryGetClass(out @class) && @class.IsInterface &&
                     parameter.HasDefaultValue)
                 {
-                    WriteLine("var param{0} = ({1}) {2};",  j++, @class.OriginalClass.OriginalName,
+                    WriteLine("var param{0} = ({1}) {2};", j++, @class.OriginalClass.OriginalName,
                         ExpressionPrinter.VisitParameter(parameter));
                 }
             }
@@ -2487,7 +2550,7 @@ namespace CppSharp.Generators.CSharp
         {
             Function @virtual = method;
             if (method.OriginalFunction != null &&
-                !((Class) method.OriginalFunction.Namespace).IsInterface)
+                !((Class)method.OriginalFunction.Namespace).IsInterface)
                 @virtual = method.OriginalFunction;
 
             var i = VTables.GetVTableIndex(@virtual, @class);
@@ -2636,7 +2699,7 @@ namespace CppSharp.Generators.CSharp
             Parameter operatorParam = null;
             if (method != null)
             {
-                var @class = (Class) method.Namespace;
+                var @class = (Class)method.Namespace;
                 isValueType = @class.IsValueType;
 
                 operatorParam = method.Parameters.FirstOrDefault(
@@ -2671,10 +2734,10 @@ namespace CppSharp.Generators.CSharp
                 {
                     if (string.IsNullOrWhiteSpace(construct))
                     {
-		                var typePrinterContext = new TypePrinterContext
-		                {
-		                    Type = indirectRetType.Type.Desugar()
-		                };
+                        var typePrinterContext = new TypePrinterContext
+                        {
+                            Type = indirectRetType.Type.Desugar()
+                        };
 
                         WriteLine("{0} {1};", typeMap.CSharpSignature(typePrinterContext),
                             Helpers.ReturnIdentifier);
@@ -2741,10 +2804,10 @@ namespace CppSharp.Generators.CSharp
                 Write("var {0} = ", Helpers.ReturnIdentifier);
 
             if (method != null && !method.IsConstructor && method.OriginalFunction != null &&
-                ((Method) method.OriginalFunction).IsConstructor)
+                ((Method)method.OriginalFunction).IsConstructor)
             {
                 WriteLine($@"Marshal.AllocHGlobal({
-                    ((Class) method.OriginalNamespace).Layout.Size});");
+                    ((Class)method.OriginalNamespace).Layout.Size});");
                 names.Insert(0, Helpers.ReturnIdentifier);
             }
             WriteLine("{0}({1});", functionName, string.Join(", ", names));
@@ -2794,19 +2857,19 @@ namespace CppSharp.Generators.CSharp
                 WriteCloseBraceIndent();
 
             var numFixedBlocks = @params.Count(param => param.HasUsingBlock);
-            for(var i = 0; i < numFixedBlocks; ++i)
+            for (var i = 0; i < numFixedBlocks; ++i)
                 WriteCloseBraceIndent();
         }
 
         private string GetInstanceParam(Function function)
         {
-            var from = (Class) function.Namespace;
+            var from = (Class)function.Namespace;
             var to = (function.OriginalFunction == null ||
                 // we don't need to offset the instance with Itanium if there's an existing interface impl
                 (Context.ParserOptions.IsItaniumLikeAbi &&
-                 !((Class) function.OriginalNamespace).IsInterface)) &&
+                 !((Class)function.OriginalNamespace).IsInterface)) &&
                  function.SynthKind != FunctionSynthKind.AbstractImplCall ?
-                @from.BaseClass : (Class) function.OriginalFunction.Namespace;
+                @from.BaseClass : (Class)function.OriginalFunction.Namespace;
 
             var baseOffset = 0u;
             if (to != null)
@@ -2980,7 +3043,7 @@ namespace CppSharp.Generators.CSharp
                 var attributedType = typedef.Type.GetPointee() as AttributedType;
                 var callingConvention = attributedType == null
                     ? functionType.CallingConvention
-                    : ((FunctionType) attributedType.Equivalent.Type).CallingConvention;
+                    : ((FunctionType)attributedType.Equivalent.Type).CallingConvention;
                 TypePrinter.PushContext(TypePrinterContextKind.Native);
                 var interopCallConv = callingConvention.ToInteropCallConv();
                 if (interopCallConv == System.Runtime.InteropServices.CallingConvention.Winapi)
@@ -2995,7 +3058,7 @@ namespace CppSharp.Generators.CSharp
                     WriteLine("[return: MarshalAs(UnmanagedType.I1)]");
 
                 WriteLine("{0}unsafe {1};",
-                    Helpers.GetAccess(typedef.Access),
+                   Context.Options.GenerateRawCBindings ? "internal " : Helpers.GetAccess(typedef.Access),
                     string.Format(TypePrinter.VisitDelegate(functionType).Type,
                         typedef.Name));
                 TypePrinter.PopContext();
@@ -3079,7 +3142,7 @@ namespace CppSharp.Generators.CSharp
                 }
                 else
                 {
-                    identifier.Append(function.Name);
+                    identifier.Append(Context.Options.GenerateRawCBindings ? function.OriginalName : function.Name);
                 }
             }
 
@@ -3148,7 +3211,7 @@ namespace CppSharp.Generators.CSharp
             string libName = declaration.TranslationUnit.Module.SharedLibraryName;
 
             NativeLibrary library;
-            Context.Symbols.FindLibraryBySymbol(((IMangledDecl) declaration).Mangled, out library);
+            Context.Symbols.FindLibraryBySymbol(((IMangledDecl)declaration).Mangled, out library);
 
             if (library != null)
                 libName = Path.GetFileNameWithoutExtension(library.FileName);
@@ -3207,6 +3270,6 @@ namespace CppSharp.Generators.CSharp
     internal class SymbolNotFoundException : Exception
     {
         public SymbolNotFoundException(string msg) : base(msg)
-        {}
+        { }
     }
 }

--- a/src/Generator/Generators/CSharp/CSharpSources.cs
+++ b/src/Generator/Generators/CSharp/CSharpSources.cs
@@ -508,7 +508,7 @@ namespace CppSharp.Generators.CSharp
                 GenerateClassInternalsField(field, @class);
             if (@class.IsGenerated && !@class.IsExternCContext)
             {
-                var functions = GatherClassInternalFunctions(@class);
+                var functions = GatherClassInternalFunctions(@class, !Context.Options.GenerateRawCBindings);
 
                 foreach (var function in functions)
                     GenerateInternalFunction(function);
@@ -3060,7 +3060,7 @@ namespace CppSharp.Generators.CSharp
                 WriteLine("{0}unsafe {1};",
                    Context.Options.GenerateRawCBindings ? "internal " : Helpers.GetAccess(typedef.Access),
                     string.Format(TypePrinter.VisitDelegate(functionType).Type,
-                        typedef.Name));
+                        Context.Options.GenerateRawCBindings ? typedef.OriginalName : typedef.Name));
                 TypePrinter.PopContext();
                 PopBlock(NewLineKind.BeforeNextBlock);
             }

--- a/src/Generator/Generators/CSharp/CSharpTypePrinter.cs
+++ b/src/Generator/Generators/CSharp/CSharpTypePrinter.cs
@@ -589,7 +589,7 @@ namespace CppSharp.Generators.CSharp
 
         public override TypePrinterResult VisitDeclaration(Declaration decl)
         {
-            return Context.Options.GenerateRawCBindings && !decl.GetType().Equals(typeof(Enumeration)) ?  decl.OriginalName : GetName(decl);
+            return GetName(decl);
         }
 
         public override TypePrinterResult VisitClassDecl(Class @class)
@@ -634,19 +634,33 @@ namespace CppSharp.Generators.CSharp
                 return IntPtrType;
             }
 
-            if(Context.Options.GenerateRawCBindings && paramType is TypedefType)
+            if(Context.Options.GenerateRawCBindings)
             {
-               var typedef = ((TypedefType)paramType);
-                if(typedef.Declaration.Type is PointerType && ((PointerType)typedef.Declaration.Type).Pointee is FunctionType)
+                if (paramType is TypedefType)
                 {
-                    var tDefName = typedef.Declaration.LogicalOriginalName;
-                    return tDefName;
-                  //  return paramType.dec
+                    var typedef = ((TypedefType)paramType);
+                    if (typedef.Declaration.Type is PointerType && ((PointerType)typedef.Declaration.Type).Pointee is FunctionType)
+                    {
+                        var tDefName = typedef.Declaration.Name;
+                        return tDefName;
+                        //  return paramType.dec
+                    }
                 }
+                //else if (paramType is PointerType && !(((PointerType)paramType).Pointee is FunctionType) && !((PointerType)paramType).GetFinalPointee().ToString().Equals("void"))
+                //{
+                //    // return $"ref {((PointerType)paramType).Pointee} {parameter.Name}";
+                //    parameter.QualifiedType = new QualifiedType(((PointerType)paramType).Pointee);
+                   
+
+                //        return $"ref {parameter.Type}";
+
+                //}
             }
+          
 
             Parameter = parameter;
-            var ret = paramType.Visit(this);
+            var pType = parameter.Type;
+            var ret = pType.Visit(this);
             Parameter = null;
 
             return ret;
@@ -695,7 +709,7 @@ namespace CppSharp.Generators.CSharp
                 !string.IsNullOrWhiteSpace(unit.Module.OutputNamespace))
                 names.Push(unit.Module.OutputNamespace);
 
-            return $"global::{string.Join(".", names)}";
+            return string.Join(".", names);
         }
 
         public override TypePrinterResult VisitParameters(IEnumerable<Parameter> @params,

--- a/src/Generator/Generators/CSharp/CSharpTypePrinter.cs
+++ b/src/Generator/Generators/CSharp/CSharpTypePrinter.cs
@@ -205,13 +205,26 @@ namespace CppSharp.Generators.CSharp
 
         private bool allowStrings = true;
 
+        static System.Text.RegularExpressions.Regex ptrSelector = new System.Text.RegularExpressions.Regex(@"[\*&]*$");
         public override TypePrinterResult VisitPointerType(PointerType pointer,
             TypeQualifiers quals)
         {
-            if (MarshalKind == MarshalKind.NativeField)
-                return IntPtrType;
-
             var pointee = pointer.Pointee;
+
+            if (Context.Options.GenerateRawCBindings && !(pointee is FunctionType))
+            {
+                var ptrStr = ptrSelector.Match(pointer.ToNativeString()).Value;
+                var d = pointee.Desugar();
+                var res = string.Concat(d, ptrStr);
+                return res;
+            }
+
+
+            if (MarshalKind == MarshalKind.NativeField)
+            {
+
+                return IntPtrType;
+            }
 
             if (pointee is FunctionType)
             {
@@ -535,16 +548,32 @@ namespace CppSharp.Generators.CSharp
                 case PrimitiveType.LongLong:
                 case PrimitiveType.ULongLong:
                     return GetIntString(primitive, Context.TargetInfo);
-                case PrimitiveType.Int128: return new TypePrinterResult { Type = "fixed byte",
-                    NameSuffix = "[16]"}; // The type is always 128 bits wide
-                case PrimitiveType.UInt128: return new TypePrinterResult { Type = "fixed byte",
-                    NameSuffix = "[16]"}; // The type is always 128 bits wide
-                case PrimitiveType.Half: return new TypePrinterResult { Type = "fixed byte",
-                    NameSuffix = $"[{Context.TargetInfo.HalfWidth}]"};
+                case PrimitiveType.Int128:
+                    return new TypePrinterResult
+                    {
+                        Type = "fixed byte",
+                        NameSuffix = "[16]"
+                    }; // The type is always 128 bits wide
+                case PrimitiveType.UInt128:
+                    return new TypePrinterResult
+                    {
+                        Type = "fixed byte",
+                        NameSuffix = "[16]"
+                    }; // The type is always 128 bits wide
+                case PrimitiveType.Half:
+                    return new TypePrinterResult
+                    {
+                        Type = "fixed byte",
+                        NameSuffix = $"[{Context.TargetInfo.HalfWidth}]"
+                    };
                 case PrimitiveType.Float: return "float";
                 case PrimitiveType.Double: return "double";
-                case PrimitiveType.LongDouble: return new TypePrinterResult { Type = "fixed byte",
-                    NameSuffix = $"[{Context.TargetInfo.LongDoubleWidth}]"};
+                case PrimitiveType.LongDouble:
+                    return new TypePrinterResult
+                    {
+                        Type = "fixed byte",
+                        NameSuffix = $"[{Context.TargetInfo.LongDoubleWidth}]"
+                    };
                 case PrimitiveType.IntPtr: return IntPtrType;
                 case PrimitiveType.UIntPtr: return "global::System.UIntPtr";
                 case PrimitiveType.Null: return "void*";
@@ -557,13 +586,16 @@ namespace CppSharp.Generators.CSharp
 
         public override TypePrinterResult VisitDeclaration(Declaration decl)
         {
-            return GetName(decl);
+            return Context.Options.GenerateRawCBindings && !decl.GetType().Equals(typeof(Enumeration)) ?  decl.OriginalName : GetName(decl);
         }
 
         public override TypePrinterResult VisitClassDecl(Class @class)
         {
             if (ContextKind == TypePrinterContextKind.Native)
-                return $"{VisitDeclaration(@class.OriginalClass ?? @class)}.{Helpers.InternalStruct}";
+                if (Context.Options.GenerateRawCBindings)
+                    return $"{VisitDeclaration(@class.OriginalClass ?? @class)}";
+                else return $"{VisitDeclaration(@class.OriginalClass ?? @class)}.{Helpers.InternalStruct}";
+
 
             var printed = VisitDeclaration(@class).Type;
             if (!@class.IsDependent)
@@ -594,9 +626,10 @@ namespace CppSharp.Generators.CSharp
         {
             var paramType = parameter.Type;
 
-            if (parameter.Kind == ParameterKind.IndirectReturnType)
+            if (parameter.Kind == ParameterKind.IndirectReturnType && !Context.Options.GenerateRawCBindings)
+            {
                 return IntPtrType;
-
+            }
             Parameter = parameter;
             var ret = paramType.Visit(this);
             Parameter = null;
@@ -753,15 +786,15 @@ namespace CppSharp.Generators.CSharp
                 safeIdentifier = cSharpSourcesDummy.SafeIdentifier(field.Name);
             }
 
-            PushMarshalKind(MarshalKind.NativeField);   
+            PushMarshalKind(MarshalKind.NativeField);
             var fieldTypePrinted = field.QualifiedType.Visit(this);
             PopMarshalKind();
-                     
+
             var returnTypePrinter = new TypePrinterResult();
             if (!string.IsNullOrWhiteSpace(fieldTypePrinted.NameSuffix))
                 returnTypePrinter.NameSuffix = fieldTypePrinted.NameSuffix;
 
-            returnTypePrinter.Type = $"{fieldTypePrinted.Type} {safeIdentifier}"; 
+            returnTypePrinter.Type = $"{fieldTypePrinted.Type} {safeIdentifier}";
 
             return returnTypePrinter;
         }

--- a/src/Generator/Generators/CSharp/CSharpTypePrinter.cs
+++ b/src/Generator/Generators/CSharp/CSharpTypePrinter.cs
@@ -179,7 +179,7 @@ namespace CppSharp.Generators.CSharp
 
         public static bool IsConstCharString(PointerType pointer)
         {
-            var pointee = pointer.Pointee.Desugar();
+            var pointee = pointer.Pointee;//.Desugar();
 
             return (pointee.IsPrimitiveType(PrimitiveType.Char) ||
                     pointee.IsPrimitiveType(PrimitiveType.Char16) ||
@@ -214,10 +214,13 @@ namespace CppSharp.Generators.CSharp
             if (Context.Options.GenerateRawCBindings && !(pointee is FunctionType))
             {
                 var ptrStr = ptrSelector.Match(pointer.ToNativeString()).Value;
-                var d = pointee.Desugar();
+                var d = pointee.Desugar().ToString();
                 if (ptrStr.Equals("&"))
                     return $"ref {d}";
-                
+
+                //if (d.Equals("sbyte") && ptrStr.Length == 1)
+                //    return "[MarshalAs(UnmanagedType.LPStr)] string";
+
                 var res = string.Concat(d, ptrStr);
                 return res;
             }
@@ -251,6 +254,8 @@ namespace CppSharp.Generators.CSharp
                 throw new NotSupportedException(string.Format("{0} is not supported yet.",
                     Options.Encoding.EncodingName));
             }
+
+
 
             var desugared = pointee.Desugar();
 

--- a/src/Generator/Options.cs
+++ b/src/Generator/Options.cs
@@ -150,6 +150,8 @@ namespace CppSharp
         /// </summary>
         public bool GenerateSingleCSharpFile { get; set; } = true;
 
+        public bool GenerateRawCBindings { get; set; } = false;
+
         /// <summary>
         /// Generates default values of arguments in the C# code.
         /// </summary>

--- a/src/Generator/Passes/DelegatesPass.cs
+++ b/src/Generator/Passes/DelegatesPass.cs
@@ -99,11 +99,15 @@ namespace CppSharp.Passes
 
         private TypedefDecl GetDelegate(QualifiedType type, ITypedDecl typedDecl)
         {
+            var decl = (Declaration)typedDecl;
+            string delegateName = null;
             FunctionType newFunctionType = GetNewFunctionType(typedDecl, type);
+            if (Options.GenerateRawCBindings && decl.Namespace is Function)
+                delegateName = $"{decl.Namespace.OriginalName}_delegate";
 
-            var delegateName = GetDelegateName(newFunctionType);
+            else delegateName = GetDelegateName(newFunctionType);
             var access = typedDecl is Method ? AccessSpecifier.Private : AccessSpecifier.Public;
-            var decl = (Declaration) typedDecl;
+         
             Module module = decl.TranslationUnit.Module;
             var existingDelegate = delegates.Find(t => Match(t, delegateName, module));
             if (existingDelegate != null)
@@ -173,7 +177,7 @@ namespace CppSharp.Passes
 
         private DeclarationContext GetDeclContextForDelegates(DeclarationContext @namespace)
         {
-            if (Options.IsCLIGenerator)
+            if (Options.IsCLIGenerator || Options.GenerateRawCBindings)
                 return @namespace is Function ? @namespace.Namespace : @namespace;
 
             var module = @namespace.TranslationUnit.Module;
@@ -204,6 +208,8 @@ namespace CppSharp.Passes
 
         private string GetDelegateName(FunctionType functionType)
         {
+        
+
             var typesBuilder = new StringBuilder();
             if (!functionType.ReturnType.Type.IsPrimitiveType(PrimitiveType.Void))
             {

--- a/src/Generator/Passes/GenerateSymbolsPass.cs
+++ b/src/Generator/Passes/GenerateSymbolsPass.cs
@@ -105,6 +105,16 @@ namespace CppSharp.Passes
             if (!NeedsSymbol(function))
                 return false;
 
+            //Is NeedSymbol broken? Functions without symbols are included...
+            //Let's add these lines (raizam)
+            string fnName = function.OriginalName;
+            string mangledName = function.Mangled;
+            if (!(Context.Symbols.FindSymbol(ref fnName) || Context.Symbols.FindSymbol(ref mangledName)))
+            {
+                function.GenerationKind = GenerationKind.None;
+                return false;
+            }
+
             var symbolsCodeGenerator = GetSymbolsCodeGenerator(module);
             return function.Visit(symbolsCodeGenerator);
         }

--- a/src/Generator/Passes/RenamePass.cs
+++ b/src/Generator/Passes/RenamePass.cs
@@ -343,7 +343,7 @@ namespace CppSharp.Passes
         /// <param name="decl"></param>
         /// <param name="pattern">The cases.</param>
         /// <returns>string</returns>
-        static string ConvertCaseString(Declaration decl, RenameCasePattern pattern)
+        public static string ConvertCaseString(Declaration decl, RenameCasePattern pattern)
         {
             if (decl.Name.All(c => !char.IsLetter(c)))
                 return decl.Name;


### PR DESCRIPTION
This implements GenerateRawCBinding option, which is designed for C libraries, as described here in https://github.com/mono/CppSharp/issues/989.

This option remove the high level classes, and generates only the "internal" classes as structs, with raw pointers.

if enabled with C++ libraries, the behavior undefined and will probably not work.