### PR TITLE
Fix crash when trying to read a CXXRecordDecl that doesn't have a definition

### DIFF
--- a/src/CppParser/Parser.cpp
+++ b/src/CppParser/Parser.cpp
@@ -1073,6 +1073,9 @@ void Parser::WalkRecordCXX(const clang::CXXRecordDecl* Record, Class* RC)
     Sema.ForceDeclarationOfImplicitMembers(const_cast<clang::CXXRecordDecl*>(Record));
 
     WalkRecord(Record, RC);
+    
+    if (!Record->hasDefinition())
+        return;
 
     RC->isPOD = Record->isPOD();
     RC->isAbstract = Record->isAbstract();

--- a/tests/CSharp/CSharp.h
+++ b/tests/CSharp/CSharp.h
@@ -1405,3 +1405,15 @@ DLL_API boolean_t takeTypemapTypedefParam(boolean_t b);
 class DLL_API TestAnonymousMemberNameCollision : public ClassUsingUnion {
 
 };
+
+namespace CXXRecordDeclWithoutDefinition
+{
+    template<typename... T>
+    struct list;
+
+    template<typename T>
+    struct it;
+
+    template <> struct it<list<>> { };
+    template <> struct it<list<> const> { };
+}


### PR DESCRIPTION
Fixes #1416 