### PR TITLE
Fixes around pointers and const arrays

### DIFF
--- a/src/Generator/Generators/CLI/CLIMarshal.cs
+++ b/src/Generator/Generators/CLI/CLIMarshal.cs
@@ -305,7 +305,7 @@ namespace CppSharp.Generators.CLI
                 Context.Return.Write("({0} == nullptr) ? nullptr : gcnew ",
                     instance);
 
-            Context.Return.Write("{0}(", QualifiedIdentifier(@class));
+            Context.Return.Write("::{0}(", QualifiedIdentifier(@class));
             Context.Return.Write("(::{0}*)", @class.QualifiedOriginalName);
             Context.Return.Write("{0}{1})", instance, ownNativeInstance ? ", true" : "");
         }
@@ -433,39 +433,42 @@ namespace CppSharp.Generators.CLI
                 case ArrayType.ArraySize.Constant:
                     if (string.IsNullOrEmpty(Context.ReturnVarName))
                     {
-                        const string pinnedPtr = "__pinnedPtr";
-                        Context.Before.WriteLine("cli::pin_ptr<{0}> {1} = &{2}[0];",
-                            array.Type, pinnedPtr, Context.Parameter.Name);
-                        const string arrayPtr = "__arrayPtr";
-                        Context.Before.WriteLine("{0}* {1} = {2};", array.Type, arrayPtr, pinnedPtr);
-                        Context.Return.Write("({0} (&)[{1}]) {2}", array.Type, array.Size, arrayPtr);
+                        string arrayPtrRet = $"__{Context.ParameterIndex}ArrayPtr";
+                        Context.Before.WriteLine($"{array.Type} {arrayPtrRet}[{array.Size}];");
+
+                        Context.ReturnVarName = arrayPtrRet;
+
+                        Context.Return.Write(arrayPtrRet);
                     }
-                    else
+
+                    bool isPointerToPrimitive = array.Type.IsPointerToPrimitiveType(PrimitiveType.Void);
+                    bool isPrimitive = array.Type.IsPrimitiveType();
+                    var supportBefore = Context.Before;
+                    supportBefore.WriteLine("if ({0} != nullptr)", Context.Parameter.Name);
+                    supportBefore.WriteOpenBraceAndIndent();
+
+                    supportBefore.WriteLine($"if ({Context.Parameter.Name}->Length != {array.Size})");
+                    supportBefore.WriteOpenBraceAndIndent();
+                    supportBefore.WriteLine($"throw gcnew System::InvalidOperationException(\"Source array size must equal destination array size.\");");
+                    supportBefore.UnindentAndWriteCloseBrace();
+
+                    string nativeVal = string.Empty;
+                    if (isPointerToPrimitive)
                     {
-                        bool isPointerToPrimitive = array.Type.IsPointerToPrimitiveType(PrimitiveType.Void);
-                        bool isPrimitive = array.Type.IsPrimitiveType();
-                        var supportBefore = Context.Before;
-                        supportBefore.WriteLine("if ({0} != nullptr)", Context.ArgName);
-                        supportBefore.WriteOpenBraceAndIndent();
-
-                        string nativeVal = string.Empty;
-                        if (isPointerToPrimitive)
-                        {
-                            nativeVal = ".ToPointer()";
-                        }
-                        else if (!isPrimitive)
-                        {
-                            nativeVal = "->NativePtr";
-                        }
-
-                        supportBefore.WriteLine("for (int i = 0; i < {0}; i++)", array.Size);
-                        supportBefore.WriteLineIndent("{0}[i] = {1}{2}[i]{3};",
-                            Context.ReturnVarName,
-                            isPointerToPrimitive || isPrimitive ? string.Empty : "*",
-                            Context.ArgName,
-                            nativeVal);
-                        supportBefore.UnindentAndWriteCloseBrace();   
+                        nativeVal = ".ToPointer()";
                     }
