### PR TITLE
Fix generating delegates for cases like https://github.com/mono/CppSharp/issues/1144

### DIFF
--- a/src/Generator/Generators/CSharp/CSharpTypePrinter.cs
+++ b/src/Generator/Generators/CSharp/CSharpTypePrinter.cs
@@ -276,7 +276,14 @@ namespace CppSharp.Generators.CSharp
                 return typeMap.CSharpSignatureType(typePrinterContext).ToString();
             }
 
-            FunctionType func = decl.Type as FunctionType;
+            FunctionType func;
+            if (decl.Type.IsPointerTo(out func))
+            {
+                if (MarshalKind == MarshalKind.GenericDelegate && ContextKind == TypePrinterContextKind.Native)
+                    return VisitDeclaration(decl);
+            }
+
+            func = decl.Type as FunctionType;
             if (func != null || decl.Type.IsPointerTo(out func))
             {
                 if (ContextKind == TypePrinterContextKind.Native)

--- a/src/Generator/Passes/DelegatesPass.cs
+++ b/src/Generator/Passes/DelegatesPass.cs
@@ -94,6 +94,9 @@ namespace CppSharp.Passes
 
         public override bool VisitParameterDecl(Parameter parameter)
         {
+            if(parameter.Namespace?.TranslationUnit?.Module == null && namespaces.Count > 0)
+                parameter.Namespace = namespaces.Peek();
+
             if (!base.VisitDeclaration(parameter) || parameter.Namespace == null ||
                 parameter.Namespace.Ignore)
                 return false;
@@ -117,11 +120,16 @@ namespace CppSharp.Passes
 
         public override bool VisitFieldDecl(Field field)
         {
+            if (field.Namespace?.TranslationUnit?.Module != null)
+                namespaces.Push(field.Namespace);
+
             if (!base.VisitFieldDecl(field))
                 return false;
 
             field.QualifiedType = CheckForDelegate(field.QualifiedType,
                 field.Namespace);
+
+            namespaces.Clear();
 
             return true;
         }
@@ -297,5 +305,6 @@ namespace CppSharp.Passes
         /// iterating over it, so we collect all the typedefs and add them at the end.
         /// </summary>
         private readonly List<TypedefDecl> delegates = new List<TypedefDecl>();
+        private readonly Stack<DeclarationContext> namespaces = new Stack<DeclarationContext>();
     }
 }

--- a/tests/CSharp/CSharp.Tests.cs
+++ b/tests/CSharp/CSharp.Tests.cs
@@ -1268,6 +1268,8 @@ public unsafe class CSharpTests : GeneratorTestFixture
         {
             hasFunctionPtrField.FunctionPtrField = @string => @string.Length;
             Assert.That(hasFunctionPtrField.FunctionPtrField("Test"), Is.EqualTo(4));
+            hasFunctionPtrField.FunctionPtrTakeFunctionPtrField = field => field();
+            Assert.That(hasFunctionPtrField.FunctionPtrTakeFunctionPtrField(() => 42), Is.EqualTo(42));
         }
     }
 

--- a/tests/CSharp/CSharp.h
+++ b/tests/CSharp/CSharp.h
@@ -1301,6 +1301,7 @@ public:
     HasFunctionPtrField();
     ~HasFunctionPtrField();
     int (*functionPtrField)(const char*);
+    int (*functionPtrTakeFunctionPtrField)(int(*TakenInFuncPtrField)());
 };
 
 DLL_API void va_listFunction(va_list v);


### PR DESCRIPTION
```
struct fieldspointers
{
	int(*funcint)(int(*bug)());
};
```
[Result](https://gist.github.com/AleXr64/65b04836e000f4798db48df2cba88faf)
BTW, review requested