### PR TITLE
Force-set platform type to managed targets.

### DIFF
--- a/build/Helpers.lua
+++ b/build/Helpers.lua
@@ -100,6 +100,7 @@ end
 function SetupManagedProject()
   language "C#"
   location ("%{wks.location}/projects")
+  buildoptions {"/platform:".._OPTIONS["arch"]}
 
   dotnetframework "4.6"
 


### PR DESCRIPTION
In some environments mono defaults building managed targets in architecture different from the host (like AnyCPU or x86 on x64 host). For example on x64 host (linux) build system would produce i686 architecture managed executables while native libraries are built as amd64. In such case managed executables are unable to load native libraries because they target different native architectures. This change ensures architecture consistency between all built binaries.