### PR TITLE
Write error messages to stderr, renamed `messages` to `errorMessages`

### DIFF
--- a/src/Core/Diagnostics.cs
+++ b/src/Core/Diagnostics.cs
@@ -120,7 +120,14 @@ namespace CppSharp
             var currentIndent = Indents.Sum();
             var message = new string(' ', currentIndent) + info.Message;
 
-            Console.WriteLine(message);
+            if(info.Kind == DiagnosticKind.Error)
+            {
+                Console.Error.WriteLine(message);
+            }
+            else 
+            {
+                Console.WriteLine(message);
+            }
             Debug.WriteLine(message);
         }
 


### PR DESCRIPTION
Fixes #1077 

Also renamed `messages` to `errorMessages` because that's what they are, and they are going to stderr.