### PR TITLE
force bash use in ./premake5-linux

### DIFF
--- a/build/premake5-linux
+++ b/build/premake5-linux
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 DIR=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
 


### PR DESCRIPTION
building on some docker container /bin/sh default is dash, so that follow warning occurs
```
./premake5-linux: 3: ./premake5-linux: Bad substitution
```
this PR changes /bin/sh to /bin/bash in order to avoid error on `${BASH_SOURCE[0]}` expansion