### PR TITLE
Implement UnresolvedUsingType and UnresolvedUsingTypename.

### DIFF
--- a/src/AST/ASTVisitor.cs
+++ b/src/AST/ASTVisitor.cs
@@ -273,6 +273,11 @@ namespace CppSharp.AST
             return true;
         }
 
+        public bool VisitUnresolvedUsingType(UnresolvedUsingType unresolvedUsingType, TypeQualifiers quals)
+        {
+            return true;
+        }
+
         public bool VisitVectorType(VectorType vectorType, TypeQualifiers quals)
         {
             return true;
@@ -632,6 +637,14 @@ namespace CppSharp.AST
         public bool VisitNonTypeTemplateParameterDecl(NonTypeTemplateParameter nonTypeTemplateParameter)
         {
             if (!VisitDeclaration(nonTypeTemplateParameter))
+                return false;
+
+            return true;
+        }
+
+        public bool VisitUnresolvedUsingDecl(UnresolvedUsingTypename unresolvedUsingTypename)
+        {
+            if (!VisitDeclaration(unresolvedUsingTypename))
                 return false;
 
             return true;

--- a/src/AST/Declaration.cs
+++ b/src/AST/Declaration.cs
@@ -399,5 +399,6 @@ namespace CppSharp.AST
         T VisitTemplateParameterDecl(TypeTemplateParameter templateParameter);
         T VisitNonTypeTemplateParameterDecl(NonTypeTemplateParameter nonTypeTemplateParameter);
         T VisitTypeAliasTemplateDecl(TypeAliasTemplate typeAliasTemplate);
+        T VisitUnresolvedUsingDecl(UnresolvedUsingTypename unresolvedUsingTypename);
     }
 }

--- a/src/AST/Template.cs
+++ b/src/AST/Template.cs
@@ -438,4 +438,17 @@ namespace CppSharp.AST
     public class VarTemplatePartialSpecialization : VarTemplateSpecialization
     {
     }
+
+    /// <summary>
+    /// Represents a dependent using declaration which was marked with typename.
+    /// </summary>
+    public class UnresolvedUsingTypename : Declaration
+    {
+        //public TypeAliasTemplate DescribedAliasTemplate { get; set; }
+
+        public override T Visit<T>(IDeclVisitor<T> visitor)
+        {
+            return visitor.VisitUnresolvedUsingDecl(this);
+        }
+    }
 }

--- a/src/AST/Type.cs
+++ b/src/AST/Type.cs
@@ -1062,6 +1062,32 @@ namespace CppSharp.AST
             Desugared.GetHashCode() ^ BaseType.GetHashCode();
     }
 
+    public class UnresolvedUsingType : Type
+    {
+        public UnresolvedUsingType()
+        {
+        }
+
+        public UnresolvedUsingType(UnresolvedUsingType type)
+            : base(type)
+        {
+        }
+
+        public UnresolvedUsingTypename Declaration { get; set; }
+
+        public override T Visit<T>(ITypeVisitor<T> visitor, TypeQualifiers quals = new TypeQualifiers())
+        {
+            return visitor.VisitUnresolvedUsingType(this, quals);
+        }
+
+        public override object Clone()
+        {
+            return new UnresolvedUsingType(this);
+        }
+
+        public override int GetHashCode() => Declaration.GetHashCode();
+    }
+
     public class VectorType : Type
     {
         public VectorType()
@@ -1257,6 +1283,7 @@ namespace CppSharp.AST
             TypeQualifiers quals);
         T VisitPackExpansionType(PackExpansionType packExpansionType, TypeQualifiers quals);
         T VisitUnaryTransformType(UnaryTransformType unaryTransformType, TypeQualifiers quals);
+        T VisitUnresolvedUsingType(UnresolvedUsingType unresolvedUsingType, TypeQualifiers quals);
         T VisitVectorType(VectorType vectorType, TypeQualifiers quals);
         T VisitCILType(CILType type, TypeQualifiers quals);
         T VisitUnsupportedType(UnsupportedType type, TypeQualifiers quals);

--- a/src/CppParser/AST.cpp
+++ b/src/CppParser/AST.cpp
@@ -187,10 +187,11 @@ DependentNameType::DependentNameType() : Type(TypeKind::DependentName) {}
 
 DependentNameType::~DependentNameType() {}
 
-
 PackExpansionType::PackExpansionType() : Type(TypeKind::PackExpansion) {}
 
 UnaryTransformType::UnaryTransformType() : Type(TypeKind::UnaryTransform) {}
+
+UnresolvedUsingType::UnresolvedUsingType() : Type(TypeKind::UnresolvedUsing) {}
 
 VectorType::VectorType() : Type(TypeKind::Vector), numElements(0) {}
 
@@ -851,6 +852,10 @@ VarTemplatePartialSpecialization::VarTemplatePartialSpecialization()
 VarTemplatePartialSpecialization::~VarTemplatePartialSpecialization()
 {
 }
+
+UnresolvedUsingTypename::UnresolvedUsingTypename() : Declaration(DeclarationKind::UnresolvedUsingTypename) {}
+
+UnresolvedUsingTypename::~UnresolvedUsingTypename() {}
 
 Namespace::Namespace() 
     : DeclarationContext(DeclarationKind::Namespace)

--- a/src/CppParser/Bindings/CLI/Decl.cpp
+++ b/src/CppParser/Bindings/CLI/Decl.cpp
@@ -4517,6 +4517,43 @@ CppSharp::Parser::AST::VarTemplatePartialSpecialization::VarTemplatePartialSpeci
     NativePtr = new ::CppSharp::CppParser::AST::VarTemplatePartialSpecialization(__arg0);
 }
 
+CppSharp::Parser::AST::UnresolvedUsingTypename::UnresolvedUsingTypename(::CppSharp::CppParser::AST::UnresolvedUsingTypename* native)
+    : CppSharp::Parser::AST::Declaration((::CppSharp::CppParser::AST::Declaration*)native)
+{
+}
+
+CppSharp::Parser::AST::UnresolvedUsingTypename^ CppSharp::Parser::AST::UnresolvedUsingTypename::__CreateInstance(::System::IntPtr native)
+{
+    return gcnew ::CppSharp::Parser::AST::UnresolvedUsingTypename((::CppSharp::CppParser::AST::UnresolvedUsingTypename*) native.ToPointer());
+}
+
+CppSharp::Parser::AST::UnresolvedUsingTypename::~UnresolvedUsingTypename()
+{
+    if (NativePtr)
+    {
+        auto __nativePtr = NativePtr;
+        NativePtr = 0;
+        delete (::CppSharp::CppParser::AST::UnresolvedUsingTypename*) __nativePtr;
+    }
+}
+
+CppSharp::Parser::AST::UnresolvedUsingTypename::UnresolvedUsingTypename()
+    : CppSharp::Parser::AST::Declaration((::CppSharp::CppParser::AST::Declaration*)nullptr)
+{
+    __ownsNativeInstance = true;
+    NativePtr = new ::CppSharp::CppParser::AST::UnresolvedUsingTypename();
+}
+
+CppSharp::Parser::AST::UnresolvedUsingTypename::UnresolvedUsingTypename(CppSharp::Parser::AST::UnresolvedUsingTypename^ _0)
+    : CppSharp::Parser::AST::Declaration((::CppSharp::CppParser::AST::Declaration*)nullptr)
+{
+    __ownsNativeInstance = true;
+    if (ReferenceEquals(_0, nullptr))
+        throw gcnew ::System::ArgumentNullException("_0", "Cannot be null because it is a C++ reference (&).");
+    auto &__arg0 = *(::CppSharp::CppParser::AST::UnresolvedUsingTypename*)_0->NativePtr;
+    NativePtr = new ::CppSharp::CppParser::AST::UnresolvedUsingTypename(__arg0);
+}
+
 CppSharp::Parser::AST::Namespace::Namespace(::CppSharp::CppParser::AST::Namespace* native)
     : CppSharp::Parser::AST::DeclarationContext((::CppSharp::CppParser::AST::DeclarationContext*)native)
 {

--- a/src/CppParser/Bindings/CLI/Decl.h
+++ b/src/CppParser/Bindings/CLI/Decl.h
@@ -75,6 +75,7 @@ namespace CppSharp
             ref class TypeTemplateParameter;
             ref class TypedefDecl;
             ref class TypedefNameDecl;
+            ref class UnresolvedUsingTypename;
             ref class VFTableInfo;
             ref class VTableComponent;
             ref class VTableLayout;
@@ -123,7 +124,8 @@ namespace CppSharp
                 NonTypeTemplateParm = 26,
                 VarTemplate = 27,
                 VarTemplateSpecialization = 28,
-                VarTemplatePartialSpecialization = 29
+                VarTemplatePartialSpecialization = 29,
+                UnresolvedUsingTypename = 30
             };
 
             public enum struct AccessSpecifier
@@ -2248,6 +2250,19 @@ namespace CppSharp
                 VarTemplatePartialSpecialization(CppSharp::Parser::AST::VarTemplatePartialSpecialization^ _0);
 
                 ~VarTemplatePartialSpecialization();
+            };
+
+            public ref class UnresolvedUsingTypename : CppSharp::Parser::AST::Declaration
+            {
+            public:
+
+                UnresolvedUsingTypename(::CppSharp::CppParser::AST::UnresolvedUsingTypename* native);
+                static UnresolvedUsingTypename^ __CreateInstance(::System::IntPtr native);
+                UnresolvedUsingTypename();
+
+                UnresolvedUsingTypename(CppSharp::Parser::AST::UnresolvedUsingTypename^ _0);
+
+                ~UnresolvedUsingTypename();
             };
 
             public ref class Namespace : CppSharp::Parser::AST::DeclarationContext

--- a/src/CppParser/Bindings/CLI/Types.cpp
+++ b/src/CppParser/Bindings/CLI/Types.cpp
@@ -1325,6 +1325,47 @@ void CppSharp::Parser::AST::UnaryTransformType::BaseType::set(CppSharp::Parser::
     ((::CppSharp::CppParser::AST::UnaryTransformType*)NativePtr)->baseType = *(::CppSharp::CppParser::AST::QualifiedType*)value->NativePtr;
 }
 
+CppSharp::Parser::AST::UnresolvedUsingType::UnresolvedUsingType(::CppSharp::CppParser::AST::UnresolvedUsingType* native)
+    : CppSharp::Parser::AST::Type((::CppSharp::CppParser::AST::Type*)native)
+{
+}
+
+CppSharp::Parser::AST::UnresolvedUsingType^ CppSharp::Parser::AST::UnresolvedUsingType::__CreateInstance(::System::IntPtr native)
+{
+    return gcnew ::CppSharp::Parser::AST::UnresolvedUsingType((::CppSharp::CppParser::AST::UnresolvedUsingType*) native.ToPointer());
+}
+
+CppSharp::Parser::AST::UnresolvedUsingType::~UnresolvedUsingType()
+{
+}
+
+CppSharp::Parser::AST::UnresolvedUsingType::UnresolvedUsingType()
+    : CppSharp::Parser::AST::Type((::CppSharp::CppParser::AST::Type*)nullptr)
+{
+    __ownsNativeInstance = true;
+    NativePtr = new ::CppSharp::CppParser::AST::UnresolvedUsingType();
+}
+
+CppSharp::Parser::AST::UnresolvedUsingType::UnresolvedUsingType(CppSharp::Parser::AST::UnresolvedUsingType^ _0)
+    : CppSharp::Parser::AST::Type((::CppSharp::CppParser::AST::Type*)nullptr)
+{
+    __ownsNativeInstance = true;
+    if (ReferenceEquals(_0, nullptr))
+        throw gcnew ::System::ArgumentNullException("_0", "Cannot be null because it is a C++ reference (&).");
+    auto &__arg0 = *(::CppSharp::CppParser::AST::UnresolvedUsingType*)_0->NativePtr;
+    NativePtr = new ::CppSharp::CppParser::AST::UnresolvedUsingType(__arg0);
+}
+
+CppSharp::Parser::AST::UnresolvedUsingTypename^ CppSharp::Parser::AST::UnresolvedUsingType::Declaration::get()
+{
+    return (((::CppSharp::CppParser::AST::UnresolvedUsingType*)NativePtr)->declaration == nullptr) ? nullptr : gcnew CppSharp::Parser::AST::UnresolvedUsingTypename((::CppSharp::CppParser::AST::UnresolvedUsingTypename*)((::CppSharp::CppParser::AST::UnresolvedUsingType*)NativePtr)->declaration);
+}
+
+void CppSharp::Parser::AST::UnresolvedUsingType::Declaration::set(CppSharp::Parser::AST::UnresolvedUsingTypename^ value)
+{
+    ((::CppSharp::CppParser::AST::UnresolvedUsingType*)NativePtr)->declaration = (::CppSharp::CppParser::AST::UnresolvedUsingTypename*)value->NativePtr;
+}
+
 CppSharp::Parser::AST::VectorType::VectorType(::CppSharp::CppParser::AST::VectorType* native)
     : CppSharp::Parser::AST::Type((::CppSharp::CppParser::AST::Type*)native)
 {

--- a/src/CppParser/Bindings/CLI/Types.h
+++ b/src/CppParser/Bindings/CLI/Types.h
@@ -46,6 +46,8 @@ namespace CppSharp
             ref class TypedefNameDecl;
             ref class TypedefType;
             ref class UnaryTransformType;
+            ref class UnresolvedUsingType;
+            ref class UnresolvedUsingTypename;
             ref class VectorType;
         }
     }
