### PR TITLE
Use UnsupportedType description for type name instead of empty string

### DIFF
--- a/src/Generator/Generators/C/CppTypePrinter.cs
+++ b/src/Generator/Generators/C/CppTypePrinter.cs
@@ -363,7 +363,7 @@ namespace CppSharp.Generators.C
         public override TypePrinterResult VisitUnsupportedType(UnsupportedType type,
             TypeQualifiers quals)
         {
-            return string.Empty;
+            return type.Description;
         }
 
         public override TypePrinterResult VisitDeclaration(Declaration decl,

--- a/tests/CLI/CLI.Tests.cs
+++ b/tests/CLI/CLI.Tests.cs
@@ -44,4 +44,16 @@ public class CLITests : GeneratorTestFixture
             Assert.AreEqual(ClassWithNestedEnum.NestedEnum.E1, consumer.GetPassedEnum(ClassWithNestedEnum.NestedEnum.E1));
         }
     }
+
+    [Test]
+    public void TestChangePassedMappedTypeNonConstRefParam()
+    {
+        using (TestMappedTypeNonConstRefParamConsumer consumer = new TestMappedTypeNonConstRefParamConsumer())
+        {
+            string val = "Initial";
+            consumer.ChangePassedMappedTypeNonConstRefParam(ref val);
+
+            Assert.AreEqual("ChangePassedMappedTypeNonConstRefParam", val);
+        }
+    }
 }

--- a/tests/CLI/CLI.cpp
+++ b/tests/CLI/CLI.cpp
@@ -31,3 +31,20 @@ EnumParam TestByRefEnumParam::GetPassedEnumParam(EnumParam & e)
 {
     return e;
 }
+
+TestMappedTypeNonConstRefParam::TestMappedTypeNonConstRefParam(const std::string str)
+{
+    m_str = str;
+}
+
+const TestMappedTypeNonConstRefParam & TestMappedTypeNonConstRefParam::operator=(const std::string str)
+{
+    m_str = str;
+
+    return *this;
+}
+
+void TestMappedTypeNonConstRefParamConsumer::ChangePassedMappedTypeNonConstRefParam(TestMappedTypeNonConstRefParam & v)
+{
+    v = "ChangePassedMappedTypeNonConstRefParam";
+}

--- a/tests/CLI/CLI.cs
+++ b/tests/CLI/CLI.cs
@@ -1,5 +1,7 @@
 ﻿using CppSharp.AST;
 using CppSharp.Generators;
+using CppSharp.Generators.C;
+using CppSharp.Passes;
 using CppSharp.Types;
 using CppSharp.Utils;
 
@@ -19,6 +21,56 @@ namespace CppSharp.Tests
         }
     }
 
+    [TypeMap("TestMappedTypeNonConstRefParam")]
+    public class TestMappedTypeNonConstRefParamTypeMap : TypeMap
+    {
+        public override Type CLISignatureType(TypePrinterContext ctx)
+        {
+            return new CILType(typeof(string));
+        }
+
+        public override Type CppSignatureType(TypePrinterContext ctx)
+        {
+            var tagType = ctx.Type as TagType;
+            var typePrinter = new CppTypePrinter(Context);
+            return new CustomType(tagType.Declaration.Visit(typePrinter));
+        }
+
+        public override void CLIMarshalToManaged(MarshalContext ctx)
+        {
+            ctx.Return.Write("clix::marshalString<clix::E_UTF8>({0}.m_str)", ctx.ReturnVarName);
+        }
+
+        public override void CLIMarshalToNative(MarshalContext ctx)
+        {
+            if (ctx.Parameter.Usage == ParameterUsage.InOut)
+            {
+                ctx.Before.WriteLine($"System::String^ _{ctx.Parameter.Name} = {ctx.Parameter.Name};");
+            }
+
+            string paramName = ctx.Parameter.Usage == ParameterUsage.InOut ? $"_{ctx.Parameter.Name}" : ctx.Parameter.Name;
+
+            ctx.Before.WriteLine(
+                $"::TestMappedTypeNonConstRefParam _{ctx.ArgName} = clix::marshalString<clix::E_UTF8>({paramName});");
+
+            ctx.Return.Write("_{0}", ctx.ArgName);
+        }
+    }
+
+    public class TestMappedTypeNonConstRefParamToOutParamPass : TranslationUnitPass
+    {
+        public override bool VisitMethodDecl(Method method)
+        {
+            if(method.Name == "ChangePassedMappedTypeNonConstRefParam")
+            {
+                method.Parameters[0].Usage = ParameterUsage.InOut;
+                return true;
+            }
+
+            return base.VisitMethodDecl(method);
+        }
+    }
+
     public class CLITestsGenerator : GeneratorTest
     {
         public CLITestsGenerator(GeneratorKind kind)
@@ -31,6 +83,11 @@ namespace CppSharp.Tests
             driver.Options.GenerateFinalizers = true;
             driver.Options.GenerateObjectOverrides = true;
             base.Setup(driver);
+        }
+
+        public override void SetupPasses(Driver driver)
+        {           
+            driver.AddTranslationUnitPass(new TestMappedTypeNonConstRefParamToOutParamPass());
         }
 
         public static void Main(string[] args)

