### PR TITLE
Add options.LibraryDirs to module in Generator.cs

### DIFF
--- a/src/CLI/Generator.cs
+++ b/src/CLI/Generator.cs
@@ -124,6 +124,7 @@ namespace CppSharp
             module.Headers.AddRange(options.HeaderFiles);
             module.Libraries.AddRange(options.Libraries);
             module.IncludeDirs.AddRange(options.IncludeDirs);
+            module.LibraryDirs.AddRange(options.LibraryDirs);
             module.OutputNamespace = options.OutputNamespace;
 
             if (abi == CppAbi.Microsoft)


### PR DESCRIPTION
In src/CLI/Generator.cs, the setup function doesn't add options.LibraryDirs to the module, and ClangParser cannot find input libraries.
https://github.com/mono/CppSharp/blob/b3d32d8c7109d8d64ef82e51b99c6068045ab93e/src/CLI/Generator.cs#L124-L127
I have tried passing full path to -l option but didn't work. According to this part, it looks like if the LibraryDirs is empty, then it will not process any library passed into it.
https://github.com/mono/CppSharp/blob/b3d32d8c7109d8d64ef82e51b99c6068045ab93e/src/CppParser/Parser.cpp#L4613-L4652