+                    else if (!isPrimitive)
+                    {
+                        nativeVal = "->NativePtr";
+                    }
+
+                    supportBefore.WriteLine("for (int i = 0; i < {0}; i++)", array.Size);
+                    supportBefore.WriteLineIndent("{0}[i] = {1}{2}[i]{3};",
+                        Context.ReturnVarName,
+                        isPointerToPrimitive || isPrimitive ? string.Empty : "*",
+                        Context.Parameter.Name,
+                        nativeVal);
+                    supportBefore.UnindentAndWriteCloseBrace();                       
                     break;
                 default:
                     Context.Return.Write("null");
@@ -548,6 +551,12 @@ namespace CppSharp.Generators.CLI
                 Context.Return.Write("({0})", cppTypeName);
                 Context.Return.Write(Context.Parameter.Name);
                 return true;
+            }
+
+            // Pass address of argument if the parameter is a pointer to the pointer itself.
+            if (pointee is PointerType && !Context.Parameter.Type.IsReference())
+            {
+                ArgumentPrefix.Write("&");
             }
 
             return pointer.QualifiedPointee.Visit(this);
@@ -772,7 +781,8 @@ namespace CppSharp.Generators.CLI
                                  {
                                      ArgName = fieldRef,
                                      ParameterIndex = Context.ParameterIndex++,
-                                     MarshalVarPrefix = Context.MarshalVarPrefix
+                                     MarshalVarPrefix = Context.MarshalVarPrefix,
+                                     ReturnVarName = $"{marshalVar}.{property.Field.OriginalName}"
                                  };
 
             var marshal = new CLIMarshalManagedToNativePrinter(marshalCtx);
@@ -783,23 +793,26 @@ namespace CppSharp.Generators.CLI
             if (!string.IsNullOrWhiteSpace(marshal.Context.Before))
                 Context.Before.Write(marshal.Context.Before);
 
-            Type type;
-            Class @class;
-            var isRef = property.Type.IsPointerTo(out type) &&
-                !(type.TryGetClass(out @class) && @class.IsValueType) &&
-                !type.IsPrimitiveType();
-
-            if (isRef)
+            if (!string.IsNullOrWhiteSpace(marshal.Context.Return))
             {
-                Context.Before.WriteLine("if ({0} != nullptr)", fieldRef);
-                Context.Before.Indent();
+                Type type;
+                Class @class;
+                var isRef = property.Type.IsPointerTo(out type) &&
+                    !(type.TryGetClass(out @class) && @class.IsValueType) &&
+                    !type.IsPrimitiveType();
+
+                if (isRef)
+                {
+                    Context.Before.WriteLine("if ({0} != nullptr)", fieldRef);
+                    Context.Before.Indent();
+                }
+
+                Context.Before.WriteLine("{0}.{1} = {2};", marshalVar,
+                    property.Field.OriginalName, marshal.Context.Return);
+
+                if (isRef)
+                    Context.Before.Unindent();
             }
-
-            Context.Before.WriteLine("{0}.{1} = {2};", marshalVar,
-                property.Field.OriginalName, marshal.Context.Return);
-
-            if (isRef)
-                Context.Before.Unindent();
         }
 
         public override bool VisitFieldDecl(Field field)

--- a/src/Generator/Types/Std/Stdlib.cs
+++ b/src/Generator/Types/Std/Stdlib.cs
@@ -564,8 +564,10 @@ namespace CppSharp.Types.Std
             ctx.Before.WriteLine(
                 "auto {0} = gcnew System::Collections::Generic::List<{1}>();",
                 tmpVarName, managedType);
