### PR TITLE
Added type maps for primitive strings (pointers to char)

### DIFF
--- a/src/AST/CppTypePrinter.cs
+++ b/src/AST/CppTypePrinter.cs
@@ -181,7 +181,7 @@ namespace CppSharp.AST
         {
             FunctionType func;
             if (ResolveTypedefs && !typedef.Declaration.Type.IsPointerTo(out func))
-                return typedef.Declaration.Type.Visit(this);
+                return typedef.Declaration.Type.Visit(this, quals);
             var qual = GetStringQuals(quals);
             return $"{qual}{typedef.Declaration.Visit(this)}";
         }

--- a/src/Generator/Generators/CSharp/CSharpSources.cs
+++ b/src/Generator/Generators/CSharp/CSharpSources.cs
@@ -927,12 +927,12 @@ namespace CppSharp.Generators.CSharp
                 if (type.IsPointer())
                 {
                     Type pointee = type.GetFinalPointee();
-                    if (pointee.IsPrimitiveType() && !type.IsConstCharString())
+                    if (pointee.IsPrimitiveType())
                     {
                         Write($"({CSharpTypePrinter.IntPtrType}) ");
                         var templateSubstitution = pointee.Desugar(false) as TemplateParameterSubstitutionType;
                         if (templateSubstitution != null)
-                            Write($"(object) ");
+                            Write("(object) ");
                     }
                 }
                 WriteLine($"{marshal.Context.Return};");
@@ -1672,11 +1672,12 @@ namespace CppSharp.Generators.CSharp
                 {
                     ReturnType = param.QualifiedType,
                     ReturnVarName = param.Name,
-                    ParameterIndex = i
+                    ParameterIndex = i,
+                    Parameter = param
                 };
 
                 ctx.PushMarshalKind(MarshalKind.GenericDelegate);
-                var marshal = new CSharpMarshalNativeToManagedPrinter(ctx) { MarshalsParameter = true };
+                var marshal = new CSharpMarshalNativeToManagedPrinter(ctx);
                 param.Visit(marshal);
                 ctx.PopMarshalKind();
 

--- a/src/Generator/Generators/CSharp/CSharpTypePrinter.cs
+++ b/src/Generator/Generators/CSharp/CSharpTypePrinter.cs
@@ -184,16 +184,16 @@ namespace CppSharp.Generators.CSharp
 
             if (allowStrings && pointer.IsConstCharString())
             {
-                if (isManagedContext)
-                    return "string";
-                if (Parameter == null || Parameter.Name == Helpers.ReturnIdentifier)
-                    return IntPtrType;
-                if (Options.Encoding == Encoding.ASCII)
-                    return string.Format("[MarshalAs(UnmanagedType.LPStr)] string");
-                if (Options.Encoding == Encoding.Unicode ||
-                    Options.Encoding == Encoding.BigEndianUnicode)
-                    return string.Format("[MarshalAs(UnmanagedType.LPWStr)] string");
-                throw new NotSupportedException($"{Options.Encoding.EncodingName} is not supported yet.");
+                TypeMap typeMap;
+                TypeMapDatabase.FindTypeMap(pointer, out typeMap);
+                var typePrinterContext = new TypePrinterContext()
+                {
+                    Kind = Kind,
+                    MarshalKind = MarshalKind,
+                    Type = pointer.Pointee,
+                    Parameter = Parameter
+                };
+                return typeMap.CSharpSignatureType(typePrinterContext).Visit(this);
             }
 
             var pointee = pointer.Pointee.Desugar();

--- a/tests/CSharp/CSharp.cpp
+++ b/tests/CSharp/CSharp.cpp
@@ -2,6 +2,10 @@
 
 #include "CSharp.h"
 
+Foo::Foo(const QString& name)
+{
+}
+
 Foo::Foo(const char* name) : publicFieldMappedToEnum(TestFlag::Flag2)
 {
     A = 10;

--- a/tests/CSharp/CSharp.cs
+++ b/tests/CSharp/CSharp.cs
@@ -243,6 +243,25 @@ namespace CppSharp.Tests
         }
     }
 
+    [TypeMap("QString")]
+    public class QString : TypeMap
+    {
+        public override Type CSharpSignatureType(TypePrinterContext ctx)
+        {
+            return new CILType(typeof(string));
+        }
+
+        public override void CSharpMarshalToNative(CSharpMarshalContext ctx)
+        {
+            ctx.Return.Write("\"test\"");
+        }
+
+        public override void CSharpMarshalToManaged(CSharpMarshalContext ctx)
+        {
+            ctx.Return.Write("\"test\"");
+        }
+    }
+
     #endregion
 }
 

--- a/tests/CSharp/CSharp.h
+++ b/tests/CSharp/CSharp.h
@@ -8,9 +8,14 @@
 #include "AnotherUnit.h"
 #include "CSharpTemplates.h"
 
+class DLL_API QString
+{
+};
+
 class DLL_API Foo
 {
 public:
+    Foo(const QString& name);
     Foo(const char* name = 0);
     Foo(int a, int p = 0);
     Foo(char16_t ch);


### PR DESCRIPTION
const char*, const char16_t* and const wchar_t* in particular.

This enables comparison of types when resolving ambiguity.