### PR TITLE
Fixed out of range exception when property name equals "Get".

### DIFF
--- a/src/Generator/Passes/GetterSetterToPropertyPass.cs
+++ b/src/Generator/Passes/GetterSetterToPropertyPass.cs
@@ -224,7 +224,7 @@ namespace CppSharp.Passes
             private static string GetPropertyName(string name)
             {
                 var firstWord = GetFirstWord(name);
-                if (Match(firstWord, new[] { "get" }) && name != firstWord &&
+                if (Match(firstWord, new[] { "get" }) && name != firstWord && name.Length > 3 &&
                     !char.IsNumber(name[3]))
                 {
                     if (char.IsLower(name[0]))


### PR DESCRIPTION
Access on string array `name[3] ` generates an `IndexOutOfRangeException` when the given parameter euqals "Get".