### PR TITLE
By reference enum param fixes

### DIFF
--- a/src/Generator/Generators/CLI/CLIMarshal.cs
+++ b/src/Generator/Generators/CLI/CLIMarshal.cs
@@ -517,10 +517,15 @@ namespace CppSharp.Generators.CLI
             Enumeration @enum;
             if (pointee.TryGetEnum(out @enum))
             {
-                var isRef = Context.Parameter.Usage == ParameterUsage.Out ||
+                var isRef = Context.Parameter.Type.IsReference() ||
+                    Context.Parameter.Usage == ParameterUsage.Out ||
                     Context.Parameter.Usage == ParameterUsage.InOut;
 
-                ArgumentPrefix.Write("&");
+                if(!isRef)
+                {
+                    ArgumentPrefix.Write("&");
+                }
+
                 Context.Return.Write("(::{0}){1}{2}", @enum.QualifiedOriginalName,
                     isRef ? string.Empty : "*", Context.Parameter.Name);
                 return true;

--- a/src/Generator/Generators/CLI/CLITypePrinter.cs
+++ b/src/Generator/Generators/CLI/CLITypePrinter.cs
@@ -149,7 +149,8 @@ namespace CppSharp.Generators.CLI
                 var typeName = VisitDeclaration(@enum, quals);
 
                 // Skip one indirection if passed by reference
-                if (Parameter != null && (Parameter.Type.IsReference() || ((Parameter.IsOut || Parameter.IsInOut)
+                if (Parameter != null && (Parameter.Type.IsReference() 
+                    || ((Parameter.IsOut || Parameter.IsInOut)
                     && pointee == finalPointee)))
                     return typeName;
 

--- a/src/Generator/Generators/CLI/CLITypePrinter.cs
+++ b/src/Generator/Generators/CLI/CLITypePrinter.cs
@@ -146,11 +146,11 @@ namespace CppSharp.Generators.CLI
             Enumeration @enum;
             if (pointee.TryGetEnum(out @enum))
             {
-                var typeName = @enum.Visit(this);
+                var typeName = VisitDeclaration(@enum, quals);
 
                 // Skip one indirection if passed by reference
-                if (Parameter != null && (Parameter.IsOut || Parameter.IsInOut)
-                    && pointee == finalPointee)
+                if (Parameter != null && (Parameter.Type.IsReference() || ((Parameter.IsOut || Parameter.IsInOut)
+                    && pointee == finalPointee)))
                     return typeName;
 
                 return $"{typeName}*";

--- a/tests/CLI/CLI.Tests.cs
+++ b/tests/CLI/CLI.Tests.cs
@@ -17,4 +17,13 @@ public class CLITests : GeneratorTestFixture
     {
         Assert.AreEqual("test_test", new Date(0, 0, 0).TestStdString("test"));
     }
+
+    [Test]
+    public void TestByRefEnumParam()
+    {
+        using (var byRefEnumParam = new TestByRefEnumParam())
+        {
+            Assert.AreEqual(EnumParam.E1, byRefEnumParam.GetPassedEnumParam(EnumParam.E1));
+        }
+    }
 }

--- a/tests/CLI/CLI.cpp
+++ b/tests/CLI/CLI.cpp
@@ -26,3 +26,8 @@ DLL_API void useIncompleteStruct(IncompleteStruct * a)
 {
     return;
 }
+
+EnumParam TestByRefEnumParam::GetPassedEnumParam(EnumParam & e)
+{
+    return e;
+}

--- a/tests/CLI/CLI.cs
+++ b/tests/CLI/CLI.cs
@@ -24,7 +24,6 @@ namespace CppSharp.Tests
 
         public static void Main(string[] args)
         {
-            System.Diagnostics.Debugger.Launch();
             ConsoleDriver.Run(new CLITestsGenerator(GeneratorKind.CLI));
         }
     }

--- a/tests/CLI/CLI.cs
+++ b/tests/CLI/CLI.cs
@@ -24,6 +24,7 @@ namespace CppSharp.Tests
 
         public static void Main(string[] args)
         {
+            System.Diagnostics.Debugger.Launch();
             ConsoleDriver.Run(new CLITestsGenerator(GeneratorKind.CLI));
         }
     }

--- a/tests/CLI/CLI.h
+++ b/tests/CLI/CLI.h
@@ -56,3 +56,15 @@ typedef struct IncompleteStruct IncompleteStruct;
 
 DLL_API IncompleteStruct* createIncompleteStruct();
 DLL_API void useIncompleteStruct(IncompleteStruct* a);
+
+enum EnumParam
+{
+    E1,
+    E2
+};
+
+class DLL_API TestByRefEnumParam
+{
+public:
+    EnumParam GetPassedEnumParam(EnumParam& e);
+};


### PR DESCRIPTION
- Enum passed by reference is getting treated as a raw pointer, where enum is being dereferenced when it shouldn't.
- Full qualified enum name is not being used when generating enum param.