### PR TITLE
Create projects which always build generated code

### DIFF
--- a/build/Tests.lua
+++ b/build/Tests.lua
@@ -1,5 +1,34 @@
 -- Tests/examples helpers
 
+require('vstudio')
+	  
+function disableFastUpToDateCheck(prj, cfg)
+  premake.vstudio.vc2010.element("DisableFastUpToDateCheck", nil, "true")
+end
+  
+premake.override(premake.vstudio.cs2005.elements, "projectProperties",
+  function(oldfn, prj)
+    local elements = oldfn(prj)
+    if (string.endswith(prj.filename, ".CSharp") and
+    	not string.endswith(prj.filename, ".Tests.CSharp") and
+    	not string.endswith(prj.filename, ".Parser.CSharp")) then 
+      elements = table.join(elements, {disableFastUpToDateCheck})
+    end
+    return elements
+  end)
+  
+premake.override(premake.vstudio.vc2010.elements, "globals",
+  function(oldfn, prj, cfg)
+    local elements = oldfn(prj, cfg)
+    if (string.endswith(prj.filename, ".CLI") and
+    	not string.endswith(prj.filename, ".Tests.CLI") and
+    	not string.endswith(prj.filename, ".Parser.CLI") and
+    	prj.filename ~= "CppSharp.CLI") then 
+      elements = table.join(elements, {disableFastUpToDateCheck})
+    end
+    return elements
+  end)
+
 function SetupExampleProject()
   kind "ConsoleApp"
   language "C#"  


### PR DESCRIPTION
This ensures local test runs are always reliable because every time the solution is built the generated code is updated.