+
+            string retVarName = ctx.ReturnType.Type.Desugar().IsPointer() ? $"*{ctx.ReturnVarName}" : ctx.ReturnVarName;
             ctx.Before.WriteLine("for(auto _element : {0})",
-                ctx.ReturnVarName);
+                retVarName);
             ctx.Before.WriteOpenBraceAndIndent();
             {
                 var elementCtx = new MarshalContext(ctx.Context, ctx.Indentation)

--- a/tests/CLI/CLI.Tests.cs
+++ b/tests/CLI/CLI.Tests.cs
@@ -1,6 +1,8 @@
 using CppSharp.Utils;
 using NUnit.Framework;
 using CLI;
+using System.Text;
+using System;
 
 public class CLITests : GeneratorTestFixture
 {
@@ -54,6 +56,148 @@ public class CLITests : GeneratorTestFixture
             consumer.ChangePassedMappedTypeNonConstRefParam(ref val);
 
             Assert.AreEqual("ChangePassedMappedTypeNonConstRefParam", val);
+        }
+    }
+
+    [Test]
+    public void TestMultipleConstantArraysParamsTestMethod()
+    {
+        byte[] bytes = Encoding.ASCII.GetBytes("TestMulti");
+        sbyte[] sbytes = Array.ConvertAll(bytes, q => Convert.ToSByte(q));
+
+        byte[] bytes2 = Encoding.ASCII.GetBytes("TestMulti2");
+        sbyte[] sbytes2 = Array.ConvertAll(bytes2, q => Convert.ToSByte(q));
+
+        string s = CLI.CLI.MultipleConstantArraysParamsTestMethod(sbytes, sbytes2);
+        Assert.AreEqual("TestMultiTestMulti2", s);
+    }
+
+    [Test]
+    public void TestMultipleConstantArraysParamsTestMethodLongerSourceArray()
+    {
+        byte[] bytes = Encoding.ASCII.GetBytes("TestMultipleConstantArraysParamsTestMethodLongerSourceArray");
+        sbyte[] sbytes = Array.ConvertAll(bytes, q => Convert.ToSByte(q));
+
+        Assert.Throws<InvalidOperationException>(() => CLI.CLI.MultipleConstantArraysParamsTestMethod(sbytes, new sbyte[] { }));
+    }
+
+    [Test]
+    public void TestPointerToTypedefPointerTestMethod()
+    {
+        int a = 50;
+        using (PointerToTypedefPointerTest lp = new PointerToTypedefPointerTest())
+        {
+            CLI.CLI.PointerToTypedefPointerTestMethod(lp, 100);
+            Assert.AreEqual(100, lp.Val);
+        }
+    }
+
+    [Test]
+    public void TestPointerToPrimitiveTypedefPointerTestMethod()
+    {
+        int a = 50;
+        CLI.CLI.PointerToPrimitiveTypedefPointerTestMethod(ref a, 100);
+        Assert.AreEqual(100, a);
+    }
+
+    [Test]
+    public void TestStructWithNestedUnionTestMethod()
+    {
+        using (StructWithNestedUnion val = new StructWithNestedUnion())
+        {
+            byte[] bytes = Encoding.ASCII.GetBytes("TestUnions");
+            sbyte[] sbytes = Array.ConvertAll(bytes, q => Convert.ToSByte(q));
+
+            UnionNestedInsideStruct unionNestedInsideStruct;
+            unionNestedInsideStruct.SzText = sbytes;
+
+            Assert.AreEqual(sbytes.Length, unionNestedInsideStruct.SzText.Length);
+            Assert.AreEqual("TestUnions", unionNestedInsideStruct.SzText);
+
+            val.NestedUnion = unionNestedInsideStruct;
+
+            Assert.AreEqual(10, val.NestedUnion.SzText.Length);
+            Assert.AreEqual("TestUnions", val.NestedUnion.SzText);
+
+            string ret = CLI.CLI.StructWithNestedUnionTestMethod(val);
+
+            Assert.AreEqual("TestUnions", ret);
+        }
+    }
+
+    [Test]
+    public void TestStructWithNestedUnionLongerSourceArray()
+    {
+        using (StructWithNestedUnion val = new StructWithNestedUnion())
+        {
+            byte[] bytes = Encoding.ASCII.GetBytes("TestStructWithNestedUnionLongerSourceArray");
+            sbyte[] sbytes = Array.ConvertAll(bytes, q => Convert.ToSByte(q));
+
+            UnionNestedInsideStruct unionNestedInsideStruct;
+            unionNestedInsideStruct.SzText = sbytes;
+
+            Assert.Throws<InvalidOperationException>(() => val.NestedUnion = unionNestedInsideStruct);
+        }
+    }
+
+    [Test]
+    public void TestUnionWithNestedStructTestMethod()
+    {
+        using (StructNestedInsideUnion val = new StructNestedInsideUnion())
+        {
+            byte[] bytes = Encoding.ASCII.GetBytes("TestUnions");
+            sbyte[] sbytes = Array.ConvertAll(bytes, q => Convert.ToSByte(q));
+            val.SzText = sbytes;
+
+            UnionWithNestedStruct unionWithNestedStruct;
+            unionWithNestedStruct.NestedStruct = val;
+
+            Assert.AreEqual(10, unionWithNestedStruct.NestedStruct.SzText.Length);
+            Assert.AreEqual("TestUnions", unionWithNestedStruct.NestedStruct.SzText);
+
+            string ret = CLI.CLI.UnionWithNestedStructTestMethod(unionWithNestedStruct);
+
+            Assert.AreEqual("TestUnions", ret);
+        }
+    }
+
+    [Test]
+    public void TestUnionWithNestedStructArrayTestMethod()
+    {
+        using (StructNestedInsideUnion val = new StructNestedInsideUnion())
+        {
+            using (StructNestedInsideUnion val2 = new StructNestedInsideUnion())
+            {
+                byte[] bytes = Encoding.ASCII.GetBytes("TestUnion1");
+                sbyte[] sbytes = Array.ConvertAll(bytes, q => Convert.ToSByte(q));
+                val.SzText = sbytes;
+
+                byte[] bytes2 = Encoding.ASCII.GetBytes("TestUnion2");
+                sbyte[] sbytes2 = Array.ConvertAll(bytes2, q => Convert.ToSByte(q));
+                val2.SzText = sbytes2;
+
+                UnionWithNestedStructArray unionWithNestedStructArray;
+                unionWithNestedStructArray.NestedStructs = new StructNestedInsideUnion[] { val, val2 };
+
+                Assert.AreEqual(2, unionWithNestedStructArray.NestedStructs.Length);
+
+                string ret = CLI.CLI.UnionWithNestedStructArrayTestMethod(unionWithNestedStructArray);
+
+                Assert.AreEqual("TestUnion1TestUnion2", ret);
+            }
+        }
+    }
+
+    [Test]
+    public void TestVectorPointerGetter()
+    {
+        using (VectorPointerGetter v = new VectorPointerGetter())
+        {
+            var list = v.VecPtr;
+
+            Assert.AreEqual(1, list.Count);
+
+            Assert.AreEqual("VectorPointerGetter", list[0]);
         }
     }
 }

