### PR TITLE
Load symbols at startup to avoid very expensive ResolveSymbol calls everywhere

### DIFF
--- a/src/Generator/Generators/CSharp/CSharpSources.cs
+++ b/src/Generator/Generators/CSharp/CSharpSources.cs
@@ -3335,7 +3335,7 @@ namespace CppSharp.Generators.CSharp
             }
         }
 
-        class LibrarySymbolInfo
+        class LibrarySymbolInfo : TextGenerator
         {
             private static readonly Regex identifierCleanerRegex = new Regex(@"[^\w]", RegexOptions.Compiled);
             private Dictionary<string, string> symbols = new Dictionary<string, string>();
@@ -3354,47 +3354,46 @@ namespace CppSharp.Generators.CSharp
 
             public string Generate()
             {
-                var output = new TextGenerator();
-                output.WriteLine($"namespace {@namespace}");
+                WriteLine($"namespace {@namespace}");
                 {
-                    output.WriteOpenBraceAndIndent();
-                    output.WriteLine($"internal class {@class}");
+                    WriteOpenBraceAndIndent();
+                    WriteLine($"internal class {@class}");
                     {
-                        output.WriteOpenBraceAndIndent();
-                        GenerateStaticVariables(output);
-                        output.WriteLine($"static {@class}()");
+                        WriteOpenBraceAndIndent();
+                        GenerateStaticVariables();
+                        WriteLine($"static {@class}()");
                         {
-                            output.WriteOpenBraceAndIndent();
-                            GenerateStaticConstructorBody(output);
-                            output.UnindentAndWriteCloseBrace();
+                            WriteOpenBraceAndIndent();
+                            GenerateStaticConstructorBody();
+                            UnindentAndWriteCloseBrace();
                         }
-                        output.UnindentAndWriteCloseBrace();
+                        UnindentAndWriteCloseBrace();
                     }
-                    output.UnindentAndWriteCloseBrace();
+                    UnindentAndWriteCloseBrace();
                 }
-                return output.ToString();
+                return ToString();
             }
 
-            public void GenerateStaticVariables(TextGenerator output)
+            public void GenerateStaticVariables()
             {
                 foreach (var symbol in symbols)
                 {
                     var variableIdentifier = symbol.Value;
-                    output.WriteLine($"public static IntPtr {variableIdentifier} {{ get; }}");
+                    WriteLine($"public static IntPtr {variableIdentifier} {{ get; }}");
                 }
             }
 
-            public void GenerateStaticConstructorBody(TextGenerator output)
+            public void GenerateStaticConstructorBody()
             {
-                output.WriteLine($"var path = \"{path}\";");
-                output.WriteLine("var image = CppSharp.SymbolResolver.LoadImage(ref path);");
-                output.WriteLine("if (image == IntPtr.Zero) throw new System.DllNotFoundException(path);");
+                WriteLine($"var path = \"{path}\";");
+                WriteLine("var image = CppSharp.SymbolResolver.LoadImage(ref path);");
+                WriteLine("if (image == IntPtr.Zero) throw new System.DllNotFoundException(path);");
 
                 foreach (var symbol in symbols)
                 {
                     var mangled = symbol.Key;
                     var variableIdentifier = symbol.Value;
-                    output.WriteLine($"{variableIdentifier} = CppSharp.SymbolResolver.ResolveSymbol(image, \"{mangled}\");");
+                    WriteLine($"{variableIdentifier} = CppSharp.SymbolResolver.ResolveSymbol(image, \"{mangled}\");");
                 }
             }
 


### PR DESCRIPTION
```.cs


public static byte UChr
{
    get
    {	
	// Performance killer: ResolveSymbol calls GetCurrentDirectory / File.Exists / LoadLibrary / GetProcAddress
        var __ptr = (byte*)CppSharp.SymbolResolver.ResolveSymbol(image, "?UChr@StaticVariables@@2EB");
        return *__ptr;
    }
}

public static byte UChr
{
    get
    {
        // Now its as simple as accessing a pointer from a static variable that doesn't change
        var __ptr = (byte*)global::CSharp.__Symbols.CSharp_Native_dll._UChr_StaticVariables__2EB; 
        return *__ptr;  
    }
}

```