### PR TITLE
enable dotnet portable debug database in *.csproj

### DIFF
--- a/src/AST/CppSharp.AST.csproj
+++ b/src/AST/CppSharp.AST.csproj
@@ -5,4 +5,12 @@
     <ProduceReferenceAssembly>true</ProduceReferenceAssembly>
     <IsPackable>true</IsPackable>
   </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <DebugType>portable</DebugType>
+    <DebugSymbols>true</DebugSymbols>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <DebugType>portable</DebugType>
+    <DebugSymbols>true</DebugSymbols>
+  </PropertyGroup>
 </Project>

--- a/src/Core/CppSharp.csproj
+++ b/src/Core/CppSharp.csproj
@@ -4,6 +4,15 @@
     <PlatformTarget>AnyCPU</PlatformTarget>
     <ProduceReferenceAssembly>true</ProduceReferenceAssembly>
     <IsPackable>true</IsPackable>
+    <OutputType>Library</OutputType>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <DebugType>portable</DebugType>
+    <DebugSymbols>true</DebugSymbols>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <DebugType>portable</DebugType>
+    <DebugSymbols>true</DebugSymbols>
   </PropertyGroup>
   
   <ItemGroup>

--- a/src/Generator/CppSharp.Generator.csproj
+++ b/src/Generator/CppSharp.Generator.csproj
@@ -3,6 +3,14 @@
     <ProduceReferenceAssembly>true</ProduceReferenceAssembly>
     <IsPackable>true</IsPackable>
   </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <DebugType>portable</DebugType>
+    <DebugSymbols>true</DebugSymbols>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <DebugType>portable</DebugType>
+    <DebugSymbols>true</DebugSymbols>
+  </PropertyGroup>
   
   <ItemGroup>
     <EmbeddedResource Include="Passes\verbs.txt" />

--- a/src/Parser/CppSharp.Parser.csproj
+++ b/src/Parser/CppSharp.Parser.csproj
@@ -8,6 +8,14 @@
     <NativeTargetExt Condition="$(IsMacOSX)">dylib</NativeTargetExt>
     <NativeTargetPrefix Condition="!$(IsWindows)">lib</NativeTargetPrefix>
   </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <DebugType>portable</DebugType>
+    <DebugSymbols>true</DebugSymbols>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <DebugType>portable</DebugType>
+    <DebugSymbols>true</DebugSymbols>
+  </PropertyGroup>
   
   <ItemGroup Condition="$(GenerateBuildConfig)">
     <Compile Include="$(ActionDir)BuildConfig.cs" LinkBase="build" />

--- a/src/Runtime/CppSharp.Runtime.csproj
+++ b/src/Runtime/CppSharp.Runtime.csproj
@@ -7,4 +7,14 @@
     <ProduceReferenceAssembly>true</ProduceReferenceAssembly>
     <IsPackable>true</IsPackable>
   </PropertyGroup>
+
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <DebugType>portable</DebugType>
+    <DebugSymbols>true</DebugSymbols>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <DebugType>portable</DebugType>
+    <DebugSymbols>true</DebugSymbols>
+  </PropertyGroup>
+
 </Project>


### PR DESCRIPTION
by default visual studio will generate pdb files that can not be used in vscode to debug with dotnet core (tested dotnet 3.1).

This extract xml snippet can enable debug.  not sure if this work with monoDevelop. 