--- a/tests/CLI/CLI.cpp
+++ b/tests/CLI/CLI.cpp
@@ -48,3 +48,55 @@ void TestMappedTypeNonConstRefParamConsumer::ChangePassedMappedTypeNonConstRefPa
 {
     v = "ChangePassedMappedTypeNonConstRefParam";
 }
+
+std::string DLL_API MultipleConstantArraysParamsTestMethod(char arr1[9], char arr2[10])
+{
+    return std::string(arr1, arr1 + 9) + std::string(arr2, arr2 + 10);
+}
+
+void DLL_API PointerToTypedefPointerTestMethod(LPPointerToTypedefPointerTest* lp, int valToSet)
+{
+    (*(*lp)).val = valToSet;
+}
+
+void DLL_API PointerToPrimitiveTypedefPointerTestMethod(LPLONG lp, long valToSet)
+{
+    *lp = valToSet;
+}
+
+std::string DLL_API StructWithNestedUnionTestMethod(StructWithNestedUnion val)
+{   
+    return std::string(val.nestedUnion.szText, val.nestedUnion.szText + 10);
+}
+
+std::string DLL_API UnionWithNestedStructTestMethod(UnionWithNestedStruct val)
+{
+    return std::string(val.nestedStruct.szText, val.nestedStruct.szText + 10);
+}
+
+std::string DLL_API UnionWithNestedStructArrayTestMethod(UnionWithNestedStructArray arr)
+{
+    return std::string(arr.nestedStructs[0].szText, arr.nestedStructs[0].szText + 10)
+        + std::string(arr.nestedStructs[1].szText, arr.nestedStructs[1].szText + 10);
+}
+
+VectorPointerGetter::VectorPointerGetter()
+{
+    vecPtr = new std::vector<std::string>();
+    vecPtr->push_back("VectorPointerGetter");
+}
+
+VectorPointerGetter::~VectorPointerGetter()
+{
+    if (vecPtr)
+    {
+        auto tempVec = vecPtr;
+        delete vecPtr;
+        tempVec = nullptr;
+    }
+}
+
+std::vector<std::string>* VectorPointerGetter::GetVecPtr()
+{
+    return vecPtr;
+}

