### PR TITLE
Add missing `Variable.Type` null check.

### DIFF
--- a/src/AST/ASTVisitor.cs
+++ b/src/AST/ASTVisitor.cs
@@ -470,6 +470,8 @@ namespace CppSharp.AST
             if (!VisitDeclaration(variable))
                 return false;
 
+            // TODO: Remove this null check once CppParser can properly handle auto types.
+            // This is workaround for https://github.com/mono/CppSharp/issues/1412.            
             if (variable.Type == null)
                 return false;
 

--- a/src/AST/ASTVisitor.cs
+++ b/src/AST/ASTVisitor.cs
@@ -470,6 +470,9 @@ namespace CppSharp.AST
             if (!VisitDeclaration(variable))
                 return false;
 
+            if (variable.Type == null)
+                return false;
+
             return variable.Type.Visit(this, variable.QualifiedType.Qualifiers);
         }
 

--- a/tests/CSharp/CSharp.h
+++ b/tests/CSharp/CSharp.h
@@ -1430,3 +1430,15 @@ namespace CXXRecordDeclWithoutDefinition
     template <> struct it<list<>> { };
     template <> struct it<list<> const> { };
 }
+
+template<int... n>
+struct TestVariableWithoutType
+{
+    template<typename... Args>
+    static constexpr int create(Args... args)
+    {
+        return {};
+    }
+
+    static constexpr auto variable = create(n...);
+};


### PR DESCRIPTION
Fixes #1412.