@@ -76,7 +78,8 @@ namespace CppSharp
                 PackExpansion = 14,
                 Builtin = 15,
                 UnaryTransform = 16,
-                Vector = 17
+                UnresolvedUsing = 17,
+                Vector = 18
             };
 
             public enum struct CallingConvention
@@ -769,6 +772,25 @@ namespace CppSharp
                 {
                     CppSharp::Parser::AST::QualifiedType^ get();
                     void set(CppSharp::Parser::AST::QualifiedType^);
+                }
+            };
+
+            public ref class UnresolvedUsingType : CppSharp::Parser::AST::Type
+            {
+            public:
+
+                UnresolvedUsingType(::CppSharp::CppParser::AST::UnresolvedUsingType* native);
+                static UnresolvedUsingType^ __CreateInstance(::System::IntPtr native);
+                UnresolvedUsingType();
+
+                UnresolvedUsingType(CppSharp::Parser::AST::UnresolvedUsingType^ _0);
+
+                ~UnresolvedUsingType();
+
+                property CppSharp::Parser::AST::UnresolvedUsingTypename^ Declaration
+                {
+                    CppSharp::Parser::AST::UnresolvedUsingTypename^ get();
+                    void set(CppSharp::Parser::AST::UnresolvedUsingTypename^);
                 }
             };
 

--- a/src/CppParser/Bindings/CSharp/i686-apple-darwin12.4.0/CppSharp.CppParser.cs
+++ b/src/CppParser/Bindings/CSharp/i686-apple-darwin12.4.0/CppSharp.CppParser.cs
@@ -3229,7 +3229,8 @@ namespace CppSharp
                 PackExpansion = 14,
                 Builtin = 15,
                 UnaryTransform = 16,
-                Vector = 17
+                UnresolvedUsing = 17,
+                Vector = 18
             }
 
             public enum CallingConvention
@@ -5916,6 +5917,104 @@ namespace CppSharp
                 }
             }
 
+            public unsafe partial class UnresolvedUsingType : global::CppSharp.Parser.AST.Type, IDisposable
+            {
+                [StructLayout(LayoutKind.Explicit, Size = 12)]
+                public new partial struct __Internal
+                {
+                    [FieldOffset(0)]
+                    internal global::CppSharp.Parser.AST.TypeKind kind;
+
+                    [FieldOffset(4)]
+                    internal byte isDependent;
+
+                    [FieldOffset(8)]
+                    internal global::System.IntPtr declaration;
+
+                    [SuppressUnmanagedCodeSecurity]
+                    [DllImport("CppSharp.CppParser", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
+                        EntryPoint="_ZN8CppSharp9CppParser3AST19UnresolvedUsingTypeC2Ev")]
+                    internal static extern void ctor(global::System.IntPtr __instance);
+
+                    [SuppressUnmanagedCodeSecurity]
+                    [DllImport("CppSharp.CppParser", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
+                        EntryPoint="_ZN8CppSharp9CppParser3AST19UnresolvedUsingTypeC2ERKS2_")]
+                    internal static extern void cctor(global::System.IntPtr __instance, global::System.IntPtr _0);
+                }
+
+                internal static new global::CppSharp.Parser.AST.UnresolvedUsingType __CreateInstance(global::System.IntPtr native, bool skipVTables = false)
+                {
+                    return new global::CppSharp.Parser.AST.UnresolvedUsingType(native.ToPointer(), skipVTables);
+                }
+
+                internal static global::CppSharp.Parser.AST.UnresolvedUsingType __CreateInstance(global::CppSharp.Parser.AST.UnresolvedUsingType.__Internal native, bool skipVTables = false)
+                {
+                    return new global::CppSharp.Parser.AST.UnresolvedUsingType(native, skipVTables);
+                }
+
+                private static void* __CopyValue(global::CppSharp.Parser.AST.UnresolvedUsingType.__Internal native)
+                {
+                    var ret = Marshal.AllocHGlobal(sizeof(global::CppSharp.Parser.AST.UnresolvedUsingType.__Internal));
+                    global::CppSharp.Parser.AST.UnresolvedUsingType.__Internal.cctor(ret, new global::System.IntPtr(&native));
+                    return ret.ToPointer();
+                }
+
+                private UnresolvedUsingType(global::CppSharp.Parser.AST.UnresolvedUsingType.__Internal native, bool skipVTables = false)
+                    : this(__CopyValue(native), skipVTables)
+                {
+                    __ownsNativeInstance = true;
+                    NativeToManagedMap[__Instance] = this;
+                }
+
+                protected UnresolvedUsingType(void* native, bool skipVTables = false)
+                    : base((void*) null)
+                {
+                    __PointerAdjustment = 0;
+                    if (native == null)
+                        return;
+                    __Instance = new global::System.IntPtr(native);
+                }
+
+                public UnresolvedUsingType()
+                    : this((void*) null)
+                {
+                    __Instance = Marshal.AllocHGlobal(sizeof(global::CppSharp.Parser.AST.UnresolvedUsingType.__Internal));
+                    __ownsNativeInstance = true;
+                    NativeToManagedMap[__Instance] = this;
+                    __Internal.ctor((__Instance + __PointerAdjustment));
+                }
+
+                public UnresolvedUsingType(global::CppSharp.Parser.AST.UnresolvedUsingType _0)
+                    : this((void*) null)
+                {
+                    __Instance = Marshal.AllocHGlobal(sizeof(global::CppSharp.Parser.AST.UnresolvedUsingType.__Internal));
+                    __ownsNativeInstance = true;
+                    NativeToManagedMap[__Instance] = this;
+                    if (ReferenceEquals(_0, null))
+                        throw new global::System.ArgumentNullException("_0", "Cannot be null because it is a C++ reference (&).");
+                    var __arg0 = _0.__Instance;
+                    __Internal.cctor((__Instance + __PointerAdjustment), __arg0);
+                }
+
+                public global::CppSharp.Parser.AST.UnresolvedUsingTypename Declaration
+                {
+                    get
+                    {
+                        global::CppSharp.Parser.AST.UnresolvedUsingTypename __result0;
+                        if (((global::CppSharp.Parser.AST.UnresolvedUsingType.__Internal*) __Instance)->declaration == IntPtr.Zero) __result0 = null;
+                        else if (global::CppSharp.Parser.AST.UnresolvedUsingTypename.NativeToManagedMap.ContainsKey(((global::CppSharp.Parser.AST.UnresolvedUsingType.__Internal*) __Instance)->declaration))
+                            __result0 = (global::CppSharp.Parser.AST.UnresolvedUsingTypename) global::CppSharp.Parser.AST.UnresolvedUsingTypename.NativeToManagedMap[((global::CppSharp.Parser.AST.UnresolvedUsingType.__Internal*) __Instance)->declaration];
+                        else __result0 = global::CppSharp.Parser.AST.UnresolvedUsingTypename.__CreateInstance(((global::CppSharp.Parser.AST.UnresolvedUsingType.__Internal*) __Instance)->declaration);
+                        return __result0;
+                    }
+
+                    set
+                    {
+                        ((global::CppSharp.Parser.AST.UnresolvedUsingType.__Internal*)__Instance)->declaration = ReferenceEquals(value, null) ? global::System.IntPtr.Zero : value.__Instance;
+                    }
+                }
+            }
+
             public unsafe partial class VectorType : global::CppSharp.Parser.AST.Type, IDisposable
             {
                 [StructLayout(LayoutKind.Explicit, Size = 20)]
@@ -6160,7 +6259,8 @@ namespace CppSharp
                 NonTypeTemplateParm = 26,
                 VarTemplate = 27,
                 VarTemplateSpecialization = 28,
-                VarTemplatePartialSpecialization = 29
+                VarTemplatePartialSpecialization = 29,
+                UnresolvedUsingTypename = 30
             }
 
             public enum AccessSpecifier
@@ -16280,6 +16380,155 @@ namespace CppSharp
                     : this((void*) null)
                 {
                     __Instance = Marshal.AllocHGlobal(sizeof(global::CppSharp.Parser.AST.VarTemplatePartialSpecialization.__Internal));
+                    __ownsNativeInstance = true;
+                    NativeToManagedMap[__Instance] = this;
+                    if (ReferenceEquals(_0, null))
+                        throw new global::System.ArgumentNullException("_0", "Cannot be null because it is a C++ reference (&).");
+                    var __arg0 = _0.__Instance;
+                    __Internal.cctor((__Instance + __PointerAdjustment), __arg0);
+                }
+
+                public override void Dispose(bool disposing)
+                {
+                    if (__Instance == IntPtr.Zero)
+                        return;
+                    global::CppSharp.Parser.AST.Declaration __dummy;
+                    NativeToManagedMap.TryRemove(__Instance, out __dummy);
+                    if (disposing)
+                        __Internal.dtor((__Instance + __PointerAdjustment));
+                    if (__ownsNativeInstance)
+                        Marshal.FreeHGlobal(__Instance);
+                    __Instance = IntPtr.Zero;
+                }
+            }
+
+            public unsafe partial class UnresolvedUsingTypename : global::CppSharp.Parser.AST.Declaration, IDisposable
+            {
+                [StructLayout(LayoutKind.Explicit, Size = 108)]
+                public new partial struct __Internal
+                {
+                    [FieldOffset(0)]
+                    internal global::CppSharp.Parser.AST.DeclarationKind kind;
+
+                    [FieldOffset(4)]
+                    internal int maxFieldAlignment;
+
+                    [FieldOffset(8)]
+                    internal global::CppSharp.Parser.AST.AccessSpecifier access;
+
+                    [FieldOffset(12)]
+                    internal global::System.IntPtr _namespace;
+
+                    [FieldOffset(16)]
+                    internal global::CppSharp.Parser.SourceLocation.__Internal location;
+
+                    [FieldOffset(20)]
+                    internal int lineNumberStart;
+
+                    [FieldOffset(24)]
+                    internal int lineNumberEnd;
+
+                    [FieldOffset(28)]
+                    internal global::Std.BasicString.__Internalc__N_std_N___1_S_basic_string__C___N_std_N___1_S_char_traits__C___N_std_N___1_S_allocator__C name;
+
+                    [FieldOffset(40)]
+                    internal global::Std.BasicString.__Internalc__N_std_N___1_S_basic_string__C___N_std_N___1_S_char_traits__C___N_std_N___1_S_allocator__C USR;
+
+                    [FieldOffset(52)]
+                    internal global::Std.BasicString.__Internalc__N_std_N___1_S_basic_string__C___N_std_N___1_S_char_traits__C___N_std_N___1_S_allocator__C debugText;
+
+                    [FieldOffset(64)]
+                    internal byte isIncomplete;
+
+                    [FieldOffset(65)]
+                    internal byte isDependent;
+
+                    [FieldOffset(66)]
+                    internal byte isImplicit;
+
+                    [FieldOffset(67)]
+                    internal byte isInvalid;
+
+                    [FieldOffset(68)]
+                    internal global::System.IntPtr completeDeclaration;
+
+                    [FieldOffset(72)]
+                    internal uint definitionOrder;
+
+                    [FieldOffset(76)]
+                    internal global::Std.Vector.__Internalc__N_std_N___1_S_vector_____N_CppSharp_N_CppParser_N_AST_S_PreprocessedEntity___N_std_N___1_S_allocator__S0_ PreprocessedEntities;
+
+                    [FieldOffset(88)]
+                    internal global::Std.Vector.__Internalc__N_std_N___1_S_vector_____N_CppSharp_N_CppParser_N_AST_S_Declaration___N_std_N___1_S_allocator__S0_ Redeclarations;
+
+                    [FieldOffset(100)]
+                    internal global::System.IntPtr originalPtr;
+
+                    [FieldOffset(104)]
+                    internal global::System.IntPtr comment;
+
+                    [SuppressUnmanagedCodeSecurity]
+                    [DllImport("CppSharp.CppParser", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
+                        EntryPoint="_ZN8CppSharp9CppParser3AST23UnresolvedUsingTypenameC2Ev")]
+                    internal static extern void ctor(global::System.IntPtr __instance);
+
+                    [SuppressUnmanagedCodeSecurity]
+                    [DllImport("CppSharp.CppParser", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
+                        EntryPoint="_ZN8CppSharp9CppParser3AST23UnresolvedUsingTypenameC2ERKS2_")]
+                    internal static extern void cctor(global::System.IntPtr __instance, global::System.IntPtr _0);
+
+                    [SuppressUnmanagedCodeSecurity]
+                    [DllImport("CppSharp.CppParser", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
+                        EntryPoint="_ZN8CppSharp9CppParser3AST23UnresolvedUsingTypenameD2Ev")]
+                    internal static extern void dtor(global::System.IntPtr __instance);
+                }
+
+                internal static new global::CppSharp.Parser.AST.UnresolvedUsingTypename __CreateInstance(global::System.IntPtr native, bool skipVTables = false)
+                {
+                    return new global::CppSharp.Parser.AST.UnresolvedUsingTypename(native.ToPointer(), skipVTables);
+                }
+
+                internal static global::CppSharp.Parser.AST.UnresolvedUsingTypename __CreateInstance(global::CppSharp.Parser.AST.UnresolvedUsingTypename.__Internal native, bool skipVTables = false)
+                {
+                    return new global::CppSharp.Parser.AST.UnresolvedUsingTypename(native, skipVTables);
+                }
+
+                private static void* __CopyValue(global::CppSharp.Parser.AST.UnresolvedUsingTypename.__Internal native)
+                {
+                    var ret = Marshal.AllocHGlobal(sizeof(global::CppSharp.Parser.AST.UnresolvedUsingTypename.__Internal));
+                    global::CppSharp.Parser.AST.UnresolvedUsingTypename.__Internal.cctor(ret, new global::System.IntPtr(&native));
+                    return ret.ToPointer();
+                }
+
+                private UnresolvedUsingTypename(global::CppSharp.Parser.AST.UnresolvedUsingTypename.__Internal native, bool skipVTables = false)
+                    : this(__CopyValue(native), skipVTables)
+                {
+                    __ownsNativeInstance = true;
+                    NativeToManagedMap[__Instance] = this;
+                }
+
+                protected UnresolvedUsingTypename(void* native, bool skipVTables = false)
+                    : base((void*) null)
+                {
+                    __PointerAdjustment = 0;
+                    if (native == null)
+                        return;
+                    __Instance = new global::System.IntPtr(native);
+                }
+
+                public UnresolvedUsingTypename()
+                    : this((void*) null)
+                {
+                    __Instance = Marshal.AllocHGlobal(sizeof(global::CppSharp.Parser.AST.UnresolvedUsingTypename.__Internal));
+                    __ownsNativeInstance = true;
+                    NativeToManagedMap[__Instance] = this;
+                    __Internal.ctor((__Instance + __PointerAdjustment));
+                }
+
+                public UnresolvedUsingTypename(global::CppSharp.Parser.AST.UnresolvedUsingTypename _0)
+                    : this((void*) null)
+                {
+                    __Instance = Marshal.AllocHGlobal(sizeof(global::CppSharp.Parser.AST.UnresolvedUsingTypename.__Internal));
                     __ownsNativeInstance = true;
                     NativeToManagedMap[__Instance] = this;
                     if (ReferenceEquals(_0, null))

--- a/src/CppParser/Bindings/CSharp/i686-pc-win32-msvc/CppSharp.CppParser.cs
+++ b/src/CppParser/Bindings/CSharp/i686-pc-win32-msvc/CppSharp.CppParser.cs
@@ -3229,7 +3229,8 @@ namespace CppSharp
                 PackExpansion = 14,
                 Builtin = 15,
                 UnaryTransform = 16,
-                Vector = 17
+                UnresolvedUsing = 17,
+                Vector = 18
             }
 
             public enum CallingConvention
@@ -5916,6 +5917,104 @@ namespace CppSharp
                 }
             }
 
