### PR TITLE
Fix a crash for secondary bases with secondary bases

### DIFF
--- a/src/Generator/Generators/CSharp/CSharpSources.cs
+++ b/src/Generator/Generators/CSharp/CSharpSources.cs
@@ -2945,7 +2945,7 @@ namespace CppSharp.Generators.CSharp
                 to = to.OriginalClass ?? to;
                 baseOffset = GetOffsetToBase(from, to);
             }
-            var isPrimaryBase = from.BaseClass == to;
+            var isPrimaryBase = (from.BaseClass?.OriginalClass ?? from.BaseClass) == to;
             if (isPrimaryBase)
             {
                 return string.Format("({0} + {1}{2})",

--- a/tests/CSharp/CSharp.Tests.cs
+++ b/tests/CSharp/CSharp.Tests.cs
@@ -371,13 +371,20 @@ public unsafe class CSharpTests : GeneratorTestFixture
     [Test]
     public void TestPrimarySecondaryBase()
     {
-        var a = new MI_A0();
-        var resa = a.Get();
-        Assert.That(resa, Is.EqualTo(50));
+        using (var a = new MI_A0())
+        {
+            Assert.That(a.Get(), Is.EqualTo(50));
+        }
 
-        var c = new MI_C();
-        var res = c.Get();
-        Assert.That(res, Is.EqualTo(50));
+        using (var c = new MI_C())
+        {
+            Assert.That(c.Get(), Is.EqualTo(50));
+        }
+
+        using (var d = new MI_D())
+        {
+            Assert.That(d.Get(), Is.EqualTo(50));
+        }
     }
 
     [Test]

--- a/tests/CSharp/CSharp.h
+++ b/tests/CSharp/CSharp.h
@@ -580,6 +580,20 @@ struct DLL_API MI_C : public MI_A0, public MI_B
 
 MI_C::MI_C() {}
 
+struct DLL_API MI_A1
+{
+    MI_A1();
+};
+
+MI_A1::MI_A1() {}
+
+struct DLL_API MI_D : public MI_A1, public MI_C
+{
+    MI_D();
+};
+
+MI_D::MI_D() {}
+
 class DLL_API StructWithPrivateFields
 {
 public:


### PR DESCRIPTION
The test has also uncovered a bug where the call to a primary base isn't always adjusted so the fix is extended accordingly.