### PR TITLE
Use pull_request_target to fix permission issue when running nunit-reporter step

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,6 +1,6 @@
 name: CI
 
-on: [push, pull_request]
+on: [push, pull_request_target]
 
 jobs:
   posix:


### PR DESCRIPTION
https://github.blog/2020-08-03-github-actions-improvements-for-fork-and-pull-request-workflows/

> In order to solve this, we’ve added a new pull_request_target event, which behaves in an almost identical way to the pull_request event with the same set of filters and payload. However, instead of running against the workflow and code from the merge commit, the event runs against the workflow and code from the base of the pull request. This means the workflow is running from a trusted source and is given access to a read/write token as well as secrets enabling the maintainer to safely comment on or label a pull request.