+            public unsafe partial class UnresolvedUsingType : global::CppSharp.Parser.AST.Type, IDisposable
+            {
+                [StructLayout(LayoutKind.Explicit, Size = 12)]
+                public new partial struct __Internal
+                {
+                    [FieldOffset(0)]
+                    internal global::CppSharp.Parser.AST.TypeKind kind;
+
+                    [FieldOffset(4)]
+                    internal byte isDependent;
+
+                    [FieldOffset(8)]
+                    internal global::System.IntPtr declaration;
+
+                    [SuppressUnmanagedCodeSecurity]
+                    [DllImport("CppSharp.CppParser.dll", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.ThisCall,
+                        EntryPoint="??0UnresolvedUsingType@AST@CppParser@CppSharp@@QAE@XZ")]
+                    internal static extern global::System.IntPtr ctor(global::System.IntPtr __instance);
+
+                    [SuppressUnmanagedCodeSecurity]
+                    [DllImport("CppSharp.CppParser.dll", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.ThisCall,
+                        EntryPoint="??0UnresolvedUsingType@AST@CppParser@CppSharp@@QAE@ABV0123@@Z")]
+                    internal static extern global::System.IntPtr cctor(global::System.IntPtr __instance, global::System.IntPtr _0);
+                }
+
+                internal static new global::CppSharp.Parser.AST.UnresolvedUsingType __CreateInstance(global::System.IntPtr native, bool skipVTables = false)
+                {
+                    return new global::CppSharp.Parser.AST.UnresolvedUsingType(native.ToPointer(), skipVTables);
+                }
+
+                internal static global::CppSharp.Parser.AST.UnresolvedUsingType __CreateInstance(global::CppSharp.Parser.AST.UnresolvedUsingType.__Internal native, bool skipVTables = false)
+                {
+                    return new global::CppSharp.Parser.AST.UnresolvedUsingType(native, skipVTables);
+                }
+
+                private static void* __CopyValue(global::CppSharp.Parser.AST.UnresolvedUsingType.__Internal native)
+                {
+                    var ret = Marshal.AllocHGlobal(sizeof(global::CppSharp.Parser.AST.UnresolvedUsingType.__Internal));
+                    global::CppSharp.Parser.AST.UnresolvedUsingType.__Internal.cctor(ret, new global::System.IntPtr(&native));
+                    return ret.ToPointer();
+                }
+
+                private UnresolvedUsingType(global::CppSharp.Parser.AST.UnresolvedUsingType.__Internal native, bool skipVTables = false)
+                    : this(__CopyValue(native), skipVTables)
+                {
+                    __ownsNativeInstance = true;
+                    NativeToManagedMap[__Instance] = this;
+                }
+
+                protected UnresolvedUsingType(void* native, bool skipVTables = false)
+                    : base((void*) null)
+                {
+                    __PointerAdjustment = 0;
+                    if (native == null)
+                        return;
+                    __Instance = new global::System.IntPtr(native);
+                }
+
+                public UnresolvedUsingType()
+                    : this((void*) null)
+                {
+                    __Instance = Marshal.AllocHGlobal(sizeof(global::CppSharp.Parser.AST.UnresolvedUsingType.__Internal));
+                    __ownsNativeInstance = true;
+                    NativeToManagedMap[__Instance] = this;
+                    __Internal.ctor((__Instance + __PointerAdjustment));
+                }
+
+                public UnresolvedUsingType(global::CppSharp.Parser.AST.UnresolvedUsingType _0)
+                    : this((void*) null)
+                {
+                    __Instance = Marshal.AllocHGlobal(sizeof(global::CppSharp.Parser.AST.UnresolvedUsingType.__Internal));
+                    __ownsNativeInstance = true;
+                    NativeToManagedMap[__Instance] = this;
+                    if (ReferenceEquals(_0, null))
+                        throw new global::System.ArgumentNullException("_0", "Cannot be null because it is a C++ reference (&).");
+                    var __arg0 = _0.__Instance;
+                    __Internal.cctor((__Instance + __PointerAdjustment), __arg0);
+                }
+
+                public global::CppSharp.Parser.AST.UnresolvedUsingTypename Declaration
+                {
+                    get
+                    {
+                        global::CppSharp.Parser.AST.UnresolvedUsingTypename __result0;
+                        if (((global::CppSharp.Parser.AST.UnresolvedUsingType.__Internal*) __Instance)->declaration == IntPtr.Zero) __result0 = null;
+                        else if (global::CppSharp.Parser.AST.UnresolvedUsingTypename.NativeToManagedMap.ContainsKey(((global::CppSharp.Parser.AST.UnresolvedUsingType.__Internal*) __Instance)->declaration))
+                            __result0 = (global::CppSharp.Parser.AST.UnresolvedUsingTypename) global::CppSharp.Parser.AST.UnresolvedUsingTypename.NativeToManagedMap[((global::CppSharp.Parser.AST.UnresolvedUsingType.__Internal*) __Instance)->declaration];
+                        else __result0 = global::CppSharp.Parser.AST.UnresolvedUsingTypename.__CreateInstance(((global::CppSharp.Parser.AST.UnresolvedUsingType.__Internal*) __Instance)->declaration);
+                        return __result0;
+                    }
+
+                    set
+                    {
+                        ((global::CppSharp.Parser.AST.UnresolvedUsingType.__Internal*)__Instance)->declaration = ReferenceEquals(value, null) ? global::System.IntPtr.Zero : value.__Instance;
+                    }
+                }
+            }
+
             public unsafe partial class VectorType : global::CppSharp.Parser.AST.Type, IDisposable
             {
                 [StructLayout(LayoutKind.Explicit, Size = 20)]
@@ -6160,7 +6259,8 @@ namespace CppSharp
                 NonTypeTemplateParm = 26,
                 VarTemplate = 27,
                 VarTemplateSpecialization = 28,
-                VarTemplatePartialSpecialization = 29
+                VarTemplatePartialSpecialization = 29,
+                UnresolvedUsingTypename = 30
             }
 
             public enum AccessSpecifier
@@ -16280,6 +16380,155 @@ namespace CppSharp
                     : this((void*) null)
                 {
                     __Instance = Marshal.AllocHGlobal(sizeof(global::CppSharp.Parser.AST.VarTemplatePartialSpecialization.__Internal));
+                    __ownsNativeInstance = true;
+                    NativeToManagedMap[__Instance] = this;
+                    if (ReferenceEquals(_0, null))
+                        throw new global::System.ArgumentNullException("_0", "Cannot be null because it is a C++ reference (&).");
+                    var __arg0 = _0.__Instance;
+                    __Internal.cctor((__Instance + __PointerAdjustment), __arg0);
+                }
+
+                public override void Dispose(bool disposing)
+                {
+                    if (__Instance == IntPtr.Zero)
+                        return;
+                    global::CppSharp.Parser.AST.Declaration __dummy;
+                    NativeToManagedMap.TryRemove(__Instance, out __dummy);
+                    if (disposing)
+                        __Internal.dtor((__Instance + __PointerAdjustment), 0);
+                    if (__ownsNativeInstance)
+                        Marshal.FreeHGlobal(__Instance);
+                    __Instance = IntPtr.Zero;
+                }
+            }
+
+            public unsafe partial class UnresolvedUsingTypename : global::CppSharp.Parser.AST.Declaration, IDisposable
+            {
+                [StructLayout(LayoutKind.Explicit, Size = 144)]
+                public new partial struct __Internal
+                {
+                    [FieldOffset(0)]
+                    internal global::CppSharp.Parser.AST.DeclarationKind kind;
+
+                    [FieldOffset(4)]
+                    internal int maxFieldAlignment;
+
+                    [FieldOffset(8)]
+                    internal global::CppSharp.Parser.AST.AccessSpecifier access;
+
+                    [FieldOffset(12)]
+                    internal global::System.IntPtr _namespace;
+
+                    [FieldOffset(16)]
+                    internal global::CppSharp.Parser.SourceLocation.__Internal location;
+
+                    [FieldOffset(20)]
+                    internal int lineNumberStart;
+
+                    [FieldOffset(24)]
+                    internal int lineNumberEnd;
+
+                    [FieldOffset(28)]
+                    internal global::Std.BasicString.__Internalc__N_std_S_basic_string__C___N_std_S_char_traits__C___N_std_S_allocator__C name;
+
+                    [FieldOffset(52)]
+                    internal global::Std.BasicString.__Internalc__N_std_S_basic_string__C___N_std_S_char_traits__C___N_std_S_allocator__C USR;
+
+                    [FieldOffset(76)]
+                    internal global::Std.BasicString.__Internalc__N_std_S_basic_string__C___N_std_S_char_traits__C___N_std_S_allocator__C debugText;
+
+                    [FieldOffset(100)]
+                    internal byte isIncomplete;
+
+                    [FieldOffset(101)]
+                    internal byte isDependent;
+
+                    [FieldOffset(102)]
+                    internal byte isImplicit;
+
+                    [FieldOffset(103)]
+                    internal byte isInvalid;
+
+                    [FieldOffset(104)]
+                    internal global::System.IntPtr completeDeclaration;
+
+                    [FieldOffset(108)]
+                    internal uint definitionOrder;
+
+                    [FieldOffset(112)]
+                    internal global::Std.Vector.__Internalc__N_std_S_vector_____N_CppSharp_N_CppParser_N_AST_S_PreprocessedEntity___N_std_S_allocator__S0_ PreprocessedEntities;
+
+                    [FieldOffset(124)]
+                    internal global::Std.Vector.__Internalc__N_std_S_vector_____N_CppSharp_N_CppParser_N_AST_S_Declaration___N_std_S_allocator__S0_ Redeclarations;
+
+                    [FieldOffset(136)]
+                    internal global::System.IntPtr originalPtr;
+
+                    [FieldOffset(140)]
+                    internal global::System.IntPtr comment;
+
+                    [SuppressUnmanagedCodeSecurity]
+                    [DllImport("CppSharp.CppParser.dll", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.ThisCall,
+                        EntryPoint="??0UnresolvedUsingTypename@AST@CppParser@CppSharp@@QAE@XZ")]
+                    internal static extern global::System.IntPtr ctor(global::System.IntPtr __instance);
+
+                    [SuppressUnmanagedCodeSecurity]
+                    [DllImport("CppSharp.CppParser.dll", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.ThisCall,
+                        EntryPoint="??0UnresolvedUsingTypename@AST@CppParser@CppSharp@@QAE@ABV0123@@Z")]
+                    internal static extern global::System.IntPtr cctor(global::System.IntPtr __instance, global::System.IntPtr _0);
+
+                    [SuppressUnmanagedCodeSecurity]
+                    [DllImport("CppSharp.CppParser.dll", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.ThisCall,
+                        EntryPoint="??1UnresolvedUsingTypename@AST@CppParser@CppSharp@@QAE@XZ")]
+                    internal static extern void dtor(global::System.IntPtr __instance, int delete);
+                }
+
+                internal static new global::CppSharp.Parser.AST.UnresolvedUsingTypename __CreateInstance(global::System.IntPtr native, bool skipVTables = false)
+                {
+                    return new global::CppSharp.Parser.AST.UnresolvedUsingTypename(native.ToPointer(), skipVTables);
+                }
+
+                internal static global::CppSharp.Parser.AST.UnresolvedUsingTypename __CreateInstance(global::CppSharp.Parser.AST.UnresolvedUsingTypename.__Internal native, bool skipVTables = false)
+                {
+                    return new global::CppSharp.Parser.AST.UnresolvedUsingTypename(native, skipVTables);
+                }
+
+                private static void* __CopyValue(global::CppSharp.Parser.AST.UnresolvedUsingTypename.__Internal native)
+                {
+                    var ret = Marshal.AllocHGlobal(sizeof(global::CppSharp.Parser.AST.UnresolvedUsingTypename.__Internal));
+                    global::CppSharp.Parser.AST.UnresolvedUsingTypename.__Internal.cctor(ret, new global::System.IntPtr(&native));
+                    return ret.ToPointer();
+                }
+
+                private UnresolvedUsingTypename(global::CppSharp.Parser.AST.UnresolvedUsingTypename.__Internal native, bool skipVTables = false)
+                    : this(__CopyValue(native), skipVTables)
+                {
+                    __ownsNativeInstance = true;
+                    NativeToManagedMap[__Instance] = this;
+                }
+
+                protected UnresolvedUsingTypename(void* native, bool skipVTables = false)
+                    : base((void*) null)
+                {
+                    __PointerAdjustment = 0;
+                    if (native == null)
+                        return;
+                    __Instance = new global::System.IntPtr(native);
+                }
+
+                public UnresolvedUsingTypename()
+                    : this((void*) null)
+                {
+                    __Instance = Marshal.AllocHGlobal(sizeof(global::CppSharp.Parser.AST.UnresolvedUsingTypename.__Internal));
+                    __ownsNativeInstance = true;
+                    NativeToManagedMap[__Instance] = this;
+                    __Internal.ctor((__Instance + __PointerAdjustment));
+                }
+
+                public UnresolvedUsingTypename(global::CppSharp.Parser.AST.UnresolvedUsingTypename _0)
+                    : this((void*) null)
+                {
+                    __Instance = Marshal.AllocHGlobal(sizeof(global::CppSharp.Parser.AST.UnresolvedUsingTypename.__Internal));
                     __ownsNativeInstance = true;
                     NativeToManagedMap[__Instance] = this;
                     if (ReferenceEquals(_0, null))

--- a/src/CppParser/Bindings/CSharp/x86_64-apple-darwin12.4.0/CppSharp.CppParser.cs
+++ b/src/CppParser/Bindings/CSharp/x86_64-apple-darwin12.4.0/CppSharp.CppParser.cs
@@ -3229,7 +3229,8 @@ namespace CppSharp
                 PackExpansion = 14,
                 Builtin = 15,
                 UnaryTransform = 16,
-                Vector = 17
+                UnresolvedUsing = 17,
+                Vector = 18
             }
 
             public enum CallingConvention
@@ -5916,6 +5917,104 @@ namespace CppSharp
                 }
             }
 
