### PR TITLE
Fix enum with zeros for hex literals

### DIFF
--- a/src/Generator.Tests/Passes/TestPasses.cs
+++ b/src/Generator.Tests/Passes/TestPasses.cs
@@ -108,6 +108,11 @@ namespace CppSharp.Generator.Tests.Passes
             var @enum = AstContext.Enum("TestEnumItemName");
             Assert.IsNotNull(@enum);
 
+            // Testing the values read for the enum
+            Assert.AreEqual(0, @enum.Items[0].Value); // Decimal literal
+            Assert.AreEqual(1, @enum.Items[1].Value); // Hex literal
+            Assert.AreEqual(2, @enum.Items[2].Value); // Hex literal with suffix
+
             passBuilder.RemovePrefix("TEST_ENUM_ITEM_NAME_", RenameTargets.EnumItem);
             passBuilder.AddPass(new CleanInvalidDeclNamesPass());
             passBuilder.RunPasses(pass => pass.VisitASTContext(AstContext));

--- a/src/Generator/Library.cs
+++ b/src/Generator/Library.cs
@@ -103,6 +103,9 @@ namespace CppSharp
             {
                 num = num.Substring(2);
 
+                // This is in case the literal contains suffix
+                num = Regex.Replace(num, "(?i)[ul]*$", String.Empty);
+
                 return long.TryParse(num, NumberStyles.HexNumber,
                     CultureInfo.CurrentCulture, out val);
             }

--- a/tests/Native/Passes.h
+++ b/tests/Native/Passes.h
@@ -39,8 +39,8 @@ struct TestReadOnlyProperties
 };
 
 #define TEST_ENUM_ITEM_NAME_0 0
-#define TEST_ENUM_ITEM_NAME_1 1
-#define TEST_ENUM_ITEM_NAME_2 2
+#define TEST_ENUM_ITEM_NAME_1 0x1
+#define TEST_ENUM_ITEM_NAME_2 0x2U
 
 // TestStructInheritance
 struct S1 { int F1, F2; };


### PR DESCRIPTION
I am not sure how to add a unit tests, there does not seems to be a tests file for Library.cs, so I could not update the tests.

I ran the existing tests and they passed.

Fixes #1264 