### PR TITLE
Add ability for managed module wrapper to reference extra assemblies.

### DIFF
--- a/src/AST/Module.cs
+++ b/src/AST/Module.cs
@@ -14,6 +14,7 @@ namespace CppSharp.AST
         public string OutputNamespace { get; set; }
         public List<TranslationUnit> Units { get; } = new List<TranslationUnit>();
         public List<string> CodeFiles { get; } = new List<string>();
+        public List<string> ReferencedAssemblies { get; } = new List<string>();
         public List<Module> Dependencies { get; } = new List<Module>();
 
         [Obsolete("Use Module(string libraryName) instead.")]

--- a/src/Generator/Driver.cs
+++ b/src/Generator/Driver.cs
@@ -357,6 +357,8 @@ namespace CppSharp
                  where libraryMappings.ContainsKey(dependency)
                  select libraryMappings[dependency]).ToArray());
 
+            compilerParameters.ReferencedAssemblies.AddRange(module.ReferencedAssemblies.ToArray());
+
             Diagnostics.Message($"Compiling {module.LibraryName}...");
             CompilerResults compilerResults;
             using (var codeProvider = new CSharpCodeProvider(


### PR DESCRIPTION
I came to need of this when converting native `Color` type to `System.Drawing.Color`. .net type requires reference to extra assembly. This will probably be useful for more types as well.