+            public unsafe partial class UnresolvedUsingType : global::CppSharp.Parser.AST.Type, IDisposable
+            {
+                [StructLayout(LayoutKind.Explicit, Size = 16)]
+                public new partial struct __Internal
+                {
+                    [FieldOffset(0)]
+                    internal global::CppSharp.Parser.AST.TypeKind kind;
+
+                    [FieldOffset(4)]
+                    internal byte isDependent;
+
+                    [FieldOffset(8)]
+                    internal global::System.IntPtr declaration;
+
+                    [SuppressUnmanagedCodeSecurity]
+                    [DllImport("CppSharp.CppParser", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
+                        EntryPoint="_ZN8CppSharp9CppParser3AST19UnresolvedUsingTypeC2Ev")]
+                    internal static extern void ctor(global::System.IntPtr __instance);
+
+                    [SuppressUnmanagedCodeSecurity]
+                    [DllImport("CppSharp.CppParser", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
+                        EntryPoint="_ZN8CppSharp9CppParser3AST19UnresolvedUsingTypeC2ERKS2_")]
+                    internal static extern void cctor(global::System.IntPtr __instance, global::System.IntPtr _0);
+                }
+
+                internal static new global::CppSharp.Parser.AST.UnresolvedUsingType __CreateInstance(global::System.IntPtr native, bool skipVTables = false)
+                {
+                    return new global::CppSharp.Parser.AST.UnresolvedUsingType(native.ToPointer(), skipVTables);
+                }
+
+                internal static global::CppSharp.Parser.AST.UnresolvedUsingType __CreateInstance(global::CppSharp.Parser.AST.UnresolvedUsingType.__Internal native, bool skipVTables = false)
+                {
+                    return new global::CppSharp.Parser.AST.UnresolvedUsingType(native, skipVTables);
+                }
+
+                private static void* __CopyValue(global::CppSharp.Parser.AST.UnresolvedUsingType.__Internal native)
+                {
+                    var ret = Marshal.AllocHGlobal(sizeof(global::CppSharp.Parser.AST.UnresolvedUsingType.__Internal));
+                    global::CppSharp.Parser.AST.UnresolvedUsingType.__Internal.cctor(ret, new global::System.IntPtr(&native));
+                    return ret.ToPointer();
+                }
+
+                private UnresolvedUsingType(global::CppSharp.Parser.AST.UnresolvedUsingType.__Internal native, bool skipVTables = false)
+                    : this(__CopyValue(native), skipVTables)
+                {
+                    __ownsNativeInstance = true;
+                    NativeToManagedMap[__Instance] = this;
+                }
+
+                protected UnresolvedUsingType(void* native, bool skipVTables = false)
+                    : base((void*) null)
+                {
+                    __PointerAdjustment = 0;
+                    if (native == null)
+                        return;
+                    __Instance = new global::System.IntPtr(native);
+                }
+
+                public UnresolvedUsingType()
+                    : this((void*) null)
+                {
+                    __Instance = Marshal.AllocHGlobal(sizeof(global::CppSharp.Parser.AST.UnresolvedUsingType.__Internal));
+                    __ownsNativeInstance = true;
+                    NativeToManagedMap[__Instance] = this;
+                    __Internal.ctor((__Instance + __PointerAdjustment));
+                }
+
+                public UnresolvedUsingType(global::CppSharp.Parser.AST.UnresolvedUsingType _0)
+                    : this((void*) null)
+                {
+                    __Instance = Marshal.AllocHGlobal(sizeof(global::CppSharp.Parser.AST.UnresolvedUsingType.__Internal));
+                    __ownsNativeInstance = true;
+                    NativeToManagedMap[__Instance] = this;
+                    if (ReferenceEquals(_0, null))
+                        throw new global::System.ArgumentNullException("_0", "Cannot be null because it is a C++ reference (&).");
+                    var __arg0 = _0.__Instance;
+                    __Internal.cctor((__Instance + __PointerAdjustment), __arg0);
+                }
+
+                public global::CppSharp.Parser.AST.UnresolvedUsingTypename Declaration
+                {
+                    get
+                    {
+                        global::CppSharp.Parser.AST.UnresolvedUsingTypename __result0;
+                        if (((global::CppSharp.Parser.AST.UnresolvedUsingType.__Internal*) __Instance)->declaration == IntPtr.Zero) __result0 = null;
+                        else if (global::CppSharp.Parser.AST.UnresolvedUsingTypename.NativeToManagedMap.ContainsKey(((global::CppSharp.Parser.AST.UnresolvedUsingType.__Internal*) __Instance)->declaration))
+                            __result0 = (global::CppSharp.Parser.AST.UnresolvedUsingTypename) global::CppSharp.Parser.AST.UnresolvedUsingTypename.NativeToManagedMap[((global::CppSharp.Parser.AST.UnresolvedUsingType.__Internal*) __Instance)->declaration];
+                        else __result0 = global::CppSharp.Parser.AST.UnresolvedUsingTypename.__CreateInstance(((global::CppSharp.Parser.AST.UnresolvedUsingType.__Internal*) __Instance)->declaration);
+                        return __result0;
+                    }
+
+                    set
+                    {
+                        ((global::CppSharp.Parser.AST.UnresolvedUsingType.__Internal*)__Instance)->declaration = ReferenceEquals(value, null) ? global::System.IntPtr.Zero : value.__Instance;
+                    }
+                }
+            }
+
             public unsafe partial class VectorType : global::CppSharp.Parser.AST.Type, IDisposable
             {
                 [StructLayout(LayoutKind.Explicit, Size = 32)]
@@ -6160,7 +6259,8 @@ namespace CppSharp
                 NonTypeTemplateParm = 26,
                 VarTemplate = 27,
                 VarTemplateSpecialization = 28,
-                VarTemplatePartialSpecialization = 29
+                VarTemplatePartialSpecialization = 29,
+                UnresolvedUsingTypename = 30
             }
 
             public enum AccessSpecifier
@@ -16279,6 +16379,155 @@ namespace CppSharp
                     : this((void*) null)
                 {
                     __Instance = Marshal.AllocHGlobal(sizeof(global::CppSharp.Parser.AST.VarTemplatePartialSpecialization.__Internal));
+                    __ownsNativeInstance = true;
+                    NativeToManagedMap[__Instance] = this;
+                    if (ReferenceEquals(_0, null))
+                        throw new global::System.ArgumentNullException("_0", "Cannot be null because it is a C++ reference (&).");
+                    var __arg0 = _0.__Instance;
+                    __Internal.cctor((__Instance + __PointerAdjustment), __arg0);
+                }
+
+                public override void Dispose(bool disposing)
+                {
+                    if (__Instance == IntPtr.Zero)
+                        return;
+                    global::CppSharp.Parser.AST.Declaration __dummy;
+                    NativeToManagedMap.TryRemove(__Instance, out __dummy);
+                    if (disposing)
+                        __Internal.dtor((__Instance + __PointerAdjustment));
+                    if (__ownsNativeInstance)
+                        Marshal.FreeHGlobal(__Instance);
+                    __Instance = IntPtr.Zero;
+                }
+            }
+
+            public unsafe partial class UnresolvedUsingTypename : global::CppSharp.Parser.AST.Declaration, IDisposable
+            {
+                [StructLayout(LayoutKind.Explicit, Size = 200)]
+                public new partial struct __Internal
+                {
+                    [FieldOffset(0)]
+                    internal global::CppSharp.Parser.AST.DeclarationKind kind;
+
+                    [FieldOffset(4)]
+                    internal int maxFieldAlignment;
+
+                    [FieldOffset(8)]
+                    internal global::CppSharp.Parser.AST.AccessSpecifier access;
+
+                    [FieldOffset(16)]
+                    internal global::System.IntPtr _namespace;
+
+                    [FieldOffset(24)]
+                    internal global::CppSharp.Parser.SourceLocation.__Internal location;
+
+                    [FieldOffset(28)]
+                    internal int lineNumberStart;
+
+                    [FieldOffset(32)]
+                    internal int lineNumberEnd;
+
+                    [FieldOffset(40)]
+                    internal global::Std.BasicString.__Internalc__N_std_N___1_S_basic_string__C___N_std_N___1_S_char_traits__C___N_std_N___1_S_allocator__C name;
+
+                    [FieldOffset(64)]
+                    internal global::Std.BasicString.__Internalc__N_std_N___1_S_basic_string__C___N_std_N___1_S_char_traits__C___N_std_N___1_S_allocator__C USR;
+
+                    [FieldOffset(88)]
+                    internal global::Std.BasicString.__Internalc__N_std_N___1_S_basic_string__C___N_std_N___1_S_char_traits__C___N_std_N___1_S_allocator__C debugText;
+
+                    [FieldOffset(112)]
+                    internal byte isIncomplete;
+
+                    [FieldOffset(113)]
+                    internal byte isDependent;
+
+                    [FieldOffset(114)]
+                    internal byte isImplicit;
+
+                    [FieldOffset(115)]
+                    internal byte isInvalid;
+
+                    [FieldOffset(120)]
+                    internal global::System.IntPtr completeDeclaration;
+
+                    [FieldOffset(128)]
+                    internal uint definitionOrder;
+
+                    [FieldOffset(136)]
+                    internal global::Std.Vector.__Internalc__N_std_N___1_S_vector_____N_CppSharp_N_CppParser_N_AST_S_PreprocessedEntity___N_std_N___1_S_allocator__S0_ PreprocessedEntities;
+
+                    [FieldOffset(160)]
+                    internal global::Std.Vector.__Internalc__N_std_N___1_S_vector_____N_CppSharp_N_CppParser_N_AST_S_Declaration___N_std_N___1_S_allocator__S0_ Redeclarations;
+
+                    [FieldOffset(184)]
+                    internal global::System.IntPtr originalPtr;
+
+                    [FieldOffset(192)]
+                    internal global::System.IntPtr comment;
+
+                    [SuppressUnmanagedCodeSecurity]
+                    [DllImport("CppSharp.CppParser", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
+                        EntryPoint="_ZN8CppSharp9CppParser3AST23UnresolvedUsingTypenameC2Ev")]
+                    internal static extern void ctor(global::System.IntPtr __instance);
+
+                    [SuppressUnmanagedCodeSecurity]
+                    [DllImport("CppSharp.CppParser", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
+                        EntryPoint="_ZN8CppSharp9CppParser3AST23UnresolvedUsingTypenameC2ERKS2_")]
+                    internal static extern void cctor(global::System.IntPtr __instance, global::System.IntPtr _0);
+
+                    [SuppressUnmanagedCodeSecurity]
+                    [DllImport("CppSharp.CppParser", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
+                        EntryPoint="_ZN8CppSharp9CppParser3AST23UnresolvedUsingTypenameD2Ev")]
+                    internal static extern void dtor(global::System.IntPtr __instance);
+                }
+
+                internal static new global::CppSharp.Parser.AST.UnresolvedUsingTypename __CreateInstance(global::System.IntPtr native, bool skipVTables = false)
+                {
+                    return new global::CppSharp.Parser.AST.UnresolvedUsingTypename(native.ToPointer(), skipVTables);
+                }
+
+                internal static global::CppSharp.Parser.AST.UnresolvedUsingTypename __CreateInstance(global::CppSharp.Parser.AST.UnresolvedUsingTypename.__Internal native, bool skipVTables = false)
+                {
+                    return new global::CppSharp.Parser.AST.UnresolvedUsingTypename(native, skipVTables);
+                }
+
+                private static void* __CopyValue(global::CppSharp.Parser.AST.UnresolvedUsingTypename.__Internal native)
+                {
+                    var ret = Marshal.AllocHGlobal(sizeof(global::CppSharp.Parser.AST.UnresolvedUsingTypename.__Internal));
+                    global::CppSharp.Parser.AST.UnresolvedUsingTypename.__Internal.cctor(ret, new global::System.IntPtr(&native));
+                    return ret.ToPointer();
+                }
+
+                private UnresolvedUsingTypename(global::CppSharp.Parser.AST.UnresolvedUsingTypename.__Internal native, bool skipVTables = false)
+                    : this(__CopyValue(native), skipVTables)
+                {
+                    __ownsNativeInstance = true;
+                    NativeToManagedMap[__Instance] = this;
+                }
+
+                protected UnresolvedUsingTypename(void* native, bool skipVTables = false)
+                    : base((void*) null)
+                {
+                    __PointerAdjustment = 0;
+                    if (native == null)
+                        return;
+                    __Instance = new global::System.IntPtr(native);
+                }
+
+                public UnresolvedUsingTypename()
+                    : this((void*) null)
+                {
+                    __Instance = Marshal.AllocHGlobal(sizeof(global::CppSharp.Parser.AST.UnresolvedUsingTypename.__Internal));
+                    __ownsNativeInstance = true;
+                    NativeToManagedMap[__Instance] = this;
+                    __Internal.ctor((__Instance + __PointerAdjustment));
+                }
+
+                public UnresolvedUsingTypename(global::CppSharp.Parser.AST.UnresolvedUsingTypename _0)
+                    : this((void*) null)
+                {
+                    __Instance = Marshal.AllocHGlobal(sizeof(global::CppSharp.Parser.AST.UnresolvedUsingTypename.__Internal));
                     __ownsNativeInstance = true;
                     NativeToManagedMap[__Instance] = this;
                     if (ReferenceEquals(_0, null))

--- a/src/CppParser/Bindings/CSharp/x86_64-linux-gnu-cxx11abi/CppSharp.CppParser.cs
+++ b/src/CppParser/Bindings/CSharp/x86_64-linux-gnu-cxx11abi/CppSharp.CppParser.cs
@@ -3229,7 +3229,8 @@ namespace CppSharp
                 PackExpansion = 14,
                 Builtin = 15,
                 UnaryTransform = 16,
-                Vector = 17
+                UnresolvedUsing = 17,
+                Vector = 18
             }
 
             public enum CallingConvention
@@ -5916,6 +5917,104 @@ namespace CppSharp
                 }
             }
 
