### PR TITLE
Fix build on Visual Studio 2019 16.10

### DIFF
--- a/src/Generator/Generators/CSharp/CSharpSources.cs
+++ b/src/Generator/Generators/CSharp/CSharpSources.cs
@@ -2689,6 +2689,14 @@ internal static{(@new ? " new" : string.Empty)} {printedClass} __GetInstance({Ty
                 {
                     GenerateVirtualFunctionCall(method);
                 }
+                else if (method.IsDestructor)
+                {
+                    // It is possible that HasNonTrivialDestructor property different for specialization vs.
+                    // the template. When we generate the Internal struct we only put a dtor there if the specialization
+                    // has a non-trivial dtor. So we must make sure do the same test here.
+                    if (@class.HasNonTrivialDestructor)
+                        GenerateInternalFunctionCall(method, returnType: returnType);
+                }
                 else
                 {
                     GenerateInternalFunctionCall(method, returnType: returnType);


### PR DESCRIPTION
The latest Visual Studio 2019 (version 16.10, aka 14.29.30037) slightly changes the `std::allocator` template which causes CppSharp to misbehave. In particular, it tries to generate a call to a function that does not exist.

Steps to repro:
1. Build CppSharp using VC 14.29.3003.
Result:
4 errors:
```
Severity	Code	Description	Project	File	Line	Suppression State
Error	CS0117	'__Internal' does not contain a definition for 'dtorc__N_std_S_allocator__C'	CSharp.CSharp	E:\git\CppSharp\build\gen\CSharp\Std.cs	2725	Active
Error	CS0117	'__Internal' does not contain a definition for 'dtorc__N_std_S_allocator__C'	Common.CSharp	E:\git\CppSharp\build\gen\Common\Std_GenerateName.cs	2724	Active
Error	CS0117	'__Internal' does not contain a definition for 'dtorc__N_std_S_allocator__C'	Encodings.CSharp	E:\git\CppSharp\build\gen\Encodings\Std.cs	2724	Active
Error	CS0117	'__Internal' does not contain a definition for 'dtorc__N_std_S_allocator__C'	VTables.CSharp	E:\git\CppSharp\build\gen\VTables\Std.cs	2724	Active
```
Expected: no errors

This PR patches the problem.