### PR TITLE
Ensure a tested specialization is really generated

### DIFF
--- a/src/Generator.Tests/GeneratorTest.cs
+++ b/src/Generator.Tests/GeneratorTest.cs
@@ -40,7 +40,6 @@ namespace CppSharp.Utils
 
             var path = Path.GetFullPath(GetTestsDirectory(name));
             testModule.IncludeDirs.Add(path);
-            testModule.Defines.Add("DLL_EXPORT");
 
             Diagnostics.Message("Looking for tests in: {0}", path);
             var files = Directory.EnumerateFiles(path, "*.h");

--- a/tests/CSharp/CSharpTemplates.cpp
+++ b/tests/CSharp/CSharpTemplates.cpp
@@ -130,8 +130,11 @@ void TemplateSpecializer::completeSpecializationInParameter(TwoTemplateArgs<int 
                                                             TwoTemplateArgs<int *, int> p2,
                                                             TwoTemplateArgs<int *, float> p3,
                                                             TwoTemplateArgs<const char *, int> p4,
-                                                            TwoTemplateArgs<QString, int> p5,
-                                                            TwoTemplateArgs<const char *, int>::iterator p6,
+                                                            TwoTemplateArgs<QString, int> p5)
+{
+}
+
+void TemplateSpecializer::completeSpecializationInParameter(TwoTemplateArgs<const char *, int>::iterator p6,
                                                             TwoTemplateArgs<QString, int>::iterator p7)
 {
 }

--- a/tests/CSharp/CSharpTemplates.h
+++ b/tests/CSharp/CSharpTemplates.h
@@ -580,8 +580,8 @@ public:
                                            TwoTemplateArgs<int*, int> p2,
                                            TwoTemplateArgs<int*, float> p3,
                                            TwoTemplateArgs<const char*, int> p4,
-                                           TwoTemplateArgs<QString, int> p5,
-                                           TwoTemplateArgs<const char*, int>::iterator p6,
+                                           TwoTemplateArgs<QString, int> p5);
+    void completeSpecializationInParameter(TwoTemplateArgs<const char*, int>::iterator p6,
                                            TwoTemplateArgs<QString, int>::iterator p7);
     VirtualTemplate<void> returnSpecializedWithVoid();
 private:


### PR DESCRIPTION
The only function to use the specialization in question is actually ignored because the types of two of its parameters aren't supported. This was hidden by an otherwise redundant definition of a C++ symbol which is now removed.