### PR TITLE
Include type ref header in consumer header if type is nested enum

### DIFF
--- a/src/Generator/AST/ASTRecord.cs
+++ b/src/Generator/AST/ASTRecord.cs
@@ -150,6 +150,19 @@ namespace CppSharp.Generators.AST
             return field.Type.Desugar().TryGetClass(out decl) && decl.IsValueType;
         }
 
+        public static bool IsEnumNestedInClass(this ASTRecord<Declaration> record)
+        {
+            Enumeration @enum = record.Value as Enumeration;
+            var typedDecl = record.Value as ITypedDecl;
+            if (@enum != null 
+                || (typedDecl?.Type?.TryGetEnum(out @enum)).GetValueOrDefault())
+            {
+                return @enum.Namespace is Class;
+            }
+
+            return false;
+        }
+
         public static bool IsDelegate(this ASTRecord record)
         {
             var typedef = record.Object as TypedefDecl;

--- a/src/Generator/Generators/CLI/CLITypeReferences.cs
+++ b/src/Generator/Generators/CLI/CLITypeReferences.cs
@@ -176,7 +176,8 @@ namespace CppSharp.Generators.CLI
             if (TranslationUnit == record.Value.Namespace.TranslationUnit)
                 return false;
 
-            return record.IsBaseClass() || record.IsFieldValueType() || record.IsDelegate();
+            return record.IsBaseClass() || record.IsFieldValueType() || record.IsDelegate()
+                || record.IsEnumNestedInClass();
         }
 
         public override bool VisitDeclaration(Declaration decl)

--- a/tests/CLI/CLI.Tests.cs
+++ b/tests/CLI/CLI.Tests.cs
@@ -35,4 +35,13 @@ public class CLITests : GeneratorTestFixture
             Assert.AreEqual("Employee", org.Employee.Name);
         }
     }
+
+    [Test]
+    public void TestConsumerOfEnumNestedInClass()
+    {
+        using (NestedEnumConsumer consumer = new NestedEnumConsumer())
+        {
+            Assert.AreEqual(ClassWithNestedEnum.NestedEnum.E1, consumer.GetPassedEnum(ClassWithNestedEnum.NestedEnum.E1));
+        }
+    }
 }

--- a/tests/CLI/CLI.h
+++ b/tests/CLI/CLI.h
@@ -3,6 +3,9 @@
 #include "UseTemplateTypeFromIgnoredClassTemplate/Employee.h"
 #include "UseTemplateTypeFromIgnoredClassTemplate/EmployeeOrg.h"
 
+#include "NestedEnumInClassTest/ClassWithNestedEnum.h"
+#include "NestedEnumInClassTest/NestedEnumConsumer.h"
+
 #include <ostream>
 
 // Tests for C++ types

--- a/tests/CLI/NestedEnumInClassTest/ClassWithNestedEnum.cpp
+++ b/tests/CLI/NestedEnumInClassTest/ClassWithNestedEnum.cpp
@@ -1,0 +1,1 @@
+#include "ClassWithNestedEnum.h"

--- a/tests/CLI/NestedEnumInClassTest/ClassWithNestedEnum.h
+++ b/tests/CLI/NestedEnumInClassTest/ClassWithNestedEnum.h
@@ -1,0 +1,13 @@
+#pragma once
+
+#include "../../Tests.h"
+
+class DLL_API ClassWithNestedEnum
+{
+public:
+    enum NestedEnum
+    {
+        E1,
+        E2
+    };
+};

--- a/tests/CLI/NestedEnumInClassTest/NestedEnumConsumer.cpp
+++ b/tests/CLI/NestedEnumInClassTest/NestedEnumConsumer.cpp
@@ -1,0 +1,6 @@
+#include "NestedEnumConsumer.h"
+
+ClassWithNestedEnum::NestedEnum NestedEnumConsumer::GetPassedEnum(ClassWithNestedEnum::NestedEnum e)
+{
+    return e;
+}

--- a/tests/CLI/NestedEnumInClassTest/NestedEnumConsumer.h
+++ b/tests/CLI/NestedEnumInClassTest/NestedEnumConsumer.h
@@ -1,0 +1,11 @@
+#pragma once
+
+#include "../../Tests.h"
+
+#include "ClassWithNestedEnum.h"
+
+class DLL_API NestedEnumConsumer
+{
+public:
+    ClassWithNestedEnum::NestedEnum GetPassedEnum(ClassWithNestedEnum::NestedEnum e);
+};

--- a/tests/CLI/premake4.lua
+++ b/tests/CLI/premake4.lua
@@ -1,2 +1,2 @@
 group "Tests/CLI"
-  SetupTestCLI("CLI", { "Employee", "EmployeeOrg" })
+  SetupTestCLI("CLI", { "Employee", "EmployeeOrg", "ClassWithNestedEnum", "NestedEnumConsumer" })


### PR DESCRIPTION
This fixes an issues where if a consumer is using an enum that is nested in another class, the generated header for the consumer cannot see the enum because the header where the enum lives is not included.

P.S - I think this might be the last fix I need to get things working on my side. I'll see what happens, so there may be other possible future PRs.

When does the master branch normally get published to NuGet?

Thanks.