### PR TITLE
Fix default arguments to only map to null if pointers

### DIFF
--- a/src/AST/FunctionExtensions.cs
+++ b/src/AST/FunctionExtensions.cs
@@ -16,18 +16,8 @@ namespace CppSharp.AST
 
             var pointer = new QualifiedType(new PointerType(new QualifiedType(new BuiltinType(PrimitiveType.Void))));
 
-            if (isInstanceMethod && !isItaniumLikeAbi)
-            {
-                @params.Add(new Parameter
-                    {
-                        QualifiedType = pointer,
-                        Name = "__instance",
-                        Namespace = function
-                    });
-            }
-
-            if (!function.HasIndirectReturnTypeParameter &&
-                isInstanceMethod && isItaniumLikeAbi)
+            if (isInstanceMethod &&
+                (!isItaniumLikeAbi || !function.HasIndirectReturnTypeParameter))
             {
                 @params.Add(new Parameter
                     {

--- a/src/Generator/Driver.cs
+++ b/src/Generator/Driver.cs
@@ -253,11 +253,6 @@ namespace CppSharp
 
             if (Options.IsCSharpGenerator)
             {
-                if (Options.GenerateDefaultValuesForArguments)
-                {
-                    TranslationUnitPasses.AddPass(new FixDefaultParamValuesOfOverridesPass());
-                    TranslationUnitPasses.AddPass(new HandleDefaultParamValuesPass());
-                }
                 TranslationUnitPasses.AddPass(new GenerateAbstractImplementationsPass());
                 TranslationUnitPasses.AddPass(new MultipleInheritancePass());
             }

--- a/src/Generator/Generators/CSharp/CSharpGenerator.cs
+++ b/src/Generator/Generators/CSharp/CSharpGenerator.cs
@@ -25,6 +25,12 @@ namespace CppSharp.Generators.CSharp
 
         public override bool SetupPasses()
         {
+            if (Context.Options.GenerateDefaultValuesForArguments)
+            {
+                Context.TranslationUnitPasses.AddPass(new FixDefaultParamValuesOfOverridesPass());
+                Context.TranslationUnitPasses.AddPass(new HandleDefaultParamValuesPass());
+            }
+
             // Both the CheckOperatorsOverloadsPass and CheckAbiParameters can
             // create and and new parameters to functions and methods. Make sure
             // CheckAbiParameters runs last because hidden structure parameters

--- a/src/Generator/Passes/HandleDefaultParamValuesPass.cs
+++ b/src/Generator/Passes/HandleDefaultParamValuesPass.cs
@@ -75,7 +75,7 @@ namespace CppSharp.Passes
         {
             var desugared = type.Desugar();
 
-            if (!desugared.IsPrimitiveTypeConvertibleToRef() &&
+            if (desugared.IsAddress() && !desugared.IsPrimitiveTypeConvertibleToRef() &&
                 (expression.String == "0" || expression.String == "nullptr"))
             {
                 result = desugared.GetPointee()?.Desugar() is FunctionType ?

--- a/tests/CSharp/CSharp.Tests.cs
+++ b/tests/CSharp/CSharp.Tests.cs
@@ -249,7 +249,7 @@ public unsafe class CSharpTests : GeneratorTestFixture
             methodsWithDefaultValues.DefaultMappedToZeroEnum();
             methodsWithDefaultValues.DefaultMappedToEnumAssignedWithCtor();
             methodsWithDefaultValues.DefaultZeroMappedToEnumAssignedWithCtor();
-            methodsWithDefaultValues.DefaultImplicitCtorInt();
+            Assert.That(methodsWithDefaultValues.DefaultImplicitCtorInt().Priv, Is.EqualTo(0));
             methodsWithDefaultValues.DefaultImplicitCtorChar();
             methodsWithDefaultValues.DefaultImplicitCtorFoo();
             methodsWithDefaultValues.DefaultImplicitCtorEnum();

--- a/tests/CSharp/CSharp.cpp
+++ b/tests/CSharp/CSharp.cpp
@@ -117,7 +117,7 @@ Quux::Quux() : _setterWithDefaultOverload(0)
 
 Quux::Quux(int i) : Quux()
 {
-
+    priv = i;
 }
 
 Quux::Quux(char c) : Quux()
@@ -137,6 +137,11 @@ Quux::~Quux()
         delete _setterWithDefaultOverload;
         _setterWithDefaultOverload = 0;
     }
+}
+
+int Quux::getPriv() const
+{
+    return priv;
 }
 
 Foo* Quux::setterWithDefaultOverload()
@@ -645,8 +650,9 @@ void MethodsWithDefaultValues::defaultZeroMappedToEnumAssignedWithCtor(DefaultZe
 {
 }
 
-void MethodsWithDefaultValues::defaultImplicitCtorInt(Quux arg)
+Quux MethodsWithDefaultValues::defaultImplicitCtorInt(Quux arg)
 {
+    return arg;
 }
 
 void MethodsWithDefaultValues::defaultImplicitCtorChar(Quux arg)

--- a/tests/CSharp/CSharp.h
+++ b/tests/CSharp/CSharp.h
@@ -56,6 +56,7 @@ public:
     Quux(Foo f);
     ~Quux();
 
+    int getPriv() const;
     Foo* setterWithDefaultOverload();
     void setSetterWithDefaultOverload(Foo* value = new Foo());
 
@@ -419,7 +420,7 @@ public:
     void defaultMappedToZeroEnum(QFlags<Flags> qFlags = 0);
     void defaultMappedToEnumAssignedWithCtor(QFlags<Flags> qFlags = QFlags<Flags>());
     void defaultZeroMappedToEnumAssignedWithCtor(DefaultZeroMappedToEnum defaultZeroMappedToEnum = DefaultZeroMappedToEnum());
-    void defaultImplicitCtorInt(Quux arg = 0);
+    Quux defaultImplicitCtorInt(Quux arg = 0);
     void defaultImplicitCtorChar(Quux arg = 'a');
     void defaultImplicitCtorFoo(Quux arg = Foo());
     // this looks the same test as 'defaultRefTypeEnumImplicitCtor' two lines below


### PR DESCRIPTION
This bug is revealed by properly fixing the reading of ABI parameters in the parser.