### PR TITLE
Fix IntPtr array marshalling bug and move hard to read code to CppSharp.Runtime

### DIFF
--- a/build/Helpers.lua
+++ b/build/Helpers.lua
@@ -165,7 +165,7 @@ end
 function SetupManagedProject()
   language "C#"
   location ("%{wks.location}/projects")
-  buildoptions {"/langversion:7.2"}
+  buildoptions {"/langversion:7.3"}
   buildoptions {"/platform:".._OPTIONS["arch"]}
 
   dotnetframework "4.7.2"

--- a/src/Runtime/MarshalUtil.cs
+++ b/src/Runtime/MarshalUtil.cs
@@ -30,5 +30,30 @@ namespace CppSharp.Runtime
 
             return encoding.GetString((byte*)str, byteCount);
         }
+
+        public static T[] GetArray<T>(void* array, int size) where T : unmanaged
+        {
+            if (array == null)
+                return null;
+            var result = new T[size];
+            fixed (void* fixedResult = result)
+                Buffer.MemoryCopy(array, fixedResult, sizeof(T) * size, sizeof(T) * size);
+            return result;
+        }
+
+        public static char[] GetCharArray(sbyte* array, int size)
+        {
+            if (array == null)
+                return null;
+            var result = new char[size];
+            for (var i = 0; i < size; ++i)
+                result[i] = Convert.ToChar(array[i]);
+            return result;
+        }
+
+        public static IntPtr[] GetIntPtrArray(IntPtr* array, int size)
+        {
+            return GetArray<IntPtr>(array, size);
+        }
     }
 }

--- a/tests/CSharp/CSharp.Tests.cs
+++ b/tests/CSharp/CSharp.Tests.cs
@@ -748,6 +748,7 @@ public unsafe class CSharpTests : GeneratorTestFixture
         Assert.That(StaticVariables.IntArray, Is.EqualTo(new[] { 1020304050 , 1526374850 }));
         Assert.That(StaticVariables.FloatArray, Is.EqualTo(new[] { 0.5020f, 0.6020f }));
         Assert.That(StaticVariables.BoolArray, Is.EqualTo(new[] { false, true }));
+        Assert.That(StaticVariables.VoidPtrArray, Is.EqualTo(new IntPtr[] { new IntPtr(0x10203040), new IntPtr(0x40302010) }));
     }
 
     [Test]

--- a/tests/CSharp/CSharp.cpp
+++ b/tests/CSharp/CSharp.cpp
@@ -1414,6 +1414,7 @@ const char StaticVariables::ChrArray[2] { 'A', 'B' };
 const int StaticVariables::IntArray[2] { 1020304050, 1526374850 };
 const float StaticVariables::FloatArray[2] { 0.5020f, 0.6020f };
 const bool StaticVariables::BoolArray[2] { false, true };
+const void* StaticVariables::VoidPtrArray[2] { (void*)0x10203040, (void*)0x40302010 };
 
 TestString::TestString() : unicodeConst(L"ქართული ენა"), unicode(0)
 {

--- a/tests/CSharp/CSharp.h
+++ b/tests/CSharp/CSharp.h
@@ -1117,6 +1117,7 @@ public:
     static const int IntArray[2];
     static const float FloatArray[2];
     static const bool BoolArray[2];
+    static const void* VoidPtrArray[2];
 };
 
 static constexpr double ConstexprCreateDoubleValue(double value) {


### PR DESCRIPTION
Before & After:

```.cs

public static global::System.IntPtr[] VoidPtrArray
{
    get
    {
        var __ptr = (global::System.IntPtr*)CppSharp.SymbolResolver.ResolveSymbol("CSharp.Native.dll", "?VoidPtrArray@StaticVariables@@2PAPEBXA");
        global::System.IntPtr[] __value = null;
        if (__ptr != null)
        {
            __value = new global::System.IntPtr[2];
            for (int i = 0; i < 2; i++)
                __value[i] = new global::System.IntPtr(__ptr[i]); // Bug: cannot convert from System.IntPtr to int
        }
        return __value;
    }
}
		
public static global::System.IntPtr[] VoidPtrArray
{
    get
    {
        var __ptr = (global::System.IntPtr*)CppSharp.SymbolResolver.ResolveSymbol("CSharp.Native.dll", "?VoidPtrArray@StaticVariables@@2PAPEBXA");
        return CppSharp.Runtime.MarshalUtil.GetIntPtrArray(__ptr, 2);
    }
}
```