### PR TITLE
Linux fixes, Bootstrap.cs build errors, warnings

### DIFF
--- a/src/CLI/CLI.cs
+++ b/src/CLI/CLI.cs
@@ -154,7 +154,7 @@ namespace CppSharp
                     messages.Add(string.Format("File '{0}' could not be found.", args));
                 }
             }
-            catch(Exception ex)
+            catch(Exception)
             {
                 messages.Add(string.Format("Error while looking for files inside path '{0}'. Ignoring.", args));
             }

--- a/src/CLI/Generator.cs
+++ b/src/CLI/Generator.cs
@@ -212,7 +212,9 @@ namespace CppSharp
                 Path.Combine("usr", "include", "x86_64-linux-gnu", "c++", gccVersion),
                 Path.Combine("usr", "include", "c++", gccVersion, "backward"),
                 Path.Combine("usr", "lib", "gcc", "x86_64-linux-gnu", gccVersion, "include"),
+                Path.Combine("usr", "lib", "gcc", "x86_64-pc-linux-gnu", gccVersion, "include"),
                 Path.Combine("usr", "include", "x86_64-linux-gnu"),
+                Path.Combine("usr", "include", "x86_64-pc-linux-gnu"),
                 Path.Combine("usr", "include")
             };
 

--- a/src/CppParser/Bootstrap/Bootstrap.cs
+++ b/src/CppParser/Bootstrap/Bootstrap.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using CppSharp.AST;
+using CppSharp.Generators;
 
 namespace CppSharp
 {
@@ -30,14 +31,13 @@ namespace CppSharp
 
         public void Setup(Driver driver)
         {
-            var options = driver.Options;
-            options.GeneratorKind = GeneratorKind.CSharp;
-            options.DryRun = true;
-            options.SetupXcode();
-            options.MicrosoftMode = false;
-            options.TargetTriple = "i686-apple-darwin12.4.0";
+            driver.Options.GeneratorKind = GeneratorKind.CSharp;
+            driver.Options.DryRun = true;
+            driver.ParserOptions.SetupXcode();
+            driver.ParserOptions.MicrosoftMode = false;
+            driver.ParserOptions.TargetTriple = "i686-apple-darwin12.4.0";
 
-            var module = options.AddModule("CppSharp");
+            var module = driver.Options.AddModule("CppSharp");
 
             module.Defines.Add("__STDC_LIMIT_MACROS");
             module.Defines.Add("__STDC_CONSTANT_MACROS");

--- a/src/CppParser/ParserGen/ParserGen.cs
+++ b/src/CppParser/ParserGen/ParserGen.cs
@@ -63,7 +63,6 @@ namespace CppSharp
                 "Sources.h",
                 "CppParser.h"
             });
-            parserModule.Libraries.Add("CppSharp.CppParser.lib");
             parserModule.OutputNamespace = string.Empty;
 
             if (Abi == CppAbi.Microsoft)
@@ -116,7 +115,9 @@ namespace CppSharp
                 Path.Combine("usr", "include", "x86_64-linux-gnu", "c++", gccVersion),
                 Path.Combine("usr", "include", "c++", gccVersion, "backward"),
                 Path.Combine("usr", "lib", "gcc", "x86_64-linux-gnu", gccVersion, "include"),
+                Path.Combine("usr", "lib", "gcc", "x86_64-pc-linux-gnu", gccVersion, "include"),
                 Path.Combine("usr", "include", "x86_64-linux-gnu"),
+                Path.Combine("usr", "include", "x86_64-pc-linux-gnu"),
                 Path.Combine("usr", "include")
             };
 

--- a/src/Parser/ASTConverter.cs
+++ b/src/Parser/ASTConverter.cs
@@ -1047,7 +1047,7 @@ namespace CppSharp
                 VisitDeclContext(decl, _decl);
             }
 
-            for (uint i = 0, j = 0; i < ctx.ClassesCount; ++i)
+            for (uint i = 0; i < ctx.ClassesCount; ++i)
             {
                 var decl = ctx.GetClasses(i);
                 var _decl = (AST.Class) Visit(decl);


### PR DESCRIPTION
* Fixed two warnings due to unused variables.
* Added more system include dirs. Covers at least Archlinux, maybe some other distros as well.
* Fixed build errors in `Bootstrap.cs`.
* Removed parsing of `CppSharp.CppParser.lib` of as per @ddobrev's instructions.