--- a/tests/CLI/CLI.cs
+++ b/tests/CLI/CLI.cs
@@ -57,20 +57,6 @@ namespace CppSharp.Tests
         }
     }
 
-    public class TestMappedTypeNonConstRefParamToOutParamPass : TranslationUnitPass
-    {
-        public override bool VisitMethodDecl(Method method)
-        {
-            if(method.Name == "ChangePassedMappedTypeNonConstRefParam")
-            {
-                method.Parameters[0].Usage = ParameterUsage.InOut;
-                return true;
-            }
-
-            return base.VisitMethodDecl(method);
-        }
-    }
-
     public class CLITestsGenerator : GeneratorTest
     {
         public CLITestsGenerator(GeneratorKind kind)
@@ -85,9 +71,10 @@ namespace CppSharp.Tests
             base.Setup(driver);
         }
 
-        public override void SetupPasses(Driver driver)
-        {           
-            driver.AddTranslationUnitPass(new TestMappedTypeNonConstRefParamToOutParamPass());
+        public override void Preprocess(Driver driver, ASTContext ctx)
+        {
+            LibraryHelpers.SetMethodParameterUsage(driver.Context.ASTContext, "TestMappedTypeNonConstRefParamConsumer",
+                "ChangePassedMappedTypeNonConstRefParam", 1, ParameterUsage.InOut);
         }
 
         public static void Main(string[] args)

--- a/tests/CLI/CLI.cs
+++ b/tests/CLI/CLI.cs
@@ -73,7 +73,7 @@ namespace CppSharp.Tests
 
         public override void Preprocess(Driver driver, ASTContext ctx)
         {
-            LibraryHelpers.SetMethodParameterUsage(driver.Context.ASTContext, "TestMappedTypeNonConstRefParamConsumer",
+            LibraryHelpers.SetMethodParameterUsage(ctx, "TestMappedTypeNonConstRefParamConsumer",
                 "ChangePassedMappedTypeNonConstRefParam", 1, ParameterUsage.InOut);
         }
 

--- a/tests/CLI/CLI.h
+++ b/tests/CLI/CLI.h
@@ -74,3 +74,18 @@ class DLL_API TestByRefEnumParam
 public:
     EnumParam GetPassedEnumParam(EnumParam& e);
 };
+
+class DLL_API TestMappedTypeNonConstRefParam
+{
+public:
+    TestMappedTypeNonConstRefParam(const std::string);
+    const TestMappedTypeNonConstRefParam& operator=(const std::string);
+
+    std::string m_str;
+};
+
+class DLL_API TestMappedTypeNonConstRefParamConsumer
+{
+public:
+    void ChangePassedMappedTypeNonConstRefParam(TestMappedTypeNonConstRefParam&);
+};


### PR DESCRIPTION
`CppTypePrinter.VisitTagType` has changed recently to use type maps, which consequently calls `CppSignatureType` instead of the previous `tag.Declaration.Visit(this)` call. This is breaking code generation for us as we are using `CustomType` for some tag types mapping.

The fix is to return the `UnsupportedType` (`CustomType` base) description instead of an empty string so that we can generate the correct type name, instead of `void*`, which is what is currently getting generated.

@tritao @ddobrev If you're happy with this PR, it would be really appreciated if we can get another NuGet release please. Unfortunately I just found this issue when testing the latest NuGet release.

Thank you.