### PR TITLE
Ctor, dtor and finalizer body blocks

### DIFF
--- a/src/Generator/Generators/CLI/CLIHeaders.cs
+++ b/src/Generator/Generators/CLI/CLIHeaders.cs
@@ -376,6 +376,7 @@ namespace CppSharp.Generators.CLI
 
             // Output a default constructor that takes the native pointer.
             WriteLine("{0}({1} native);", @class.Name, nativeType);
+            WriteLine("{0}({1} native, bool ownNativeInstance);", @class.Name, nativeType);
             WriteLine("static {0}^ {1}(::System::IntPtr native);",
                 @class.Name, Helpers.CreateInstanceIdentifier);
 

--- a/src/Generator/Generators/CLI/CLIMarshal.cs
+++ b/src/Generator/Generators/CLI/CLIMarshal.cs
@@ -275,15 +275,19 @@ namespace CppSharp.Generators.CLI
             instance += Context.ReturnVarName;
             var needsCopy = Context.MarshalKind != MarshalKind.NativeField;
 
+            bool ownNativeInstance = false;
+
             if (@class.IsRefType && needsCopy)
             {
                 var name = Generator.GeneratedIdentifier(Context.ReturnVarName);
                 Context.Before.WriteLine("auto {0} = new ::{1}({2});", name,
                     @class.QualifiedOriginalName, Context.ReturnVarName);
                 instance = name;
+
+                ownNativeInstance = true;
             }
 
-            WriteClassInstance(@class, instance);
+            WriteClassInstance(@class, instance, ownNativeInstance);
             return true;
         }
 
@@ -295,7 +299,7 @@ namespace CppSharp.Generators.CLI
             return decl.QualifiedName;
         }
 
-        public void WriteClassInstance(Class @class, string instance)
+        public void WriteClassInstance(Class @class, string instance, bool ownNativeInstance = false)
         {
             if (@class.IsRefType)
                 Context.Return.Write("({0} == nullptr) ? nullptr : gcnew ",
@@ -303,7 +307,7 @@ namespace CppSharp.Generators.CLI
 
             Context.Return.Write("{0}(", QualifiedIdentifier(@class));
             Context.Return.Write("(::{0}*)", @class.QualifiedOriginalName);
-            Context.Return.Write("{0})", instance);
+            Context.Return.Write("{0}{1})", instance, ownNativeInstance ? ", true" : "");
         }
 
         public override bool VisitFieldDecl(Field field)

--- a/src/Generator/Utils/BlockGenerator.cs
+++ b/src/Generator/Utils/BlockGenerator.cs
@@ -50,6 +50,9 @@ namespace CppSharp
         Destructor,
         AccessSpecifier,
         Fields,
+        ConstructorBody,
+        DestructorBody,
+        FinalizerBody
     }
 
     [DebuggerDisplay("{Kind} | {Object}")]


### PR DESCRIPTION
Add body blocks for ctor, dtor and finalizer to allow consumer to modify these methods bodies.

Create a ctor overload that takes a bool from the caller to tell the wrapper if it should own the native pointer passed to it, therefore making it responsible for deleting it later, or the caller is the only owner of the pointer.

Didn't think there were any tests needed as it is only generating a new ctor, which can be verified by looking at the generated code. How the ctor is used is up to the consumer.