### PR TITLE
Fix template type checking in CovariantTypeComparer.

### DIFF
--- a/src/Generator/Passes/CheckVirtualOverrideReturnCovariance.cs
+++ b/src/Generator/Passes/CheckVirtualOverrideReturnCovariance.cs
@@ -71,6 +71,19 @@ namespace CppSharp.Passes
             return tag.Declaration.Visit(this);
         }
 
+        public override bool VisitTemplateSpecializationType(TemplateSpecializationType template,
+            TypeQualifiers quals)
+        {
+            if (!currentType.Qualifiers.Equals(quals))
+                return false;
+
+            var currentTemplateType = currentType.Type as TemplateSpecializationType;
+            if (currentTemplateType == null)
+                return false;
+
+            return currentTemplateType.Equals(template);
+        }
+
         static bool IsDescendentOf(Class @class, Class parent)
         {
             return @class == parent ||

--- a/tests/Common/Common.h
+++ b/tests/Common/Common.h
@@ -6,6 +6,7 @@
 #endif
 #include <string>
 #include <vector>
+#include <memory>
 
 class DLL_API TestPacking
 {
@@ -1522,3 +1523,17 @@ struct DLL_API StructWithCopyCtor
 };
 
 uint16_t DLL_API TestStructWithCopyCtorByValue(StructWithCopyCtor s);
+
+// Issue: https://github.com/mono/CppSharp/issues/1266
+struct BaseCovariant;
+typedef std::unique_ptr<BaseCovariant> PtrCovariant;
+
+struct BaseCovariant {
+  virtual PtrCovariant clone() const = 0;
+};
+
+struct DerivedCovariant: public BaseCovariant {
+  std::unique_ptr<BaseCovariant> clone() const override {
+    return PtrCovariant(new DerivedCovariant());
+  }
+};


### PR DESCRIPTION
Fixes https://github.com/mono/CppSharp/issues/1266.