--- a/tests/CLI/CLI.h
+++ b/tests/CLI/CLI.h
@@ -7,6 +7,7 @@
 #include "NestedEnumInClassTest/NestedEnumConsumer.h"
 
 #include <ostream>
+#include <vector>
 
 // Tests for C++ types
 struct DLL_API Types
@@ -88,4 +89,61 @@ class DLL_API TestMappedTypeNonConstRefParamConsumer
 {
 public:
     void ChangePassedMappedTypeNonConstRefParam(TestMappedTypeNonConstRefParam&);
+};
+
+std::string DLL_API MultipleConstantArraysParamsTestMethod(char arr1[9], char arr2[10]);
+
+struct DLL_API PointerToTypedefPointerTest
+{
+    int val;
+};
+typedef PointerToTypedefPointerTest *LPPointerToTypedefPointerTest;
+
+void DLL_API PointerToTypedefPointerTestMethod(LPPointerToTypedefPointerTest* lp, int valToSet);
+
+typedef long *LPLONG;
+
+void DLL_API PointerToPrimitiveTypedefPointerTestMethod(LPLONG lp, long valToSet);
+
+union DLL_API UnionNestedInsideStruct
+{
+    char szText[10];
+};
+
+struct DLL_API StructWithNestedUnion
+{
+    UnionNestedInsideStruct nestedUnion;
+};
+
+std::string DLL_API StructWithNestedUnionTestMethod(StructWithNestedUnion val);
+
+struct DLL_API StructNestedInsideUnion
+{
+    char szText[10];
+};
+
+union DLL_API UnionWithNestedStruct
+{
+    StructNestedInsideUnion nestedStruct;
+};
+
+std::string DLL_API UnionWithNestedStructTestMethod(UnionWithNestedStruct val);
+
+union DLL_API UnionWithNestedStructArray
+{
+    StructNestedInsideUnion nestedStructs[2];
+};
+
+std::string DLL_API UnionWithNestedStructArrayTestMethod(UnionWithNestedStructArray val);
+
+class DLL_API VectorPointerGetter
+{
+public:
+    VectorPointerGetter();
+    ~VectorPointerGetter();
+
+    std::vector<std::string>* GetVecPtr();
+
+private:
+    std::vector<std::string>* vecPtr;
 };


### PR DESCRIPTION
- Ensure constant arrays, especially in value types, are correctly marshalled from managed to native by using a for loop, same way that a loop is used when a return var name is available. Ensure exception is thrown if provided array does not match size of array that we will fill.

- Pass address of pointer type if the native function call expects a pointer to pointer.

- Desugar the parameter type before visiting it so that we end up visiting the actual type rather than the typedef. This is required for typedef of pointers to primitive types to work.

- Ensure vector is dereferenced in loop if the native call gives us a pointer.