+            public unsafe partial class UnresolvedUsingType : global::CppSharp.Parser.AST.Type, IDisposable
+            {
+                [StructLayout(LayoutKind.Explicit, Size = 16)]
+                public new partial struct __Internal
+                {
+                    [FieldOffset(0)]
+                    internal global::CppSharp.Parser.AST.TypeKind kind;
+
+                    [FieldOffset(4)]
+                    internal byte isDependent;
+
+                    [FieldOffset(8)]
+                    internal global::System.IntPtr declaration;
+
+                    [SuppressUnmanagedCodeSecurity]
+                    [DllImport("CppSharp.CppParser", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
+                        EntryPoint="_ZN8CppSharp9CppParser3AST19UnresolvedUsingTypeC2Ev")]
+                    internal static extern void ctor(global::System.IntPtr __instance);
+
+                    [SuppressUnmanagedCodeSecurity]
+                    [DllImport("CppSharp.CppParser", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
+                        EntryPoint="_ZN8CppSharp9CppParser3AST19UnresolvedUsingTypeC2ERKS2_")]
+                    internal static extern void cctor(global::System.IntPtr __instance, global::System.IntPtr _0);
+                }
+
+                internal static new global::CppSharp.Parser.AST.UnresolvedUsingType __CreateInstance(global::System.IntPtr native, bool skipVTables = false)
+                {
+                    return new global::CppSharp.Parser.AST.UnresolvedUsingType(native.ToPointer(), skipVTables);
+                }
+
+                internal static global::CppSharp.Parser.AST.UnresolvedUsingType __CreateInstance(global::CppSharp.Parser.AST.UnresolvedUsingType.__Internal native, bool skipVTables = false)
+                {
+                    return new global::CppSharp.Parser.AST.UnresolvedUsingType(native, skipVTables);
+                }
+
+                private static void* __CopyValue(global::CppSharp.Parser.AST.UnresolvedUsingType.__Internal native)
+                {
+                    var ret = Marshal.AllocHGlobal(sizeof(global::CppSharp.Parser.AST.UnresolvedUsingType.__Internal));
+                    global::CppSharp.Parser.AST.UnresolvedUsingType.__Internal.cctor(ret, new global::System.IntPtr(&native));
+                    return ret.ToPointer();
+                }
+
+                private UnresolvedUsingType(global::CppSharp.Parser.AST.UnresolvedUsingType.__Internal native, bool skipVTables = false)
+                    : this(__CopyValue(native), skipVTables)
+                {
+                    __ownsNativeInstance = true;
+                    NativeToManagedMap[__Instance] = this;
+                }
+
+                protected UnresolvedUsingType(void* native, bool skipVTables = false)
+                    : base((void*) null)
+                {
+                    __PointerAdjustment = 0;
+                    if (native == null)
+                        return;
+                    __Instance = new global::System.IntPtr(native);
+                }
+
+                public UnresolvedUsingType()
+                    : this((void*) null)
+                {
+                    __Instance = Marshal.AllocHGlobal(sizeof(global::CppSharp.Parser.AST.UnresolvedUsingType.__Internal));
+                    __ownsNativeInstance = true;
+                    NativeToManagedMap[__Instance] = this;
+                    __Internal.ctor((__Instance + __PointerAdjustment));
+                }
+
+                public UnresolvedUsingType(global::CppSharp.Parser.AST.UnresolvedUsingType _0)
+                    : this((void*) null)
+                {
+                    __Instance = Marshal.AllocHGlobal(sizeof(global::CppSharp.Parser.AST.UnresolvedUsingType.__Internal));
+                    __ownsNativeInstance = true;
+                    NativeToManagedMap[__Instance] = this;
+                    if (ReferenceEquals(_0, null))
+                        throw new global::System.ArgumentNullException("_0", "Cannot be null because it is a C++ reference (&).");
+                    var __arg0 = _0.__Instance;
+                    __Internal.cctor((__Instance + __PointerAdjustment), __arg0);
+                }
+
+                public global::CppSharp.Parser.AST.UnresolvedUsingTypename Declaration
+                {
+                    get
+                    {
+                        global::CppSharp.Parser.AST.UnresolvedUsingTypename __result0;
+                        if (((global::CppSharp.Parser.AST.UnresolvedUsingType.__Internal*) __Instance)->declaration == IntPtr.Zero) __result0 = null;
+                        else if (global::CppSharp.Parser.AST.UnresolvedUsingTypename.NativeToManagedMap.ContainsKey(((global::CppSharp.Parser.AST.UnresolvedUsingType.__Internal*) __Instance)->declaration))
+                            __result0 = (global::CppSharp.Parser.AST.UnresolvedUsingTypename) global::CppSharp.Parser.AST.UnresolvedUsingTypename.NativeToManagedMap[((global::CppSharp.Parser.AST.UnresolvedUsingType.__Internal*) __Instance)->declaration];
+                        else __result0 = global::CppSharp.Parser.AST.UnresolvedUsingTypename.__CreateInstance(((global::CppSharp.Parser.AST.UnresolvedUsingType.__Internal*) __Instance)->declaration);
+                        return __result0;
+                    }
+
+                    set
+                    {
+                        ((global::CppSharp.Parser.AST.UnresolvedUsingType.__Internal*)__Instance)->declaration = ReferenceEquals(value, null) ? global::System.IntPtr.Zero : value.__Instance;
+                    }
+                }
+            }
+
             public unsafe partial class VectorType : global::CppSharp.Parser.AST.Type, IDisposable
             {
                 [StructLayout(LayoutKind.Explicit, Size = 32)]
@@ -6160,7 +6259,8 @@ namespace CppSharp
                 NonTypeTemplateParm = 26,
                 VarTemplate = 27,
                 VarTemplateSpecialization = 28,
-                VarTemplatePartialSpecialization = 29
+                VarTemplatePartialSpecialization = 29,
+                UnresolvedUsingTypename = 30
             }
 
             public enum AccessSpecifier
@@ -16279,6 +16379,155 @@ namespace CppSharp
                     : this((void*) null)
                 {
                     __Instance = Marshal.AllocHGlobal(sizeof(global::CppSharp.Parser.AST.VarTemplatePartialSpecialization.__Internal));
+                    __ownsNativeInstance = true;
+                    NativeToManagedMap[__Instance] = this;
+                    if (ReferenceEquals(_0, null))
+                        throw new global::System.ArgumentNullException("_0", "Cannot be null because it is a C++ reference (&).");
+                    var __arg0 = _0.__Instance;
+                    __Internal.cctor((__Instance + __PointerAdjustment), __arg0);
+                }
+
+                public override void Dispose(bool disposing)
+                {
+                    if (__Instance == IntPtr.Zero)
+                        return;
+                    global::CppSharp.Parser.AST.Declaration __dummy;
+                    NativeToManagedMap.TryRemove(__Instance, out __dummy);
+                    if (disposing)
+                        __Internal.dtor((__Instance + __PointerAdjustment));
+                    if (__ownsNativeInstance)
+                        Marshal.FreeHGlobal(__Instance);
+                    __Instance = IntPtr.Zero;
+                }
+            }
+
+            public unsafe partial class UnresolvedUsingTypename : global::CppSharp.Parser.AST.Declaration, IDisposable
+            {
+                [StructLayout(LayoutKind.Explicit, Size = 224)]
+                public new partial struct __Internal
+                {
+                    [FieldOffset(0)]
+                    internal global::CppSharp.Parser.AST.DeclarationKind kind;
+
+                    [FieldOffset(4)]
+                    internal int maxFieldAlignment;
+
+                    [FieldOffset(8)]
+                    internal global::CppSharp.Parser.AST.AccessSpecifier access;
+
+                    [FieldOffset(16)]
+                    internal global::System.IntPtr _namespace;
+
+                    [FieldOffset(24)]
+                    internal global::CppSharp.Parser.SourceLocation.__Internal location;
+
+                    [FieldOffset(28)]
+                    internal int lineNumberStart;
+
+                    [FieldOffset(32)]
+                    internal int lineNumberEnd;
+
+                    [FieldOffset(40)]
+                    internal global::Std.BasicString.__Internalc__N_std_N___cxx11_S_basic_string__C___N_std_S_char_traits__C___N_std_S_allocator__C name;
+
+                    [FieldOffset(72)]
+                    internal global::Std.BasicString.__Internalc__N_std_N___cxx11_S_basic_string__C___N_std_S_char_traits__C___N_std_S_allocator__C USR;
+
+                    [FieldOffset(104)]
+                    internal global::Std.BasicString.__Internalc__N_std_N___cxx11_S_basic_string__C___N_std_S_char_traits__C___N_std_S_allocator__C debugText;
+
+                    [FieldOffset(136)]
+                    internal byte isIncomplete;
+
+                    [FieldOffset(137)]
+                    internal byte isDependent;
+
+                    [FieldOffset(138)]
+                    internal byte isImplicit;
+
+                    [FieldOffset(139)]
+                    internal byte isInvalid;
+
+                    [FieldOffset(144)]
+                    internal global::System.IntPtr completeDeclaration;
+
+                    [FieldOffset(152)]
+                    internal uint definitionOrder;
+
+                    [FieldOffset(160)]
+                    internal global::Std.Vector.__Internalc__N_std_S_vector_____N_CppSharp_N_CppParser_N_AST_S_PreprocessedEntity___N_std_S_allocator__S0_ PreprocessedEntities;
+
+                    [FieldOffset(184)]
+                    internal global::Std.Vector.__Internalc__N_std_S_vector_____N_CppSharp_N_CppParser_N_AST_S_Declaration___N_std_S_allocator__S0_ Redeclarations;
+
+                    [FieldOffset(208)]
+                    internal global::System.IntPtr originalPtr;
+
+                    [FieldOffset(216)]
+                    internal global::System.IntPtr comment;
+
+                    [SuppressUnmanagedCodeSecurity]
+                    [DllImport("CppSharp.CppParser", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
+                        EntryPoint="_ZN8CppSharp9CppParser3AST23UnresolvedUsingTypenameC2Ev")]
+                    internal static extern void ctor(global::System.IntPtr __instance);
+
+                    [SuppressUnmanagedCodeSecurity]
+                    [DllImport("CppSharp.CppParser", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
+                        EntryPoint="_ZN8CppSharp9CppParser3AST23UnresolvedUsingTypenameC2ERKS2_")]
+                    internal static extern void cctor(global::System.IntPtr __instance, global::System.IntPtr _0);
+
+                    [SuppressUnmanagedCodeSecurity]
+                    [DllImport("CppSharp.CppParser", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
+                        EntryPoint="_ZN8CppSharp9CppParser3AST23UnresolvedUsingTypenameD2Ev")]
+                    internal static extern void dtor(global::System.IntPtr __instance);
+                }
+
+                internal static new global::CppSharp.Parser.AST.UnresolvedUsingTypename __CreateInstance(global::System.IntPtr native, bool skipVTables = false)
+                {
+                    return new global::CppSharp.Parser.AST.UnresolvedUsingTypename(native.ToPointer(), skipVTables);
+                }
+
+                internal static global::CppSharp.Parser.AST.UnresolvedUsingTypename __CreateInstance(global::CppSharp.Parser.AST.UnresolvedUsingTypename.__Internal native, bool skipVTables = false)
+                {
+                    return new global::CppSharp.Parser.AST.UnresolvedUsingTypename(native, skipVTables);
+                }
+
+                private static void* __CopyValue(global::CppSharp.Parser.AST.UnresolvedUsingTypename.__Internal native)
+                {
+                    var ret = Marshal.AllocHGlobal(sizeof(global::CppSharp.Parser.AST.UnresolvedUsingTypename.__Internal));
+                    global::CppSharp.Parser.AST.UnresolvedUsingTypename.__Internal.cctor(ret, new global::System.IntPtr(&native));
+                    return ret.ToPointer();
+                }
+
+                private UnresolvedUsingTypename(global::CppSharp.Parser.AST.UnresolvedUsingTypename.__Internal native, bool skipVTables = false)
+                    : this(__CopyValue(native), skipVTables)
+                {
+                    __ownsNativeInstance = true;
+                    NativeToManagedMap[__Instance] = this;
+                }
+
+                protected UnresolvedUsingTypename(void* native, bool skipVTables = false)
+                    : base((void*) null)
+                {
+                    __PointerAdjustment = 0;
+                    if (native == null)
+                        return;
+                    __Instance = new global::System.IntPtr(native);
+                }
+
+                public UnresolvedUsingTypename()
+                    : this((void*) null)
+                {
+                    __Instance = Marshal.AllocHGlobal(sizeof(global::CppSharp.Parser.AST.UnresolvedUsingTypename.__Internal));
+                    __ownsNativeInstance = true;
+                    NativeToManagedMap[__Instance] = this;
+                    __Internal.ctor((__Instance + __PointerAdjustment));
+                }
+
+                public UnresolvedUsingTypename(global::CppSharp.Parser.AST.UnresolvedUsingTypename _0)
+                    : this((void*) null)
+                {
+                    __Instance = Marshal.AllocHGlobal(sizeof(global::CppSharp.Parser.AST.UnresolvedUsingTypename.__Internal));
                     __ownsNativeInstance = true;
                     NativeToManagedMap[__Instance] = this;
                     if (ReferenceEquals(_0, null))

--- a/src/CppParser/Bindings/CSharp/x86_64-linux-gnu/CppSharp.CppParser.cs
+++ b/src/CppParser/Bindings/CSharp/x86_64-linux-gnu/CppSharp.CppParser.cs
@@ -3229,7 +3229,8 @@ namespace CppSharp
                 PackExpansion = 14,
                 Builtin = 15,
                 UnaryTransform = 16,
-                Vector = 17
+                UnresolvedUsing = 17,
+                Vector = 18
             }
 
             public enum CallingConvention
@@ -5916,6 +5917,104 @@ namespace CppSharp
                 }
             }
 
