### PR TITLE
Always use the mangled names as reported by Clang

### DIFF
--- a/src/AST/SymbolContext.cs
+++ b/src/AST/SymbolContext.cs
@@ -92,48 +92,11 @@ namespace CppSharp.AST
             }
         }
 
-        public bool FindSymbol(ref string symbol)
-        {
-            if (FindLibraryBySymbol(symbol, out _))
-                return true;
-
-            string alternativeSymbol;
-
-            // Check for C symbols with a leading underscore.
-            alternativeSymbol = "_" + symbol;
-            if (FindLibraryBySymbol(alternativeSymbol, out _))
-            {
-                symbol = alternativeSymbol;
-                return true;
-            }
-
-            alternativeSymbol = symbol.TrimStart('_');
-            if (FindLibraryBySymbol(alternativeSymbol, out _))
-            {
-                symbol = alternativeSymbol;
-                return true;
-            }
-
-            alternativeSymbol = "_imp_" + symbol;
-            if (FindLibraryBySymbol(alternativeSymbol, out _))
-            {
-                symbol = alternativeSymbol;
-                return true;
-            }
-
-            alternativeSymbol = "__imp_" + symbol;
-            if (FindLibraryBySymbol("__imp_" + symbol, out _))
-            {
-                symbol = alternativeSymbol;
-                return true;
-            }
-
-            return false;
-        }
-
-        public bool FindLibraryBySymbol(string symbol, out NativeLibrary library)
-        {
-            return Symbols.TryGetValue(symbol, out library);
-        }
+        public bool FindLibraryBySymbol(string symbol, out NativeLibrary library) =>
+            Symbols.TryGetValue(symbol, out library) ||
+            Symbols.TryGetValue("_" + symbol, out library) ||
+            Symbols.TryGetValue(symbol.TrimStart('_'), out library) ||
+            Symbols.TryGetValue("_imp_" + symbol, out library) ||
+            Symbols.TryGetValue("__imp_" + symbol, out library);
     }
 }

--- a/src/Generator/Generators/CSharp/CSharpSources.cs
+++ b/src/Generator/Generators/CSharp/CSharpSources.cs
@@ -3395,12 +3395,6 @@ internal static{(@new ? " new" : string.Empty)} {printedClass} __GetInstance({Ty
             NativeLibrary library;
             Context.Symbols.FindLibraryBySymbol(((IMangledDecl) declaration).Mangled, out library);
 
-            var targetTriple = Context.ParserOptions.TargetTriple;
-            if (library == null && targetTriple.IsMacOS())
-                // the symbol name passed to dlsym() must NOT be prepended with an underscore
-                // https://developer.apple.com/library/archive/documentation/System/Conceptual/ManPages_iPhoneOS/man3/dlsym.3.html
-                Context.Symbols.FindLibraryBySymbol('_' + ((IMangledDecl) declaration).Mangled, out library);
-
             if (library != null)
                 libName = Path.GetFileNameWithoutExtension(library.FileName);
 
@@ -3411,6 +3405,7 @@ internal static{(@new ? " new" : string.Empty)} {printedClass} __GetInstance({Ty
             if (libName == null)
                 libName = declaration.TranslationUnit.Module.SharedLibraryName;
 
+            var targetTriple = Context.ParserOptions.TargetTriple;
             if (Options.GenerateInternalImports)
                 libName = "__Internal";
             else if (targetTriple.IsWindows() &&

--- a/src/Generator/Passes/FindSymbolsPass.cs
+++ b/src/Generator/Passes/FindSymbolsPass.cs
@@ -93,15 +93,11 @@ namespace CppSharp.Passes
 
         private bool VisitMangledDeclaration(IMangledDecl mangledDecl)
         {
-            var symbol = mangledDecl.Mangled;
-
-            if (!Context.Symbols.FindSymbol(ref symbol))
+            if (!Context.Symbols.FindLibraryBySymbol(mangledDecl.Mangled, out _))
             {
-                Diagnostics.Warning("Symbol not found: {0}", symbol);
+                Diagnostics.Warning("Symbol not found: {0}", mangledDecl.Mangled);
                 return false;
             }
-
-            mangledDecl.Mangled = symbol;
             return true;
         }
 

--- a/src/Generator/Passes/GenerateSymbolsPass.cs
+++ b/src/Generator/Passes/GenerateSymbolsPass.cs
@@ -114,7 +114,6 @@ namespace CppSharp.Passes
 
         private bool NeedsSymbol(Function function)
         {
-            var mangled = function.Mangled;
             var method = function as Method;
             bool isInImplicitSpecialization;
             var declarationContext = function.Namespace;
@@ -136,7 +135,7 @@ namespace CppSharp.Passes
                  (!method.IsConstructor || !((Class) method.Namespace).IsAbstract))) &&
                 // we cannot handle nested anonymous types
                 (!(function.Namespace is Class) || !string.IsNullOrEmpty(function.Namespace.OriginalName)) &&
-                !Context.Symbols.FindSymbol(ref mangled);
+                !Context.Symbols.FindLibraryBySymbol(function.Mangled, out _);
         }
 
         private SymbolsCodeGenerator GetSymbolsCodeGenerator(Module module)


### PR DESCRIPTION
The names in the binaries themselves are sometimes different than those Clang reports. However, it seems that the reported ones are the actually correct for invocation. For example, the name passed to dlsym() (for variables) must not be prepended with an underscore (/ https://developer.apple.com/library/archive/documentation/System/Conceptual/ManPages_iPhoneOS/man3/dlsym.3.html). Another example, again on macOS, is with extern C functions which sometimes also receive an _ at the front.