### PR TITLE
Remove unsupported calling convention usage

### DIFF
--- a/tests/CSharp/CSharp.Tests.cs
+++ b/tests/CSharp/CSharp.Tests.cs
@@ -164,7 +164,7 @@ public unsafe class CSharpTests : GeneratorTestFixture
     {
         using (var f = new Foo())
         {
-            foreach(var pod in new[] { f.SmallPodCdecl, f.SmallPodStdcall, f.SmallPodFastcall, f.SmallPodThiscall, f.SmallPodVectorcall })
+            foreach(var pod in new[] { f.SmallPodCdecl, f.SmallPodStdcall, f.SmallPodThiscall })
             {
                 Assert.That(pod.A, Is.EqualTo(10000));
                 Assert.That(pod.B, Is.EqualTo(40000));

--- a/tests/CSharp/CSharp.cpp
+++ b/tests/CSharp/CSharp.cpp
@@ -110,9 +110,9 @@ int Foo::getGetPropertyCall()
     return 1;
 }
 
-SmallPOD CDECL Foo::getSmallPod_cdecl() { return { 10000, 40000 }; }
-SmallPOD STDCALL Foo::getSmallPod_stdcall() { return { 10000, 40000 }; }
-SmallPOD THISCALL Foo::getSmallPod_thiscall() { return { 10000, 40000 }; }
+SmallPOD Foo::getSmallPod_cdecl() { return { 10000, 40000 }; }
+SmallPOD Foo::getSmallPod_stdcall() { return { 10000, 40000 }; }
+SmallPOD Foo::getSmallPod_thiscall() { return { 10000, 40000 }; }
 
 int Foo::operator ++()
 {

--- a/tests/CSharp/CSharp.cpp
+++ b/tests/CSharp/CSharp.cpp
@@ -110,6 +110,10 @@ int Foo::getGetPropertyCall()
     return 1;
 }
 
+SmallPOD CDECL Foo::getSmallPod_cdecl() { return { 10000, 40000 }; }
+SmallPOD STDCALL Foo::getSmallPod_stdcall() { return { 10000, 40000 }; }
+SmallPOD THISCALL Foo::getSmallPod_thiscall() { return { 10000, 40000 }; }
+
 int Foo::operator ++()
 {
     return 5;

--- a/tests/CSharp/CSharp.h
+++ b/tests/CSharp/CSharp.h
@@ -46,9 +46,9 @@ public:
     static int propertyCall();
     static int getGetPropertyCall();
 
-    SmallPOD CDECL getSmallPod_cdecl() { return { 10000, 40000 }; }
-    SmallPOD STDCALL getSmallPod_stdcall() { return { 10000, 40000 }; }
-    SmallPOD THISCALL getSmallPod_thiscall() { return { 10000, 40000 }; }
+    SmallPOD CDECL getSmallPod_cdecl();
+    SmallPOD STDCALL getSmallPod_stdcall();
+    SmallPOD THISCALL getSmallPod_thiscall();
 
     int operator ++();
     int operator --();

--- a/tests/CSharp/CSharp.h
+++ b/tests/CSharp/CSharp.h
@@ -48,9 +48,7 @@ public:
 
     SmallPOD CDECL getSmallPod_cdecl() { return { 10000, 40000 }; }
     SmallPOD STDCALL getSmallPod_stdcall() { return { 10000, 40000 }; }
-    SmallPOD FASTCALL getSmallPod_fastcall() { return { 10000, 40000 }; }
     SmallPOD THISCALL getSmallPod_thiscall() { return { 10000, 40000 }; }
-    SmallPOD VECTORCALL getSmallPod_vectorcall() { return { 10000, 40000 }; }
 
     int operator ++();
     int operator --();

--- a/tests/Tests.h
+++ b/tests/Tests.h
@@ -40,8 +40,6 @@
 #define THISCALL
 #endif
 
-#define 
-
 #endif
 
 #define CS_OUT

--- a/tests/Tests.h
+++ b/tests/Tests.h
@@ -16,16 +16,8 @@
 #define CDECL __cdecl
 #endif
 
-#ifndef FASTCALL
-#define FASTCALL __fastcall
-#endif
-
 #ifndef THISCALL
 #define THISCALL __thiscall
-#endif
-
-#ifndef VECTORCALL
-#define VECTORCALL __vectorcall
 #endif
 
 #else
@@ -44,16 +36,8 @@
 #define CDECL __attribute__((cdecl))
 #endif
 
-#ifndef FASTCALL
-#define FASTCALL
-#endif
-
 #ifndef THISCALL
 #define THISCALL
-#endif
-
-#ifndef VECTORCALL
-#define VECTORCALL
 #endif
 
 #define 


### PR DESCRIPTION
> System.TypeLoadException : Invalid unmanaged calling convention: must be one of stdcall, cdecl, or thiscall.
