### PR TITLE
Enable cxx11 abi for GCC 4.9+ on linux.

### DIFF
--- a/build/scripts/LLVM.lua
+++ b/build/scripts/LLVM.lua
@@ -181,6 +181,14 @@ function cmake(gen, conf, builddir, options)
 	os.chdir(builddir)
 	local cmake = os.ishost("macosx") and "/Applications/CMake.app/Contents/bin/cmake"
 		or "cmake"
+
+	if options == nil then
+		options = ""
+	end
+	if os.istarget("linux") and _OPTIONS["no-cxx11-abi"] ~= nil then
+		options = options.." -DCMAKE_CXX_FLAGS='-D_GLIBCXX_USE_CXX11_ABI=0'"
+	end
+
 	local cmd = cmake .. " -G " .. '"' .. gen .. '"'
  		.. ' -DLLVM_BUILD_TOOLS=false '
  		.. ' -DLLVM_ENABLE_LIBEDIT=false'

--- a/src/CppParser/Bindings/CSharp/premake5.lua
+++ b/src/CppParser/Bindings/CSharp/premake5.lua
@@ -25,7 +25,11 @@ project "CppSharp.Parser.CSharp"
       end
 
   elseif os.istarget("linux") then
-      files { "x86_64-linux-gnu/**.cs" }
+      local abi = ""
+      if UseCxx11ABI() then
+          abi = "-cxx11abi"
+      end
+      files { "x86_64-linux-gnu"..abi.."/**.cs" }
   else
       print "Unknown architecture"
   end

--- a/src/CppParser/premake5.lua
+++ b/src/CppParser/premake5.lua
@@ -22,9 +22,6 @@ project "CppSharp.CppParser"
     linkoptions { "/ignore:4099" } -- LNK4099: linking object as if no debug info
   end
 
-  filter "system:linux"
-    defines { "_GLIBCXX_USE_CXX11_ABI=0" }
-
   filter {}
   
   files
@@ -65,7 +62,11 @@ project "Std-symbols"
       end
 
   elseif os.istarget("linux") then
-      files { "Bindings/CSharp/x86_64-linux-gnu/Std-symbols.cpp" }
+      local abi = ""
+      if UseCxx11ABI() then
+          abi = "-cxx11abi"
+      end
+      files { "Bindings/CSharp/x86_64-linux-gnu"..abi.."/Std-symbols.cpp" }
   else
       print "Unknown architecture"
   end


### PR DESCRIPTION
GCC version is checked, if version is 4.8 or lower then cxx11 ABI is disabled. Added new `--no-cxx11-abi` option. It explicitly disables cxx11 ABI even on new compilers. This option is also taken into account when building LLVM.