### PR TITLE
Use C# 'default literal' to avoid using a type's name that may be renamed

### DIFF
--- a/build/Helpers.lua
+++ b/build/Helpers.lua
@@ -164,7 +164,7 @@ end
 
 function SetupManagedProject()
   language "C#"
-  csversion "7.2"
+  csversion ("7.2")
   location ("%{wks.location}/projects")
   buildoptions {"/platform:".._OPTIONS["arch"]}
 

--- a/build/Helpers.lua
+++ b/build/Helpers.lua
@@ -164,8 +164,8 @@ end
 
 function SetupManagedProject()
   language "C#"
-  csversion ("7.2")
   location ("%{wks.location}/projects")
+  buildoptions {"/langversion:7.2"}
   buildoptions {"/platform:".._OPTIONS["arch"]}
 
   dotnetframework "4.7.2"

--- a/build/Helpers.lua
+++ b/build/Helpers.lua
@@ -164,6 +164,7 @@ end
 
 function SetupManagedProject()
   language "C#"
+  csversion "7.2"
   location ("%{wks.location}/projects")
   buildoptions {"/platform:".._OPTIONS["arch"]}
 

--- a/src/Generator/Passes/HandleDefaultParamValuesPass.cs
+++ b/src/Generator/Passes/HandleDefaultParamValuesPass.cs
@@ -54,7 +54,7 @@ namespace CppSharp.Passes
 
                 var result = parameter.DefaultArgument.String;
                 if (PrintExpression(function, parameter.Type,
-                        parameter.OriginalDefaultArgument, allowDefaultLiteral: false, ref result) == null)
+                        parameter.OriginalDefaultArgument, allowDefaultLiteral: true, ref result) == null)
                     overloadIndices.Add(function.Parameters.IndexOf(parameter));
                 if (string.IsNullOrEmpty(result))
                 {

--- a/src/Generator/Passes/HandleDefaultParamValuesPass.cs
+++ b/src/Generator/Passes/HandleDefaultParamValuesPass.cs
@@ -54,7 +54,7 @@ namespace CppSharp.Passes
 
                 var result = parameter.DefaultArgument.String;
                 if (PrintExpression(function, parameter.Type,
-                        parameter.OriginalDefaultArgument, ref result) == null)
+                        parameter.OriginalDefaultArgument, allowDefaultLiteral: false, ref result) == null)
                     overloadIndices.Add(function.Parameters.IndexOf(parameter));
                 if (string.IsNullOrEmpty(result))
                 {
@@ -71,7 +71,7 @@ namespace CppSharp.Passes
             return true;
         }
 
-        private bool? PrintExpression(Function function, Type type, ExpressionObsolete expression, ref string result)
+        private bool? PrintExpression(Function function, Type type, ExpressionObsolete expression, bool allowDefaultLiteral, ref string result)
         {
             var desugared = type.Desugar();
 
@@ -79,7 +79,7 @@ namespace CppSharp.Passes
                 (expression.String == "0" || expression.String == "nullptr"))
             {
                 result = desugared.GetPointee()?.Desugar() is FunctionType ?
-                    "null" : $"default({desugared})";
+                    "null" : (allowDefaultLiteral ? "default" : $"default({desugared})");
                 return true;
             }
 
@@ -212,8 +212,9 @@ namespace CppSharp.Passes
                 {
                     var argument = ctor.Arguments[i];
                     var argResult = argument.String;
+              
                     expressionSupported &= PrintExpression(method,
-                        method.Parameters[i].Type.Desugar(), argument, ref argResult) ?? false;
+                        method.Parameters[i].Type.Desugar(), argument, allowDefaultLiteral: false, ref argResult) ?? false;
                     argsBuilder.Append(argResult);
                     if (i < ctor.Arguments.Count - 1)
                         argsBuilder.Append(", ");

