### PR TITLE
Explicitly disable use of libedit, zlib, terminfo and libxml2 in LLVM builds

### DIFF
--- a/build/scripts/LLVM.lua
+++ b/build/scripts/LLVM.lua
@@ -183,6 +183,10 @@ function cmake(gen, conf, builddir, options)
 		or "cmake"
 	local cmd = cmake .. " -G " .. '"' .. gen .. '"'
  		.. ' -DLLVM_BUILD_TOOLS=false '
+ 		.. ' -DLLVM_ENABLE_LIBEDIT=false'
+ 		.. ' -DLLVM_ENABLE_ZLIB=false'
+ 		.. ' -DLLVM_ENABLE_TERMINFO=false'
+ 		.. ' -DLLVM_ENABLE_LIBXML2=false'
  		.. ' -DLLVM_INCLUDE_EXAMPLES=false '
  		.. ' -DLLVM_INCLUDE_DOCS=false '
  		.. ' -DLLVM_INCLUDE_TESTS=false'


### PR DESCRIPTION
These libs are not used by current official CppSharp binary distributions of LLVM, however building LLVM locally will pick these libs up and link to them if they are installed on local system. Since premake does not link to any of those libs linking to local LLVM build will cause `DllNotFoundException` due to missing symbols.