### PR TITLE
publish the clang lib folder

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -72,7 +72,7 @@ on_success:
 
 after_build:
   - echo 'Preparing artifacts...'
-  - 7z a %ARTIFACT_NAME% %LIB_PATH%\CppSharp*
+  - 7z a %ARTIFACT_NAME% %LIB_PATH%\CppSharp* %LIB_PATH%\lib
   - appveyor PushArtifact %ARTIFACT_NAME%
 
 #---------------------------------#


### PR DESCRIPTION
The clang lib folder is not published on windows appveyor build. The lib folder is required to run the generator. This is useful if we want to test a build of CppSharp when a NuGet package is not available.