+            public unsafe partial class UnresolvedUsingType : global::CppSharp.Parser.AST.Type, IDisposable
+            {
+                [StructLayout(LayoutKind.Explicit, Size = 16)]
+                public new partial struct __Internal
+                {
+                    [FieldOffset(0)]
+                    internal global::CppSharp.Parser.AST.TypeKind kind;
+
+                    [FieldOffset(4)]
+                    internal byte isDependent;
+
+                    [FieldOffset(8)]
+                    internal global::System.IntPtr declaration;
+
+                    [SuppressUnmanagedCodeSecurity]
+                    [DllImport("CppSharp.CppParser", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
+                        EntryPoint="_ZN8CppSharp9CppParser3AST19UnresolvedUsingTypeC2Ev")]
+                    internal static extern void ctor(global::System.IntPtr __instance);
+
+                    [SuppressUnmanagedCodeSecurity]
+                    [DllImport("CppSharp.CppParser", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
+                        EntryPoint="_ZN8CppSharp9CppParser3AST19UnresolvedUsingTypeC2ERKS2_")]
+                    internal static extern void cctor(global::System.IntPtr __instance, global::System.IntPtr _0);
+                }
+
+                internal static new global::CppSharp.Parser.AST.UnresolvedUsingType __CreateInstance(global::System.IntPtr native, bool skipVTables = false)
+                {
+                    return new global::CppSharp.Parser.AST.UnresolvedUsingType(native.ToPointer(), skipVTables);
+                }
+
+                internal static global::CppSharp.Parser.AST.UnresolvedUsingType __CreateInstance(global::CppSharp.Parser.AST.UnresolvedUsingType.__Internal native, bool skipVTables = false)
+                {
+                    return new global::CppSharp.Parser.AST.UnresolvedUsingType(native, skipVTables);
+                }
+
+                private static void* __CopyValue(global::CppSharp.Parser.AST.UnresolvedUsingType.__Internal native)
+                {
+                    var ret = Marshal.AllocHGlobal(sizeof(global::CppSharp.Parser.AST.UnresolvedUsingType.__Internal));
+                    global::CppSharp.Parser.AST.UnresolvedUsingType.__Internal.cctor(ret, new global::System.IntPtr(&native));
+                    return ret.ToPointer();
+                }
+
+                private UnresolvedUsingType(global::CppSharp.Parser.AST.UnresolvedUsingType.__Internal native, bool skipVTables = false)
+                    : this(__CopyValue(native), skipVTables)
+                {
+                    __ownsNativeInstance = true;
+                    NativeToManagedMap[__Instance] = this;
+                }
+
+                protected UnresolvedUsingType(void* native, bool skipVTables = false)
+                    : base((void*) null)
+                {
+                    __PointerAdjustment = 0;
+                    if (native == null)
+                        return;
+                    __Instance = new global::System.IntPtr(native);
+                }
+
+                public UnresolvedUsingType()
+                    : this((void*) null)
+                {
+                    __Instance = Marshal.AllocHGlobal(sizeof(global::CppSharp.Parser.AST.UnresolvedUsingType.__Internal));
+                    __ownsNativeInstance = true;
+                    NativeToManagedMap[__Instance] = this;
+                    __Internal.ctor((__Instance + __PointerAdjustment));
+                }
+
+                public UnresolvedUsingType(global::CppSharp.Parser.AST.UnresolvedUsingType _0)
+                    : this((void*) null)
+                {
+                    __Instance = Marshal.AllocHGlobal(sizeof(global::CppSharp.Parser.AST.UnresolvedUsingType.__Internal));
+                    __ownsNativeInstance = true;
+                    NativeToManagedMap[__Instance] = this;
+                    if (ReferenceEquals(_0, null))
+                        throw new global::System.ArgumentNullException("_0", "Cannot be null because it is a C++ reference (&).");
+                    var __arg0 = _0.__Instance;
+                    __Internal.cctor((__Instance + __PointerAdjustment), __arg0);
+                }
+
+                public global::CppSharp.Parser.AST.UnresolvedUsingTypename Declaration
+                {
+                    get
+                    {
+                        global::CppSharp.Parser.AST.UnresolvedUsingTypename __result0;
+                        if (((global::CppSharp.Parser.AST.UnresolvedUsingType.__Internal*) __Instance)->declaration == IntPtr.Zero) __result0 = null;
+                        else if (global::CppSharp.Parser.AST.UnresolvedUsingTypename.NativeToManagedMap.ContainsKey(((global::CppSharp.Parser.AST.UnresolvedUsingType.__Internal*) __Instance)->declaration))
+                            __result0 = (global::CppSharp.Parser.AST.UnresolvedUsingTypename) global::CppSharp.Parser.AST.UnresolvedUsingTypename.NativeToManagedMap[((global::CppSharp.Parser.AST.UnresolvedUsingType.__Internal*) __Instance)->declaration];
+                        else __result0 = global::CppSharp.Parser.AST.UnresolvedUsingTypename.__CreateInstance(((global::CppSharp.Parser.AST.UnresolvedUsingType.__Internal*) __Instance)->declaration);
+                        return __result0;
+                    }
+
+                    set
+                    {
+                        ((global::CppSharp.Parser.AST.UnresolvedUsingType.__Internal*)__Instance)->declaration = ReferenceEquals(value, null) ? global::System.IntPtr.Zero : value.__Instance;
+                    }
+                }
+            }
+
             public unsafe partial class VectorType : global::CppSharp.Parser.AST.Type, IDisposable
             {
                 [StructLayout(LayoutKind.Explicit, Size = 32)]
@@ -6160,7 +6259,8 @@ namespace CppSharp
                 NonTypeTemplateParm = 26,
                 VarTemplate = 27,
                 VarTemplateSpecialization = 28,
-                VarTemplatePartialSpecialization = 29
+                VarTemplatePartialSpecialization = 29,
+                UnresolvedUsingTypename = 30
             }
 
             public enum AccessSpecifier
