### PR TITLE
Fix linking to LLVM libs on linux, when system has llvm/clang installed.

### DIFF
--- a/build/LLVM.lua
+++ b/build/LLVM.lua
@@ -100,19 +100,12 @@ function SetupLLVMLibs()
     defines { "__STDC_CONSTANT_MACROS", "__STDC_LIMIT_MACROS" }
 
   filter { "system:macosx" }
-    links { "c++", "curses" }
-
-  filter { "system:macosx or system:linux" }
-    links { "pthread", "z" }
+    links { "c++", "curses", "pthread", "z" }
 
   filter { "action:vs*" }
     links { "version" }
 
   filter {}
-
-  if os.ishost("linux") and os.isfile("/usr/lib/libtinfo.so") then
-    links { "tinfo" }
-  end
 
   if LLVMDirPerConfiguration then
     filter { "configurations:Debug" }

--- a/build/scripts/LLVM.lua
+++ b/build/scripts/LLVM.lua
@@ -4,6 +4,14 @@ require "../Helpers"
 
 local llvm = path.getabsolute(basedir .. "/../deps/llvm")
 
+-- Prevent premake from inserting /usr/lib64 search path on linux. GCC does not need this path specified
+-- as compiler automatically knows where to look for system libs. Insertion of this path causes issues
+-- when system has clang/llvm libs installed. Build would link to system libraries instead of custom
+-- build required by CppSharp.
+if os.istarget("linux") then
+	premake.tools.gcc.libraryDirectories['architecture']['x86_64'] = function(cfg) return {} end
+end
+
 -- If we are inside vagrant then clone and build LLVM outside the shared folder,
 -- otherwise file I/O performance will be terrible.
 if is_vagrant() then


### PR DESCRIPTION
This change prevents premake from inserting /usr/lib64 search path on linux. GCC does not need this path specified compiler automatically knows where to look for system libs. Insertion of this path causes issues system has clang/llvm libs installed. Build would link to system libraries instead of custom required by CppSharp.

Also this patch revealed that linking to `pthread`, `z` and `tinfo` libraries on linux is not necessary and disabling them in LLVM build config works. Linking to these libs was removed. As you probably have guessed in the past CppSharp would throw `DllNotFoundException` due to missing symbols because it linked to system LLVM libs, not custom in-tree LLVM build.

This should be a final piece of the puzzle to linux builds. Binaries produced by `build/Compile.sh` can now run and produce bindings on Archlinux and probably any other modern linux distribution (even though `CSharp.Gen` test still crashes for me).