### PR TITLE
Ensure typedefs of std::vector are mapped

### DIFF
--- a/src/Generator/Types/Std/Stdlib.cs
+++ b/src/Generator/Types/Std/Stdlib.cs
@@ -489,7 +489,8 @@ namespace CppSharp.Types.Std
 
         public override void CLIMarshalToNative(MarshalContext ctx)
         {
-            var templateType = Type as TemplateSpecializationType;
+            var desugared = Type.Desugar();
+            var templateType = desugared as TemplateSpecializationType;
             var type = templateType.Arguments[0].Type;
             var isPointerToPrimitive = type.Type.IsPointerToPrimitiveType();
             var managedType = isPointerToPrimitive
@@ -546,7 +547,8 @@ namespace CppSharp.Types.Std
 
         public override void CLIMarshalToManaged(MarshalContext ctx)
         {
-            var templateType = Type as TemplateSpecializationType;
+            var desugared = Type.Desugar();
+            var templateType = desugared as TemplateSpecializationType;
             var type = templateType.Arguments[0].Type;
             var isPointerToPrimitive = type.Type.IsPointerToPrimitiveType();
             var managedType = isPointerToPrimitive

--- a/tests/StandardLib/StandardLib.h
+++ b/tests/StandardLib/StandardLib.h
@@ -12,6 +12,8 @@ struct DLL_API IntWrapperValueType
     int Value;
 };
 
+typedef std::vector<IntWrapperValueType> VectorTypedef;
+
 struct DLL_API TestVectors
 {
     TestVectors();
@@ -28,6 +30,8 @@ struct DLL_API TestVectors
     std::vector<IntWrapper*> IntWrapperPtrVector;
     // Should get mapped to List<IntWrapperValueType>
     std::vector<IntWrapperValueType> IntWrapperValueTypeVector;
+    // Should get mapped to List<IntWrapperValueType>
+    VectorTypedef IntWrapperValueTypeVectorTypedef;
 };
 
 struct DLL_API OStreamTest


### PR DESCRIPTION
We have situations where we are using a `std::vector` typedef. Make sure `Desugar` is called on the type before it is marshalled, so that we get the underlying vector type of the typedef.