@@ -16279,6 +16379,155 @@ namespace CppSharp
                     : this((void*) null)
                 {
                     __Instance = Marshal.AllocHGlobal(sizeof(global::CppSharp.Parser.AST.VarTemplatePartialSpecialization.__Internal));
+                    __ownsNativeInstance = true;
+                    NativeToManagedMap[__Instance] = this;
+                    if (ReferenceEquals(_0, null))
+                        throw new global::System.ArgumentNullException("_0", "Cannot be null because it is a C++ reference (&).");
+                    var __arg0 = _0.__Instance;
+                    __Internal.cctor((__Instance + __PointerAdjustment), __arg0);
+                }
+
+                public override void Dispose(bool disposing)
+                {
+                    if (__Instance == IntPtr.Zero)
+                        return;
+                    global::CppSharp.Parser.AST.Declaration __dummy;
+                    NativeToManagedMap.TryRemove(__Instance, out __dummy);
+                    if (disposing)
+                        __Internal.dtor((__Instance + __PointerAdjustment));
+                    if (__ownsNativeInstance)
+                        Marshal.FreeHGlobal(__Instance);
+                    __Instance = IntPtr.Zero;
+                }
+            }
+
+            public unsafe partial class UnresolvedUsingTypename : global::CppSharp.Parser.AST.Declaration, IDisposable
+            {
+                [StructLayout(LayoutKind.Explicit, Size = 152)]
+                public new partial struct __Internal
+                {
+                    [FieldOffset(0)]
+                    internal global::CppSharp.Parser.AST.DeclarationKind kind;
+
+                    [FieldOffset(4)]
+                    internal int maxFieldAlignment;
+
+                    [FieldOffset(8)]
+                    internal global::CppSharp.Parser.AST.AccessSpecifier access;
+
+                    [FieldOffset(16)]
+                    internal global::System.IntPtr _namespace;
+
+                    [FieldOffset(24)]
+                    internal global::CppSharp.Parser.SourceLocation.__Internal location;
+
+                    [FieldOffset(28)]
+                    internal int lineNumberStart;
+
+                    [FieldOffset(32)]
+                    internal int lineNumberEnd;
+
+                    [FieldOffset(40)]
+                    internal global::Std.BasicString.__Internalc__N_std_S_basic_string__C___N_std_S_char_traits__C___N_std_S_allocator__C name;
+
+                    [FieldOffset(48)]
+                    internal global::Std.BasicString.__Internalc__N_std_S_basic_string__C___N_std_S_char_traits__C___N_std_S_allocator__C USR;
+
+                    [FieldOffset(56)]
+                    internal global::Std.BasicString.__Internalc__N_std_S_basic_string__C___N_std_S_char_traits__C___N_std_S_allocator__C debugText;
+
+                    [FieldOffset(64)]
+                    internal byte isIncomplete;
+
+                    [FieldOffset(65)]
+                    internal byte isDependent;
+
+                    [FieldOffset(66)]
+                    internal byte isImplicit;
+
+                    [FieldOffset(67)]
+                    internal byte isInvalid;
+
+                    [FieldOffset(72)]
+                    internal global::System.IntPtr completeDeclaration;
+
+                    [FieldOffset(80)]
+                    internal uint definitionOrder;
+
+                    [FieldOffset(88)]
+                    internal global::Std.Vector.__Internalc__N_std_S_vector_____N_CppSharp_N_CppParser_N_AST_S_PreprocessedEntity___N_std_S_allocator__S0_ PreprocessedEntities;
+
+                    [FieldOffset(112)]
+                    internal global::Std.Vector.__Internalc__N_std_S_vector_____N_CppSharp_N_CppParser_N_AST_S_Declaration___N_std_S_allocator__S0_ Redeclarations;
+
+                    [FieldOffset(136)]
+                    internal global::System.IntPtr originalPtr;
+
+                    [FieldOffset(144)]
+                    internal global::System.IntPtr comment;
+
+                    [SuppressUnmanagedCodeSecurity]
+                    [DllImport("CppSharp.CppParser", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
+                        EntryPoint="_ZN8CppSharp9CppParser3AST23UnresolvedUsingTypenameC2Ev")]
+                    internal static extern void ctor(global::System.IntPtr __instance);
+
+                    [SuppressUnmanagedCodeSecurity]
+                    [DllImport("CppSharp.CppParser", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
+                        EntryPoint="_ZN8CppSharp9CppParser3AST23UnresolvedUsingTypenameC2ERKS2_")]
+                    internal static extern void cctor(global::System.IntPtr __instance, global::System.IntPtr _0);
+
+                    [SuppressUnmanagedCodeSecurity]
+                    [DllImport("CppSharp.CppParser", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
+                        EntryPoint="_ZN8CppSharp9CppParser3AST23UnresolvedUsingTypenameD2Ev")]
+                    internal static extern void dtor(global::System.IntPtr __instance);
+                }
+
+                internal static new global::CppSharp.Parser.AST.UnresolvedUsingTypename __CreateInstance(global::System.IntPtr native, bool skipVTables = false)
+                {
+                    return new global::CppSharp.Parser.AST.UnresolvedUsingTypename(native.ToPointer(), skipVTables);
+                }
+
+                internal static global::CppSharp.Parser.AST.UnresolvedUsingTypename __CreateInstance(global::CppSharp.Parser.AST.UnresolvedUsingTypename.__Internal native, bool skipVTables = false)
+                {
+                    return new global::CppSharp.Parser.AST.UnresolvedUsingTypename(native, skipVTables);
+                }
+
+                private static void* __CopyValue(global::CppSharp.Parser.AST.UnresolvedUsingTypename.__Internal native)
+                {
+                    var ret = Marshal.AllocHGlobal(sizeof(global::CppSharp.Parser.AST.UnresolvedUsingTypename.__Internal));
+                    global::CppSharp.Parser.AST.UnresolvedUsingTypename.__Internal.cctor(ret, new global::System.IntPtr(&native));
+                    return ret.ToPointer();
+                }
+
+                private UnresolvedUsingTypename(global::CppSharp.Parser.AST.UnresolvedUsingTypename.__Internal native, bool skipVTables = false)
+                    : this(__CopyValue(native), skipVTables)
+                {
+                    __ownsNativeInstance = true;
+                    NativeToManagedMap[__Instance] = this;
+                }
+
+                protected UnresolvedUsingTypename(void* native, bool skipVTables = false)
+                    : base((void*) null)
+                {
+                    __PointerAdjustment = 0;
+                    if (native == null)
+                        return;
+                    __Instance = new global::System.IntPtr(native);
+                }
+
+                public UnresolvedUsingTypename()
+                    : this((void*) null)
+                {
+                    __Instance = Marshal.AllocHGlobal(sizeof(global::CppSharp.Parser.AST.UnresolvedUsingTypename.__Internal));
+                    __ownsNativeInstance = true;
+                    NativeToManagedMap[__Instance] = this;
+                    __Internal.ctor((__Instance + __PointerAdjustment));
+                }
+
+                public UnresolvedUsingTypename(global::CppSharp.Parser.AST.UnresolvedUsingTypename _0)
+                    : this((void*) null)
+                {
+                    __Instance = Marshal.AllocHGlobal(sizeof(global::CppSharp.Parser.AST.UnresolvedUsingTypename.__Internal));
                     __ownsNativeInstance = true;
                     NativeToManagedMap[__Instance] = this;
                     if (ReferenceEquals(_0, null))

--- a/src/CppParser/Bindings/CSharp/x86_64-pc-win32-msvc/CppSharp.CppParser.cs
+++ b/src/CppParser/Bindings/CSharp/x86_64-pc-win32-msvc/CppSharp.CppParser.cs
@@ -3229,7 +3229,8 @@ namespace CppSharp
                 PackExpansion = 14,
                 Builtin = 15,
                 UnaryTransform = 16,
-                Vector = 17
+                UnresolvedUsing = 17,
+                Vector = 18
             }
 
             public enum CallingConvention
@@ -5916,6 +5917,104 @@ namespace CppSharp
                 }
             }
 
+            public unsafe partial class UnresolvedUsingType : global::CppSharp.Parser.AST.Type, IDisposable
+            {
+                [StructLayout(LayoutKind.Explicit, Size = 16)]
+                public new partial struct __Internal
+                {
+                    [FieldOffset(0)]
+                    internal global::CppSharp.Parser.AST.TypeKind kind;
+
+                    [FieldOffset(4)]
+                    internal byte isDependent;
+
+                    [FieldOffset(8)]
+                    internal global::System.IntPtr declaration;
+
+                    [SuppressUnmanagedCodeSecurity]
+                    [DllImport("CppSharp.CppParser.dll", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
+                        EntryPoint="??0UnresolvedUsingType@AST@CppParser@CppSharp@@QEAA@XZ")]
+                    internal static extern global::System.IntPtr ctor(global::System.IntPtr __instance);
+
+                    [SuppressUnmanagedCodeSecurity]
+                    [DllImport("CppSharp.CppParser.dll", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
+                        EntryPoint="??0UnresolvedUsingType@AST@CppParser@CppSharp@@QEAA@AEBV0123@@Z")]
+                    internal static extern global::System.IntPtr cctor(global::System.IntPtr __instance, global::System.IntPtr _0);
+                }
+
+                internal static new global::CppSharp.Parser.AST.UnresolvedUsingType __CreateInstance(global::System.IntPtr native, bool skipVTables = false)
+                {
+                    return new global::CppSharp.Parser.AST.UnresolvedUsingType(native.ToPointer(), skipVTables);
+                }
+
+                internal static global::CppSharp.Parser.AST.UnresolvedUsingType __CreateInstance(global::CppSharp.Parser.AST.UnresolvedUsingType.__Internal native, bool skipVTables = false)
+                {
+                    return new global::CppSharp.Parser.AST.UnresolvedUsingType(native, skipVTables);
+                }
+
+                private static void* __CopyValue(global::CppSharp.Parser.AST.UnresolvedUsingType.__Internal native)
+                {
+                    var ret = Marshal.AllocHGlobal(sizeof(global::CppSharp.Parser.AST.UnresolvedUsingType.__Internal));
+                    global::CppSharp.Parser.AST.UnresolvedUsingType.__Internal.cctor(ret, new global::System.IntPtr(&native));
+                    return ret.ToPointer();
+                }
+
+                private UnresolvedUsingType(global::CppSharp.Parser.AST.UnresolvedUsingType.__Internal native, bool skipVTables = false)
+                    : this(__CopyValue(native), skipVTables)
+                {
+                    __ownsNativeInstance = true;
+                    NativeToManagedMap[__Instance] = this;
+                }
+
+                protected UnresolvedUsingType(void* native, bool skipVTables = false)
+                    : base((void*) null)
+                {
+                    __PointerAdjustment = 0;
+                    if (native == null)
+                        return;
+                    __Instance = new global::System.IntPtr(native);
+                }
+
+                public UnresolvedUsingType()
+                    : this((void*) null)
+                {
+                    __Instance = Marshal.AllocHGlobal(sizeof(global::CppSharp.Parser.AST.UnresolvedUsingType.__Internal));
+                    __ownsNativeInstance = true;
+                    NativeToManagedMap[__Instance] = this;
+                    __Internal.ctor((__Instance + __PointerAdjustment));
+                }
+
+                public UnresolvedUsingType(global::CppSharp.Parser.AST.UnresolvedUsingType _0)
+                    : this((void*) null)
+                {
+                    __Instance = Marshal.AllocHGlobal(sizeof(global::CppSharp.Parser.AST.UnresolvedUsingType.__Internal));
+                    __ownsNativeInstance = true;
+                    NativeToManagedMap[__Instance] = this;
+                    if (ReferenceEquals(_0, null))
+                        throw new global::System.ArgumentNullException("_0", "Cannot be null because it is a C++ reference (&).");
+                    var __arg0 = _0.__Instance;
+                    __Internal.cctor((__Instance + __PointerAdjustment), __arg0);
+                }
+
+                public global::CppSharp.Parser.AST.UnresolvedUsingTypename Declaration
+                {
+                    get
+                    {
+                        global::CppSharp.Parser.AST.UnresolvedUsingTypename __result0;
+                        if (((global::CppSharp.Parser.AST.UnresolvedUsingType.__Internal*) __Instance)->declaration == IntPtr.Zero) __result0 = null;
+                        else if (global::CppSharp.Parser.AST.UnresolvedUsingTypename.NativeToManagedMap.ContainsKey(((global::CppSharp.Parser.AST.UnresolvedUsingType.__Internal*) __Instance)->declaration))
+                            __result0 = (global::CppSharp.Parser.AST.UnresolvedUsingTypename) global::CppSharp.Parser.AST.UnresolvedUsingTypename.NativeToManagedMap[((global::CppSharp.Parser.AST.UnresolvedUsingType.__Internal*) __Instance)->declaration];
+                        else __result0 = global::CppSharp.Parser.AST.UnresolvedUsingTypename.__CreateInstance(((global::CppSharp.Parser.AST.UnresolvedUsingType.__Internal*) __Instance)->declaration);
+                        return __result0;
+                    }
+
+                    set
+                    {
+                        ((global::CppSharp.Parser.AST.UnresolvedUsingType.__Internal*)__Instance)->declaration = ReferenceEquals(value, null) ? global::System.IntPtr.Zero : value.__Instance;
+                    }
+                }
+            }
+
             public unsafe partial class VectorType : global::CppSharp.Parser.AST.Type, IDisposable
             {
                 [StructLayout(LayoutKind.Explicit, Size = 32)]
@@ -6160,7 +6259,8 @@ namespace CppSharp
                 NonTypeTemplateParm = 26,
                 VarTemplate = 27,
                 VarTemplateSpecialization = 28,
-                VarTemplatePartialSpecialization = 29
+                VarTemplatePartialSpecialization = 29,
+                UnresolvedUsingTypename = 30
             }
 
             public enum AccessSpecifier
