### PR TITLE
[WIP] Fixed generation of anonymous class types.

### DIFF
--- a/tests/CSharp/CSharp.h
+++ b/tests/CSharp/CSharp.h
@@ -1301,3 +1301,12 @@ private:
 
 DLL_API void va_listFunction(va_list v);
 DLL_API char* returnCharPointer();
+
+/* User functions. */
+struct {
+    struct {
+        struct {
+            int(*forIntegers)(int b, short s, unsigned int i);
+        } example;
+    } root;
+} kotlin;


### PR DESCRIPTION
Reverts https://github.com/mono/CppSharp/commit/a3bc0491f949454775c03786e818561fd951cc22.

And fixes the automatic renaming of such types in CleanInvalidDeclNamesPass.

Partial fix for https://github.com/mono/CppSharp/issues/1188.