--- a/src/Generator/Passes/HandleDefaultParamValuesPass.cs
+++ b/src/Generator/Passes/HandleDefaultParamValuesPass.cs
@@ -54,7 +54,7 @@ namespace CppSharp.Passes
 
                 var result = parameter.DefaultArgument.String;
                 if (PrintExpression(function, parameter.Type,
-                        parameter.OriginalDefaultArgument, true, ref result) == null)
+                        parameter.OriginalDefaultArgument, allowDefaultLiteral: true, ref result) == null)
                     overloadIndices.Add(function.Parameters.IndexOf(parameter));
                 if (string.IsNullOrEmpty(result))
                 {
@@ -214,7 +214,7 @@ namespace CppSharp.Passes
                     var argResult = argument.String;
               
                     expressionSupported &= PrintExpression(method,
-                        method.Parameters[i].Type.Desugar(), argument, false, ref argResult) ?? false;
+                        method.Parameters[i].Type.Desugar(), argument, allowDefaultLiteral: false, ref argResult) ?? false;
                     argsBuilder.Append(argResult);
                     if (i < ctor.Arguments.Count - 1)
                         argsBuilder.Append(", ");

--- a/src/Generator/Passes/HandleDefaultParamValuesPass.cs
+++ b/src/Generator/Passes/HandleDefaultParamValuesPass.cs
@@ -54,7 +54,7 @@ namespace CppSharp.Passes
 
                 var result = parameter.DefaultArgument.String;
                 if (PrintExpression(function, parameter.Type,
-                        parameter.OriginalDefaultArgument, allowDefaultLiteral: true, ref result) == null)
+                        parameter.OriginalDefaultArgument, true, ref result) == null)
                     overloadIndices.Add(function.Parameters.IndexOf(parameter));
                 if (string.IsNullOrEmpty(result))
                 {
@@ -214,7 +214,7 @@ namespace CppSharp.Passes
                     var argResult = argument.String;
               
                     expressionSupported &= PrintExpression(method,
-                        method.Parameters[i].Type.Desugar(), argument, allowDefaultLiteral: false, ref argResult) ?? false;
+                        method.Parameters[i].Type.Desugar(), argument, false, ref argResult) ?? false;
                     argsBuilder.Append(argResult);
                     if (i < ctor.Arguments.Count - 1)
                         argsBuilder.Append(", ");

--- a/tests/CSharp/CSharp.cpp
+++ b/tests/CSharp/CSharp.cpp
@@ -804,6 +804,10 @@ void MethodsWithDefaultValues::defaultWithStdNumericLimits(double d, int i)
 {
 }
 
+void MethodsWithDefaultValues::defaultWithParamRequiringRename(_ClassWithLeadingUnderscore* ptr)
+{
+}
+
 int MethodsWithDefaultValues::DefaultWithParamNamedSameAsMethod(int DefaultWithParamNamedSameAsMethod, const Foo& defaultArg)
 {
     return 1;

--- a/tests/CSharp/CSharp.h
+++ b/tests/CSharp/CSharp.h
@@ -407,6 +407,9 @@ enum class Empty : unsigned long long int
 {
 };
 
+class _ClassWithLeadingUnderscore {
+};
+
 class DLL_API MethodsWithDefaultValues : public Quux
 {
 public:
@@ -475,6 +478,7 @@ public:
     void defaultWithCharFromInt(char c = 32);
     void defaultWithFreeConstantInNameSpace(int c = HasFreeConstant::FREE_CONSTANT_IN_NAMESPACE);
     void defaultWithStdNumericLimits(double d = 1.0, int i = std::numeric_limits<double>::infinity());
+    void defaultWithParamRequiringRename(_ClassWithLeadingUnderscore* ptr = nullptr);
     int DefaultWithParamNamedSameAsMethod(int DefaultWithParamNamedSameAsMethod, const Foo& defaultArg = Foo());
     int getA();
 private:


### PR DESCRIPTION
Fixes #1410 but not completely since using a nested expression that uses a class with leading underscore will still break but those 2 cases combined should be extremely rare. I'm not using C#'s `default literal` in nested expressions because there is potential for ambiguity.

According to the source code comment the order of `HandleDefaultParamValuePass` can't be changed. If there is a better way let me know but regardless it can always be implemented at a later time.
