### PR TITLE
Fix generated symbols checking when `Options.CheckSymbols = true`

### DIFF
--- a/src/AST/SymbolContext.cs
+++ b/src/AST/SymbolContext.cs
@@ -80,15 +80,20 @@ namespace CppSharp.AST
             {
                 foreach (var symbol in library.Symbols)
                 {
-                    if (!Symbols.ContainsKey(symbol))
-                        Symbols[symbol] = library;
-                    if (symbol.StartsWith("__", StringComparison.Ordinal))
-                    {
-                        string stripped = symbol.Substring(1);
-                        if (!Symbols.ContainsKey(stripped))
-                            Symbols[stripped] = library;
-                    }
+                    AddSymbol(library, symbol);
                 }
+            }
+        }
+
+        public void AddSymbol(NativeLibrary library, string symbol)
+        {
+            if (!Symbols.ContainsKey(symbol))
+                Symbols[symbol] = library;
+            if (symbol.StartsWith("__", StringComparison.Ordinal))
+            {
+                string stripped = symbol.Substring(1);
+                if (!Symbols.ContainsKey(stripped))
+                    Symbols[stripped] = library;
             }
         }
 

--- a/src/Generator/Passes/GenerateSymbolsPass.cs
+++ b/src/Generator/Passes/GenerateSymbolsPass.cs
@@ -112,7 +112,13 @@ namespace CppSharp.Passes
                 return false;
 
             var symbolsCodeGenerator = GetSymbolsCodeGenerator(module);
-            return function.Visit(symbolsCodeGenerator);
+            if (function.Visit(symbolsCodeGenerator))
+            {
+                Context.Symbols.AddSymbol(Context.Symbols.FindOrCreateLibrary(module.SymbolsLibraryName),
+                    function.Mangled);
+                return true;
+            }
+            return false;
         }
 
         public class SymbolsCodeEventArgs : EventArgs


### PR DESCRIPTION
When `Options.CheckSymbols` was enabled CppSharp discarded generated symbols from `<name>-symbols.cpp` as non-existing, because they were not registered with `Context.Symbols`. This change registers newly generated symbols with `Context.Symbols` and they are no longer discarded.

Also previously incorrect library name for generated symbols was picked. CppSharp defaulted to picking library name of managed wrapper. As a result managed wrapper and symbols library would have name collision on windows where prefixes and suffixes of native libraries are the same as of managed libraries. This change registers generated symbols to `module.SymbolsLibraryName` and now generated symbols are correctly imported from `<name>-symbols.dll` or `lib<name>-symbols.so`.