### PR TITLE
Fix Xcode 10.2+ build

### DIFF
--- a/src/CppParser/Bindings/CSharp/i686-apple-darwin12.4.0/Std-symbols.cpp
+++ b/src/CppParser/Bindings/CSharp/i686-apple-darwin12.4.0/Std-symbols.cpp
@@ -1,4 +1,5 @@
 #define _LIBCPP_DISABLE_VISIBILITY_ANNOTATIONS
+#define _LIBCPP_HIDE_FROM_ABI
 
 #include <string>
 

--- a/src/CppParser/Bindings/CSharp/x86_64-apple-darwin12.4.0/Std-symbols.cpp
+++ b/src/CppParser/Bindings/CSharp/x86_64-apple-darwin12.4.0/Std-symbols.cpp
@@ -1,4 +1,5 @@
 #define _LIBCPP_DISABLE_VISIBILITY_ANNOTATIONS
+#define _LIBCPP_HIDE_FROM_ABI
 
 #include <string>
 


### PR DESCRIPTION
This change fixes the issue described in #1203.

The old macro is left intact to ensure compatibility with older versions of Xcode.

There is no reason to make this change for x86 build but consistency.