### PR TITLE
Disable the msvc warning about unexported template specializations

### DIFF
--- a/tests/CLI/CLI.h
+++ b/tests/CLI/CLI.h
@@ -68,9 +68,7 @@ public:
     TestMappedTypeNonConstRefParam(const std::string);
     const TestMappedTypeNonConstRefParam& operator=(const std::string);
 
-    DISABLE_WARNING_ONCE(4251,
-        std::string m_str;
-    )
+    std::string m_str;
 };
 
 class DLL_API TestMappedTypeNonConstRefParamConsumer

--- a/tests/CSharp/CSharp.h
+++ b/tests/CSharp/CSharp.h
@@ -60,10 +60,7 @@ public:
 protected:
     int P;
     TemplateInAnotherUnit<int> templateInAnotherUnit;
-
-    DISABLE_WARNING_ONCE(4251,
-        std::string _name;
-    )
+    std::string _name;
 };
 
 class DLL_API Quux
@@ -1124,16 +1121,13 @@ public:
     static const char Chr;
     static const unsigned char UChr;
     static const int Int;
-    static const float Float;   
+    static const float Float;
+    static const std::string String;
     static const char ChrArray[2];
     static const int IntArray[2];
     static const float FloatArray[2];
     static const bool BoolArray[2];
     static const void* VoidPtrArray[2];
-
-    DISABLE_WARNING_ONCE(4251,
-        static const std::string String;
-    )
 };
 
 static constexpr double ConstexprCreateDoubleValue(double value) {

--- a/tests/CSharp/CSharpTemplates.h
+++ b/tests/CSharp/CSharpTemplates.h
@@ -33,7 +33,7 @@ class DLL_API Ignored
 };
 
 template <typename T>
-class DLL_API IndependentFields : public T1
+class IndependentFields : public T1
 {
     typedef T Type;
 public:
@@ -45,7 +45,7 @@ public:
     IndependentFields(float f);
     ~IndependentFields();
     explicit IndependentFields(const std::map<T, T> &other);
-    int getIndependent();
+    float getIndependent();
     T getDependent(const T& t);
     Type property();
     static T staticDependent(const T& t);
@@ -120,9 +120,9 @@ T IndependentFields<T>::staticDependent(const T& t)
 }
 
 template <typename T>
-int IndependentFields<T>::getIndependent()
+float IndependentFields<T>::getIndependent()
 {
-    return static_cast<int>(independent);
+    return independent;
 }
 
 template <typename X>
@@ -143,7 +143,7 @@ class Base
 };
 
 template <typename T>
-class DLL_API DependentValueFields : public Base<T>
+class DependentValueFields : public Base<T>
 {
 public:
     class Nested;
@@ -248,7 +248,7 @@ public:
 };
 
 template <typename T>
-class DLL_API DependentPointerFields
+class DependentPointerFields
 {
 public:
     DependentPointerFields(T t = 0);
@@ -318,7 +318,7 @@ void TwoTemplateArgs<K, V>::takeDependentPtrToSecondTemplateArg(const V& v)
 }
 
 template <typename T, typename D = IndependentFields<T>>
-class DLL_API HasDefaultTemplateArgument
+class HasDefaultTemplateArgument
 {
 public:
     HasDefaultTemplateArgument();
@@ -688,7 +688,7 @@ enum class UsedInTemplatedIndexer
 };
 
 template <typename T>
-class DLL_API QFlags
+class QFlags
 {
     typedef int Int;
     typedef int (*Zero);

--- a/tests/Common/Common.h
+++ b/tests/Common/Common.h
@@ -808,12 +808,9 @@ public:
     HasStdString();
     ~HasStdString();
     std::string testStdString(const std::string& s);
-    std::string testStdStringPassedByValue(std::string s);    
+    std::string testStdStringPassedByValue(std::string s);
+    std::string s;
     std::string& getStdString();
-
-    DISABLE_WARNING_ONCE(4251,
-        std::string s;
-    )
 };
 
 class DLL_API InternalCtorAmbiguity

--- a/tests/Encodings/Encodings.h
+++ b/tests/Encodings/Encodings.h
@@ -4,14 +4,11 @@
 class DLL_API Foo
 {
 public:
-    DISABLE_WARNING_ONCE(4251,
-        static std::string StringVariable;
-    )
-
     Foo();
     ~Foo();
 
     const char* Unicode;
+    static std::string StringVariable;
 
 	// TODO: VC++ does not support char16
 	// char16 chr16;    

--- a/tests/StandardLib/StandardLib.h
+++ b/tests/StandardLib/StandardLib.h
@@ -20,20 +20,18 @@ struct DLL_API TestVectors
     std::vector<int> GetIntVector();
     int SumIntVector(std::vector<int>& vec);
     
-    DISABLE_WARNING_ONCE(4251,
-        // Should get mapped to List<int>
-        std::vector<int> IntVector;
-        // Should get mapped to List<IntPtr>
-        std::vector<int*> IntPtrVector;
-        // Should get mapped to List<IntWrapper>
-        std::vector<IntWrapper> IntWrapperVector;
-        // Should get mapped to List<IntWrapper>
-        std::vector<IntWrapper*> IntWrapperPtrVector;
-        // Should get mapped to List<IntWrapperValueType>
-        std::vector<IntWrapperValueType> IntWrapperValueTypeVector;
-        // Should get mapped to List<IntWrapperValueType>
-        VectorTypedef IntWrapperValueTypeVectorTypedef;
-    )
+    // Should get mapped to List<int>
+    std::vector<int> IntVector;
+    // Should get mapped to List<IntPtr>
+    std::vector<int*> IntPtrVector;
+    // Should get mapped to List<IntWrapper>
+    std::vector<IntWrapper> IntWrapperVector;
+    // Should get mapped to List<IntWrapper>
+    std::vector<IntWrapper*> IntWrapperPtrVector;
+    // Should get mapped to List<IntWrapperValueType>
+    std::vector<IntWrapperValueType> IntWrapperValueTypeVector;
+    // Should get mapped to List<IntWrapperValueType>
+    VectorTypedef IntWrapperValueTypeVectorTypedef;
 };
 
 struct DLL_API OStreamTest

--- a/tests/Tests.h
+++ b/tests/Tests.h
@@ -20,11 +20,9 @@
 #define THISCALL __thiscall
 #endif
 
-#define DISABLE_WARNING_ONCE(id, block) \
-__pragma(warning(push)) \
-__pragma(warning(disable: id)) \
-block \
-__pragma(warning(pop))
+// HACK: work around https://developercommunity.visualstudio.com/content/problem/1269158/c4251-shown-for-any-not-explicitly-exported-templa.html
+// harmless and requires exporting all template specializations
+#pragma warning (disable : 4251 )
 
 #else
 #define DLL_API __attribute__ ((visibility ("default")))
@@ -45,8 +43,6 @@ __pragma(warning(pop))
 #ifndef THISCALL
 #define THISCALL
 #endif
-
-#define DISABLE_WARNING_ONCE(id, block) block
 
 #endif
 

--- a/tests/VTables/VTables.h
+++ b/tests/VTables/VTables.h
@@ -17,10 +17,7 @@ public:
     virtual int append();
     virtual int append(int a);
     int callVirtualWithParameter(int a);
-
-    DISABLE_WARNING_ONCE(4251,
-        std::string s;
-    )
+    std::string s;
 };
 
 DLL_API int FooCallFoo(Foo* foo);


### PR DESCRIPTION
The warning is essentially a bug in msvc because it's harmless and requires exporting all accessible template specializations. See also http://www.unknownroad.com/rtfm/VisualStudio/warningC4251.html.