### PR TITLE
Prevent string destructor from being called twice when its passed by value

### DIFF
--- a/src/Generator/Types/Std/Stdlib.cs
+++ b/src/Generator/Types/Std/Stdlib.cs
@@ -366,9 +366,8 @@ namespace CppSharp.Types.Std
                 ctx.Before.WriteLine($@"{qualifiedBasicString}Extensions.{
                     assign.Name}({varBasicString}, {ctx.Parameter.Name});");
                 ctx.Return.Write($"{varBasicString}.{Helpers.InstanceIdentifier}");
-                if (!type.IsPointer() || ctx.Parameter.IsIndirect)
-                    ctx.Cleanup.WriteLine($@"{varBasicString}.Dispose({
-                        (ctx.MarshalKind == MarshalKind.NativeField ? "false" : string.Empty)});");
+                ctx.Cleanup.WriteLine($@"{varBasicString}.Dispose({
+                    (!Type.IsAddress() || ctx.Parameter?.IsIndirect == true ? "false" : string.Empty)});");
             }
         }
 

--- a/tests/Common/Common.Tests.cs
+++ b/tests/Common/Common.Tests.cs
@@ -937,12 +937,6 @@ This is a very long string. This is a very long string. This is a very long stri
     [Test]
     public void TestStdStringPassedByValue()
     {
-        if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows) && !Environment.Is64BitProcess)
-        {
-            Assert.Ignore(); // TODO: Remove me once issue #1441 is fixed.
-            return;
-        }
-
         // when C++ memory is deleted, it's only marked as free but not immediadely freed
         // this can hide memory bugs while marshalling
         // so let's use a long string to increase the chance of a crash right away


### PR DESCRIPTION
Fixes #1441 but not completely till #1449 is resolved.