@@ -16280,6 +16380,155 @@ namespace CppSharp
                     : this((void*) null)
                 {
                     __Instance = Marshal.AllocHGlobal(sizeof(global::CppSharp.Parser.AST.VarTemplatePartialSpecialization.__Internal));
+                    __ownsNativeInstance = true;
+                    NativeToManagedMap[__Instance] = this;
+                    if (ReferenceEquals(_0, null))
+                        throw new global::System.ArgumentNullException("_0", "Cannot be null because it is a C++ reference (&).");
+                    var __arg0 = _0.__Instance;
+                    __Internal.cctor((__Instance + __PointerAdjustment), __arg0);
+                }
+
+                public override void Dispose(bool disposing)
+                {
+                    if (__Instance == IntPtr.Zero)
+                        return;
+                    global::CppSharp.Parser.AST.Declaration __dummy;
+                    NativeToManagedMap.TryRemove(__Instance, out __dummy);
+                    if (disposing)
+                        __Internal.dtor((__Instance + __PointerAdjustment), 0);
+                    if (__ownsNativeInstance)
+                        Marshal.FreeHGlobal(__Instance);
+                    __Instance = IntPtr.Zero;
+                }
+            }
+
+            public unsafe partial class UnresolvedUsingTypename : global::CppSharp.Parser.AST.Declaration, IDisposable
+            {
+                [StructLayout(LayoutKind.Explicit, Size = 224)]
+                public new partial struct __Internal
+                {
+                    [FieldOffset(0)]
+                    internal global::CppSharp.Parser.AST.DeclarationKind kind;
+
+                    [FieldOffset(4)]
+                    internal int maxFieldAlignment;
+
+                    [FieldOffset(8)]
+                    internal global::CppSharp.Parser.AST.AccessSpecifier access;
+
+                    [FieldOffset(16)]
+                    internal global::System.IntPtr _namespace;
+
+                    [FieldOffset(24)]
+                    internal global::CppSharp.Parser.SourceLocation.__Internal location;
+
+                    [FieldOffset(28)]
+                    internal int lineNumberStart;
+
+                    [FieldOffset(32)]
+                    internal int lineNumberEnd;
+
+                    [FieldOffset(40)]
+                    internal global::Std.BasicString.__Internalc__N_std_S_basic_string__C___N_std_S_char_traits__C___N_std_S_allocator__C name;
+
+                    [FieldOffset(72)]
+                    internal global::Std.BasicString.__Internalc__N_std_S_basic_string__C___N_std_S_char_traits__C___N_std_S_allocator__C USR;
+
+                    [FieldOffset(104)]
+                    internal global::Std.BasicString.__Internalc__N_std_S_basic_string__C___N_std_S_char_traits__C___N_std_S_allocator__C debugText;
+
+                    [FieldOffset(136)]
+                    internal byte isIncomplete;
+
+                    [FieldOffset(137)]
+                    internal byte isDependent;
+
+                    [FieldOffset(138)]
+                    internal byte isImplicit;
+
+                    [FieldOffset(139)]
+                    internal byte isInvalid;
+
+                    [FieldOffset(144)]
+                    internal global::System.IntPtr completeDeclaration;
+
+                    [FieldOffset(152)]
+                    internal uint definitionOrder;
+
+                    [FieldOffset(160)]
+                    internal global::Std.Vector.__Internalc__N_std_S_vector_____N_CppSharp_N_CppParser_N_AST_S_PreprocessedEntity___N_std_S_allocator__S0_ PreprocessedEntities;
+
+                    [FieldOffset(184)]
+                    internal global::Std.Vector.__Internalc__N_std_S_vector_____N_CppSharp_N_CppParser_N_AST_S_Declaration___N_std_S_allocator__S0_ Redeclarations;
+
+                    [FieldOffset(208)]
+                    internal global::System.IntPtr originalPtr;
+
+                    [FieldOffset(216)]
+                    internal global::System.IntPtr comment;
+
+                    [SuppressUnmanagedCodeSecurity]
+                    [DllImport("CppSharp.CppParser.dll", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
+                        EntryPoint="??0UnresolvedUsingTypename@AST@CppParser@CppSharp@@QEAA@XZ")]
+                    internal static extern global::System.IntPtr ctor(global::System.IntPtr __instance);
+
+                    [SuppressUnmanagedCodeSecurity]
+                    [DllImport("CppSharp.CppParser.dll", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
+                        EntryPoint="??0UnresolvedUsingTypename@AST@CppParser@CppSharp@@QEAA@AEBV0123@@Z")]
+                    internal static extern global::System.IntPtr cctor(global::System.IntPtr __instance, global::System.IntPtr _0);
+
+                    [SuppressUnmanagedCodeSecurity]
+                    [DllImport("CppSharp.CppParser.dll", CallingConvention = global::System.Runtime.InteropServices.CallingConvention.Cdecl,
+                        EntryPoint="??1UnresolvedUsingTypename@AST@CppParser@CppSharp@@QEAA@XZ")]
+                    internal static extern void dtor(global::System.IntPtr __instance, int delete);
+                }
+
+                internal static new global::CppSharp.Parser.AST.UnresolvedUsingTypename __CreateInstance(global::System.IntPtr native, bool skipVTables = false)
+                {
+                    return new global::CppSharp.Parser.AST.UnresolvedUsingTypename(native.ToPointer(), skipVTables);
+                }
+
+                internal static global::CppSharp.Parser.AST.UnresolvedUsingTypename __CreateInstance(global::CppSharp.Parser.AST.UnresolvedUsingTypename.__Internal native, bool skipVTables = false)
+                {
+                    return new global::CppSharp.Parser.AST.UnresolvedUsingTypename(native, skipVTables);
+                }
+
+                private static void* __CopyValue(global::CppSharp.Parser.AST.UnresolvedUsingTypename.__Internal native)
+                {
+                    var ret = Marshal.AllocHGlobal(sizeof(global::CppSharp.Parser.AST.UnresolvedUsingTypename.__Internal));
+                    global::CppSharp.Parser.AST.UnresolvedUsingTypename.__Internal.cctor(ret, new global::System.IntPtr(&native));
+                    return ret.ToPointer();
+                }
+
+                private UnresolvedUsingTypename(global::CppSharp.Parser.AST.UnresolvedUsingTypename.__Internal native, bool skipVTables = false)
+                    : this(__CopyValue(native), skipVTables)
+                {
+                    __ownsNativeInstance = true;
+                    NativeToManagedMap[__Instance] = this;
+                }
+
+                protected UnresolvedUsingTypename(void* native, bool skipVTables = false)
+                    : base((void*) null)
+                {
+                    __PointerAdjustment = 0;
+                    if (native == null)
+                        return;
+                    __Instance = new global::System.IntPtr(native);
+                }
+
+                public UnresolvedUsingTypename()
+                    : this((void*) null)
+                {
+                    __Instance = Marshal.AllocHGlobal(sizeof(global::CppSharp.Parser.AST.UnresolvedUsingTypename.__Internal));
+                    __ownsNativeInstance = true;
+                    NativeToManagedMap[__Instance] = this;
+                    __Internal.ctor((__Instance + __PointerAdjustment));
+                }
+
+                public UnresolvedUsingTypename(global::CppSharp.Parser.AST.UnresolvedUsingTypename _0)
+                    : this((void*) null)
+                {
+                    __Instance = Marshal.AllocHGlobal(sizeof(global::CppSharp.Parser.AST.UnresolvedUsingTypename.__Internal));
                     __ownsNativeInstance = true;
                     NativeToManagedMap[__Instance] = this;
                     if (ReferenceEquals(_0, null))

--- a/src/CppParser/Decl.h
+++ b/src/CppParser/Decl.h
@@ -45,7 +45,8 @@ enum class DeclarationKind
     NonTypeTemplateParm,
     VarTemplate,
     VarTemplateSpecialization,
-    VarTemplatePartialSpecialization
+    VarTemplatePartialSpecialization,
+    UnresolvedUsingTypename,
 };
 
 #define DECLARE_DECL_KIND(klass, kind) \
@@ -739,6 +740,13 @@ class CS_API VarTemplatePartialSpecialization : public VarTemplateSpecialization
 public:
     VarTemplatePartialSpecialization();
     ~VarTemplatePartialSpecialization();
+};
+
+class CS_API UnresolvedUsingTypename : public Declaration
+{
+public:
+    UnresolvedUsingTypename();
+    ~UnresolvedUsingTypename();
 };
 
 class CS_API Namespace : public DeclarationContext

--- a/src/CppParser/Parser.h
+++ b/src/CppParser/Parser.h
@@ -98,6 +98,7 @@ private:
     TemplateTemplateParameter* WalkTemplateTemplateParameter(const clang::TemplateTemplateParmDecl* TTP);
     TypeTemplateParameter* WalkTypeTemplateParameter(const clang::TemplateTypeParmDecl* TTPD);
     NonTypeTemplateParameter* WalkNonTypeTemplateParameter(const clang::NonTypeTemplateParmDecl* TTPD);
+    UnresolvedUsingTypename* WalkUnresolvedUsingTypename(const clang::UnresolvedUsingTypenameDecl* UUTD);
     std::vector<Declaration*> WalkTemplateParameterList(const clang::TemplateParameterList* TPL);
     TypeAliasTemplate* WalkTypeAliasTemplate(const clang::TypeAliasTemplateDecl* TD);
     ClassTemplate* WalkClassTemplate(const clang::ClassTemplateDecl* TD);

--- a/src/CppParser/Types.h
+++ b/src/CppParser/Types.h
@@ -30,6 +30,7 @@ enum class TypeKind
     PackExpansion,
     Builtin,
     UnaryTransform,
+    UnresolvedUsing,
     Vector
 };
 
@@ -273,6 +274,15 @@ public:
     DECLARE_TYPE_KIND(UnaryTransform)
     QualifiedType desugared;
     QualifiedType baseType;
+};
+
+class UnresolvedUsingTypename;
+
+class CS_API UnresolvedUsingType : public Type
+{
+public:
+    DECLARE_TYPE_KIND(UnresolvedUsing)
+    UnresolvedUsingTypename* declaration;
 };
 
 class CS_API VectorType : public Type

--- a/src/Generator.Tests/AST/TestAST.cs
+++ b/src/Generator.Tests/AST/TestAST.cs
@@ -219,6 +219,11 @@ namespace CppSharp.Generator.Tests.AST
             {
                 throw new NotImplementedException();
             }
+
+            public bool VisitUnresolvedUsingDecl(UnresolvedUsingTypename unresolvedUsingTypename)
+            {
+                throw new NotImplementedException();
+            }
         }
         #endregion
 

--- a/src/Generator/Generators/CodeGenerator.cs
+++ b/src/Generator/Generators/CodeGenerator.cs
@@ -404,6 +404,11 @@ namespace CppSharp.Generators
             throw new NotImplementedException();
         }
 
+        public bool VisitUnresolvedUsingDecl(UnresolvedUsingTypename unresolvedUsingTypename)
+        {
+            throw new NotImplementedException();
+        }
+
         public bool VisitArrayType(ArrayType array, TypeQualifiers quals)
         {
             throw new NotImplementedException();
@@ -490,6 +495,11 @@ namespace CppSharp.Generators
         }
 
         public bool VisitUnaryTransformType(UnaryTransformType unaryTransformType, TypeQualifiers quals)
+        {
+            throw new NotImplementedException();
+        }
+
+        public bool VisitUnresolvedUsingType(UnresolvedUsingType unresolvedUsingType, TypeQualifiers quals)
         {
             throw new NotImplementedException();
         }

--- a/src/Generator/Generators/TypePrinter.cs
+++ b/src/Generator/Generators/TypePrinter.cs
@@ -350,6 +350,11 @@ namespace CppSharp.Generators
             throw new NotImplementedException();
         }
 
+        public TypePrinterResult VisitUnresolvedUsingType(UnresolvedUsingType unresolvedUsingType, TypeQualifiers quals)
+        {
+            throw new NotImplementedException();
+        }
+
         public virtual TypePrinterResult VisitUnsupportedType(UnsupportedType type,
             TypeQualifiers quals)
         {
@@ -368,6 +373,11 @@ namespace CppSharp.Generators
 
         public virtual TypePrinterResult VisitVarTemplateSpecializationDecl(
             VarTemplateSpecialization template)
+        {
+            throw new NotImplementedException();
+        }
+
+        public TypePrinterResult VisitUnresolvedUsingDecl(UnresolvedUsingTypename unresolvedUsingTypename)
         {
             throw new NotImplementedException();
         }

--- a/src/Parser/ASTConverter.cs
+++ b/src/Parser/ASTConverter.cs
@@ -29,6 +29,7 @@ namespace CppSharp
         public abstract TRet VisitBuiltin(BuiltinType type);
         public abstract TRet VisitPackExpansion(PackExpansionType type);
         public abstract TRet VisitUnaryTransform(UnaryTransformType type);
+        public abstract TRet VisitUnresolvedUsing(UnresolvedUsingType type);
         public abstract TRet VisitVector(VectorType type);
 
         public TRet Visit(Parser.AST.Type type)
@@ -123,6 +124,11 @@ namespace CppSharp
                     var _type = UnaryTransformType.__CreateInstance(type.__Instance);
                     return VisitUnaryTransform(_type);
                 }
+                case TypeKind.UnresolvedUsing:
+                {
+                    var _type = UnresolvedUsingType.__CreateInstance(type.__Instance);
+                    return VisitUnresolvedUsing(_type);
+                }
                 case TypeKind.Vector:
                 {
                     var _type = VectorType.__CreateInstance(type.__Instance);
@@ -168,7 +174,8 @@ namespace CppSharp
         public abstract TRet VisitTemplateTemplateParameter(TemplateTemplateParameter decl);
         public abstract TRet VisitTypeTemplateParameter(TypeTemplateParameter decl);
         public abstract TRet VisitNonTypeTemplateParameter(NonTypeTemplateParameter decl);
-
+        public abstract TRet VisitUnresolvedUsingTypename(UnresolvedUsingTypename decl);
+        
         public virtual TRet Visit(Parser.AST.Declaration decl)
         {
             switch (decl.Kind)
@@ -297,6 +304,11 @@ namespace CppSharp
                     {
                         var _decl = NonTypeTemplateParameter.__CreateInstance(decl.__Instance);
                         return VisitNonTypeTemplateParameter(_decl);
+                    }
+                case DeclarationKind.UnresolvedUsingTypename:
+                    {
+                        var _decl = UnresolvedUsingTypename.__CreateInstance(decl.__Instance);
+                        return VisitUnresolvedUsingTypename(_decl);
                     }
             }
 
@@ -807,6 +819,15 @@ namespace CppSharp
             VisitType(type, _type);
             _type.Desugared = VisitQualified(type.Desugared);
             _type.BaseType = VisitQualified(type.BaseType);
+            return _type;
+        }
+
+        public override AST.Type VisitUnresolvedUsing(UnresolvedUsingType type)
+        {
+            var _type = new AST.UnresolvedUsingType();
+            VisitType(type, _type);
+            _type.Declaration = (AST.UnresolvedUsingTypename)
+                declConverter.Visit(type.Declaration);
             return _type;
         }
 
@@ -2023,6 +2044,13 @@ namespace CppSharp
             templateTemplateParameter.IsPackExpansion = decl.IsPackExpansion;
             templateTemplateParameter.IsExpandedParameterPack = decl.IsExpandedParameterPack;
             return templateTemplateParameter;
+        }
+
+        public override AST.Declaration VisitUnresolvedUsingTypename(UnresolvedUsingTypename decl)
+        {
+            var unresolvedUsingTypename = new AST.UnresolvedUsingTypename();
+            VisitDeclaration(decl, unresolvedUsingTypename);
+            return unresolvedUsingTypename;
         }
     }
 

--- a/tests/Common/Common.h
+++ b/tests/Common/Common.h
@@ -1557,3 +1557,20 @@ class DerivedClass: public AbstractClassTemplate<int> {
   public:
     void func() override {}
 };
+
+// Issue: https://github.com/mono/CppSharp/issues/1235
+#include <functional>
+
+template <typename X, typename Y>
+class TemplateClassBase {
+  public:
+    using XType = X;
+};
+
+template <typename A, typename B = A>
+class TemplateClass : TemplateClassBase<A,B> {
+  public:
+    using typename TemplateClassBase<A,B>::XType;
+    using Func = std::function<B(XType)>;
+    explicit TemplateClass(Func function) {}
+};


### PR DESCRIPTION
Fixes https://github.com/mono/CppSharp/issues/1235.

WIP: Still missing generated parser bindings for non-Mac platforms.