### PR TITLE
Use correct LLVM build dir for includes from unpackaged LLVM builds

### DIFF
--- a/build/LLVM.lua
+++ b/build/LLVM.lua
@@ -25,7 +25,13 @@ function SearchLLVM()
 end
 
 function get_llvm_build_dir()
-  return path.join(LLVMRootDir, get_llvm_package_name())
+  local packageDir = path.join(LLVMRootDir, get_llvm_package_name())
+  local buildDir = path.join(LLVMRootDir, "build")
+  if os.isdir(buildDir) then
+    return buildDir
+  else
+    return packageDir
+  end
 end
 
 function SetupLLVMIncludes()

--- a/build/LLVM.lua
+++ b/build/LLVM.lua
@@ -94,12 +94,19 @@ function SetupLLVMLibs()
     defines { "__STDC_CONSTANT_MACROS", "__STDC_LIMIT_MACROS" }
 
   filter { "system:macosx" }
-    links { "c++", "curses", "pthread", "z" }
-    
+    links { "c++", "curses" }
+
+  filter { "system:macosx or system:linux" }
+    links { "pthread", "z" }
+
   filter { "action:vs*" }
     links { "version" }
 
   filter {}
+
+  if os.ishost("linux") and os.isfile("/usr/lib/libtinfo.so") then
+    links { "tinfo" }
+  end
 
   if LLVMDirPerConfiguration then
     filter { "configurations:Debug" }

--- a/build/LLVM.lua
+++ b/build/LLVM.lua
@@ -25,7 +25,7 @@ function SearchLLVM()
 end
 
 function get_llvm_build_dir()
-  return path.join(LLVMRootDir, "build")
+  return path.join(LLVMRootDir, get_llvm_package_name())
 end
 
 function SetupLLVMIncludes()


### PR DESCRIPTION
`get_llvm_build_dir()` returns directory `<llvm_dir>/build`. It is incorrect when using non-packaged LLVM build, because LLVM is built into `'deps/llvm/'..get_llvm_package_name()`. This change fixes issue where using unpackaged LLVM build resulted in `error: ‘StrictFP’ is not a member of ‘llvm::Attribute’`.