### PR TITLE
Fix string marshalling bug and move hard to read code to CppSharp.Runtime

### DIFF
--- a/src/Runtime/MarshalUtil.cs
+++ b/src/Runtime/MarshalUtil.cs
@@ -1,0 +1,34 @@
+﻿using System;
+using System.Text;
+
+namespace CppSharp.Runtime
+{
+    public unsafe static class MarshalUtil
+    {
+        public static string GetString(Encoding encoding, IntPtr str)
+        {
+            if (str == IntPtr.Zero)
+                return null;
+
+            int byteCount = 0;
+
+            if (encoding == Encoding.UTF32)
+            {
+                var str32 = (int*)str;
+                while (*(str32++) != 0) byteCount += sizeof(int);
+            }
+            else if (encoding == Encoding.Unicode || encoding == Encoding.BigEndianUnicode)
+            {
+                var str16 = (short*)str;
+                while (*(str16++) != 0) byteCount += sizeof(short);
+            }
+            else
+            {
+                var str8 = (byte*)str;
+                while (*(str8++) != 0) byteCount += sizeof(byte);
+            }
+
+            return encoding.GetString((byte*)str, byteCount);
+        }
+    }
+}


### PR DESCRIPTION
// DEBUG: DLL_API const wchar_t* TestCSharpStringWide(const wchar_t* in, CS_OUT const wchar_t** out)

Before

```.cs
public static string TestCSharpStringWide(string @in, out string @out)
{
    var __arg1 = global::System.IntPtr.Zero;
    var __ret = __Internal.TestCSharpStringWide(@in, &__arg1);
    if (__arg1 == global::System.IntPtr.Zero)
    {
        @out = default(string);
        return default; // Bug: completely ignoring __ret
    }
    var __retPtr1 = (short*) __arg1;
    int __length1 = 0;
    while (*(__retPtr1++) != 0) __length1 += sizeof(short);
    @out = global::System.Text.Encoding.Unicode.GetString((byte*) __arg1, __length1);
    if (__ret == global::System.IntPtr.Zero)
        return default(string);
    var __retPtr0 = (short*) __ret;
    int __length0 = 0;
    while (*(__retPtr0++) != 0) __length0 += sizeof(short);
    return global::System.Text.Encoding.Unicode.GetString((byte*) __ret, __length0);
}
```

After

```.cs
		
public static string TestCSharpStringWide(string @in, out string @out)
{
    var __arg1 = global::System.IntPtr.Zero;
    var __ret = __Internal.TestCSharpStringWide(@in, &__arg1);
    @out = CppSharp.Runtime.MarshalUtil.GetString(global::System.Text.Encoding.Unicode, __arg1);
    return CppSharp.Runtime.MarshalUtil.GetString(global::System.Text.Encoding.Unicode, __ret);
}
```