### PR TITLE
Cloning llvm from git replaced with downloading archives 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,7 +35,7 @@ src/generator/generator
 *DesignTime*
 *TemporaryGeneratedFile*
 *FileListAbsolute*
-/build/scripts/llvm*
+/build/scripts/*.tar.gz
 /build/scripts/.vagrant
 /build/vs2012
 /build/vs2013


### PR DESCRIPTION
Exact requires commits are downloaded. Entire process is now limited by your internet connection speed + archive unpacking.

One thing to watch out - at least on linux `os.rmdir` fails to remove some symlinks. Must be premake limitation. I have to manually delete that directory.

Edit:
`package_llvm` command creates archive with wrong commit hash. Do not merge until fixed.