### PR TITLE
Add support for C++ character literals (u, U, L)

### DIFF
--- a/tests/CSharp/CSharp.cpp
+++ b/tests/CSharp/CSharp.cpp
@@ -638,7 +638,7 @@ void MethodsWithDefaultValues::defaultValueType(QGenericArgument valueType)
 {
 }
 
-void MethodsWithDefaultValues::defaultChar(char c)
+void MethodsWithDefaultValues::defaultChar(char c, char uc, char Uc, char Lc)
 {
 }
 

--- a/tests/CSharp/CSharp.h
+++ b/tests/CSharp/CSharp.h
@@ -433,7 +433,7 @@ public:
     void defaultVoidStar(void* ptr = 0);
     void defaultFunctionPointer(void(*functionPtr)(int p) = nullptr);
     void defaultValueType(QGenericArgument valueType = QGenericArgument());
-    void defaultChar(char c = 'a');
+    void defaultChar(char c = 'a', char uc = u'u', char Uc = U'U', char Lc = L'L');
     void defaultEmptyChar(char c = 0);
     void defaultEmptyEnum(Empty e = Empty(-1));
     void defaultRefTypeBeforeOthers(Foo foo = Foo(), int i = 5, Bar::Items item = Bar::Item2);


### PR DESCRIPTION
There is no reason why it also shouldn't work for the 'u8' character literal but it requires C++17 and

* Changing the `LanguageVersion` to C++17 for the test projects breaks 2 tests (`defaultNonEmptyCtor` and `defaultNonEmptyCtorWithNullPtr`)
* I wasn't sure if I was allowed to change it anyways
