### PR TITLE
Remove win x86 from the NuGet for smaller size

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -48,7 +48,7 @@
     <DotNetCmd></DotNetCmd>
   </PropertyGroup>
 
-  <Target Name="prepack" DependsOnTargets="Build" Condition="'$(IsPackable)' == 'true'">
+  <Target Name="prepack" DependsOnTargets="Build" Condition="'$(IsPackable)' == 'true' AND '$(Platform)' == 'x64'">
     <Copy SourceFiles="$(TargetDir)ref\$(TargetFileName)" DestinationFolder="$(PackageDir)ref\$(GlobalTargetFramework)" Condition="'$(ProduceReferenceAssembly)' == 'true' AND '$(RID)' == 'win-x64'" />
     <Copy SourceFiles="$(TargetPath)" DestinationFolder="$(PackageDir)runtimes\$(RID)\lib\$(GlobalTargetFramework)" />
   </Target>

--- a/src/Parser/CppSharp.Parser.csproj
+++ b/src/Parser/CppSharp.Parser.csproj
@@ -29,7 +29,7 @@
     <Copy SourceFiles="@(ClangHeaders)" DestinationFiles="@(ClangHeaders->'$(PackageDir)contentFiles\any\any\lib\%(RecursiveDir)%(Filename)%(Extension)')" />
   </Target>
 
-  <Target Name="PackNativeLibs" AfterTargets="prepack">
+  <Target Name="PackNativeLibs" AfterTargets="prepack" Condition="'$(Platform)' == 'x64'">
     <ItemGroup>
       <NativeLibs Include="$(OutputPath)$(NativeTargetPrefix)CppSharp.CppParser.$(NativeTargetExt)" />
       <NativeLibs Include="$(OutputPath)$(NativeTargetPrefix)Std-symbols.$(NativeTargetExt)" />


### PR DESCRIPTION
Too few people would use a win 32 host nowadays.