### PR TITLE
GetterSetterToPropertyPass customization

### DIFF
--- a/src/AST/Method.cs
+++ b/src/AST/Method.cs
@@ -105,6 +105,7 @@ namespace CppSharp.AST
             SynthKind = method.SynthKind;
             AdjustedOffset = method.AdjustedOffset;
             OverriddenMethods.AddRange(method.OverriddenMethods);
+            ConvertToProperty = method.ConvertToProperty;
         }
 
         public Method(Function function)
@@ -171,6 +172,8 @@ namespace CppSharp.AST
         public int AdjustedOffset { get; set; }
 
         public List<Method> OverriddenMethods { get; } = new List<Method>();
+
+        public bool ConvertToProperty { get; set; }
 
         public Method GetRootBaseMethod()
         {

--- a/src/Generator/Options.cs
+++ b/src/Generator/Options.cs
@@ -162,6 +162,8 @@ namespace CppSharp
         /// </summary>
         public HashSet<string> ExplicitlyPatchedVirtualFunctions { get; }
 
+        public bool UsePropertyDetectionHeuristics { get; set; } = true;
+
         #endregion
     }
 

--- a/src/Generator/Passes/GetterSetterToPropertyPass.cs
+++ b/src/Generator/Passes/GetterSetterToPropertyPass.cs
@@ -25,7 +25,8 @@ namespace CppSharp.Passes
             {
                 this.useHeuristics = useHeuristics;
                 foreach (var method in @class.Methods.Where(
-                    m => !m.IsConstructor && !m.IsDestructor && !m.IsOperator && m.IsGenerated))
+                    m => !m.IsConstructor && !m.IsDestructor && !m.IsOperator && m.IsGenerated &&
+                         !m.ExcludeFromPasses.Contains(typeof(GetterSetterToPropertyPass))))
                     DistributeMethod(method);
             }
 
@@ -261,7 +262,7 @@ namespace CppSharp.Passes
                 }
                 else
                 {
-                    if (IsGetter(method))
+                    if (method.ConvertToProperty || IsGetter(method))
                         getters.Add(method);
                     if (method.Parameters.All(p => p.Kind == ParameterKind.IndirectReturnType))
                         nonSetters.Add(method);

--- a/src/Generator/Passes/GetterSetterToPropertyPass.cs
+++ b/src/Generator/Passes/GetterSetterToPropertyPass.cs
@@ -19,9 +19,11 @@ namespace CppSharp.Passes
             private readonly List<Method> setters = new List<Method>();
             private readonly List<Method> setMethods = new List<Method>();
             private readonly List<Method> nonSetters = new List<Method>();
+            private bool useHeuristics = true;
 
-            public PropertyGenerator(Class @class)
+            public PropertyGenerator(Class @class, bool useHeuristics)
             {
+                this.useHeuristics = useHeuristics;
                 foreach (var method in @class.Methods.Where(
                     m => !m.IsConstructor && !m.IsDestructor && !m.IsOperator && m.IsGenerated))
                     DistributeMethod(method);
@@ -266,16 +268,21 @@ namespace CppSharp.Passes
                 }
             }
 
-            private static bool IsGetter(Method method)
+            private bool IsGetter(Method method)
             {
                 if (method.IsDestructor ||
                     (method.OriginalReturnType.Type.IsPrimitiveType(PrimitiveType.Void)) ||
                     method.Parameters.Any(p => p.Kind != ParameterKind.IndirectReturnType))
                     return false;
                 var firstWord = GetFirstWord(method.Name);
-                return (firstWord.Length < method.Name.Length &&
-                    Match(firstWord, new[] { "get", "is", "has" })) ||
-                    (!Match(firstWord, new[] { "to", "new" }) && !verbs.Contains(firstWord));
+
+                if (firstWord.Length < method.Name.Length && Match(firstWord, new[] {"get", "is", "has"}))
+                    return true;
+
+                if (useHeuristics && !Match(firstWord, new[] {"to", "new"}) && !verbs.Contains(firstWord))
+                    return true;
+
+                return false;
             }
 
             private static bool Match(string prefix, IEnumerable<string> prefixes)
@@ -354,7 +361,7 @@ namespace CppSharp.Passes
         public override bool VisitClassDecl(Class @class)
         {
             if (base.VisitClassDecl(@class))
-                new PropertyGenerator(@class).GenerateProperties();
+                new PropertyGenerator(@class, Options.UsePropertyDetectionHeuristics).GenerateProperties();
             return false;
         }
     }

--- a/src/Generator/Passes/verbs.txt
+++ b/src/Generator/Passes/verbs.txt
@@ -7322,6 +7322,7 @@ ruckle
 ruddle
 ruggedize
 ruminate
+run
 runtgenize
 ruralise
 ruralize


### PR DESCRIPTION
Remove internal class from `GetterSetterToPropertyPass` and make some methods `protected virtual` in order to allow customization of this pass.

`GetterSetterToPropertyPass` is trying to be too smart and converts too many things to properties. One such example is `void Run()` method getting converted to property, which makes no sense. I can not tell original intention behind logic in `IsGetter()` so instead of changing it i propose moving everything from private `PropertyGenerator` class to `GetterSetterToPropertyPass` and making some methods virtual so user may inherit this class, override some methods and replace the pass.

My personal opinion is that CppSharp is trying to be too smart here. Converting obvious things to properties (methods stating with "get"/"set" and maybe "is") is fine, however applying heuristics to guess what user might wish is not a good idea. Heuristics get things wrong. I propose completely removing guessing part. I can do this if approved. User should still be able to customize this pass though.

Also logic in `IsGetter()` seems broken:
```cs
            return (firstWord.Length < method.Name.Length &&
                Match(firstWord, new[] { "get", "is", "has" })) ||
                (!Match(firstWord, new[] { "to", "new" }) && !verbs.Contains(firstWord));
```
A method is considered getter if it 1. does not begin with "to" or "new" and 2. is not in verbs.txt file which is full of weird words that are used rarely if ever.