### PR TITLE
Use WeakReference<T> in NativeToManagedMap to allow finalizers to run.

### DIFF
--- a/src/Generator/Generators/C/CppHeaders.cs
+++ b/src/Generator/Generators/C/CppHeaders.cs
@@ -469,7 +469,7 @@ namespace CppSharp.Generators.Cpp
                 if (destructor != null)
                 {
                     GenerateClassDestructor(@class);
-                    if (Options.GenerateFinalizers)
+                    if (Options.GenerateFinalizerFor(@class))
                         GenerateClassFinalizer(@class);
                 }
             }

--- a/src/Generator/Generators/C/CppSources.cs
+++ b/src/Generator/Generators/C/CppSources.cs
@@ -173,7 +173,7 @@ namespace CppSharp.Generators.Cpp
                 {
                     GenerateClassDestructor(@class);
 
-                    if (Options.GenerateFinalizers)
+                    if (Options.GenerateFinalizerFor(@class))
                         GenerateClassFinalizer(@class);
                 }
             }

--- a/src/Generator/Generators/CLI/CLIHeaders.cs
+++ b/src/Generator/Generators/CLI/CLIHeaders.cs
@@ -400,7 +400,7 @@ namespace CppSharp.Generators.CLI
                 if (destructor != null)
                 {
                     GenerateClassDestructor(@class);
-                    if (Options.GenerateFinalizers)
+                    if (Options.GenerateFinalizerFor(@class))
                         GenerateClassFinalizer(@class);
                 }
             }

--- a/src/Generator/Generators/CLI/CLISources.cs
+++ b/src/Generator/Generators/CLI/CLISources.cs
@@ -193,7 +193,7 @@ namespace CppSharp.Generators.CLI
                 if (destructor != null)
                 {
                     GenerateClassDestructor(@class);
-                    if (Options.GenerateFinalizers)
+                    if (Options.GenerateFinalizerFor(@class))
                         GenerateClassFinalizer(@class);
                 }
             }

--- a/src/Generator/Generators/CodeGenerator.cs
+++ b/src/Generator/Generators/CodeGenerator.cs
@@ -1302,6 +1302,8 @@ namespace CppSharp.Generators
 
         public static readonly string CreateInstanceIdentifier = Generator.GeneratedIdentifier("CreateInstance");
         public static readonly string GetOrCreateInstanceIdentifier = Generator.GeneratedIdentifier("GetOrCreateInstance");
+        public static readonly string RecordNativeToManagedMappingIdentifier = Generator.GeneratedIdentifier("RecordNativeToManagedMapping");
+        public static readonly string TryGetNativeToManagedMappingIdentifier = Generator.GeneratedIdentifier("TryGetNativeToManagedMapping");
 
         public static string GetSuffixForInternal(Class @class)
         {

--- a/src/Generator/Options.cs
+++ b/src/Generator/Options.cs
@@ -114,10 +114,42 @@ namespace CppSharp
         public List<string> NoGenIncludeDirs;
 
         /// <summary>
-        /// Enable this option to enable generation of finalizers.
-        /// Works in both CLI and C# backends.
+        /// Enable this option to enable generation of finalizers. Works in both CLI and
+        /// C# backends. 
         /// </summary>
+        /// <remarks>
+        /// Use <see cref="GenerateFinalizersFilter"/> to specify a filter so that
+        /// finalizers are generated for only a subset of classes.
+        /// </remarks>
         public bool GenerateFinalizers;
+
+        /// <summary>
+        /// A filter that can restrict the classes for which finalizers are generated when
+        /// <see cref="GenerateFinalizers"/> is <c>true</c>. 
+        /// </summary>
+        /// <remarks>
+        /// The default filter performs no filtering so that whenever <see
+        /// cref="GenerateFinalizers"/> is <c>true</c>, finalizers will be generated for
+        /// all classes. If finalizers should be generated selectively, inspect the
+        /// supplied <see cref="Class"/> parameter and return <c>true</c> if a finalizer
+        /// should be generated and <c>false</c> if a finalizer should not be generated.
+        /// </remarks>
+        public Func<Class, bool> GenerateFinalizersFilter = (@class) => true;
+
+        /// <summary>
+        /// An internal convenience method that combines the effect of <see
+        /// cref="GenerateFinalizers"/> and <see cref="GenerateFinalizersFilter"/>.
+        /// </summary>
+        /// <param name="class">
+        /// The <see cref="Class"/> to be filtered by <see
+        /// cref="GenerateFinalizersFilter"/>.
+        /// </param>
+        /// <returns>
+        /// <c>true</c> if a finalizer should be generated for <paramref name="class"/>.
+        /// <c>false</c> if a finalizer should not be generated for <paramref
+        /// name="class"/>.
+        /// </returns>
+        internal bool GenerateFinalizerFor(Class @class) => GenerateFinalizers && GenerateFinalizersFilter(@class);
 
         /// <summary>
         /// If <see cref="ZeroAllocatedMemory"/> returns <c>true</c> for a given <see cref="Class"/>,

--- a/tests/CSharp/CSharp.CSharp.csproj
+++ b/tests/CSharp/CSharp.CSharp.csproj
@@ -1,1 +1,5 @@
-﻿<Project Sdk="Microsoft.NET.Sdk" />
+﻿<Project Sdk="Microsoft.NET.Sdk">
+  <ItemGroup>
+    <Compile Include="CSharpPartialMethods.cs" />
+  </ItemGroup>
+</Project>

--- a/tests/CSharp/CSharp.Gen.cs
+++ b/tests/CSharp/CSharp.Gen.cs
@@ -66,6 +66,10 @@ namespace CppSharp.Tests
                     Namespace = ctx.TranslationUnits.First(u => u.IsValid && !u.IsSystemHeader)
                 };
 
+            // Generate a finalizer for just the one test case.
+            driver.Options.GenerateFinalizers = true;
+            driver.Options.GenerateFinalizersFilter = (@class) => @class.Name == "TestFinalizer";
+
             // Preserve the original semantics except for our one test class.
             driver.Options.ZeroAllocatedMemory = (@class) => @class.Name == "ClassZeroAllocatedMemoryTest";
         }

--- a/tests/CSharp/CSharp.h
+++ b/tests/CSharp/CSharp.h
@@ -1131,6 +1131,11 @@ public:
     const char16_t* RetrieveString();
 };
 
+class DLL_API TestFinalizer
+{
+public:
+    const int Data[1024];
+};
 
 DLL_API void decltypeFunctionPointer();
 

--- a/tests/CSharp/CSharpPartialMethods.cs
+++ b/tests/CSharp/CSharpPartialMethods.cs
@@ -1,0 +1,16 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace CSharp
+{
+    public partial class TestFinalizer
+    {
+        public static Action<bool, IntPtr> DisposeCallback { get; set; }
+
+        partial void DisposePartial(bool disposing)
+        {
+            DisposeCallback?.Invoke(disposing, __Instance);
+        }
+    }
+}


### PR DESCRIPTION
#### Problem description

If you turn on the option `Options.GenerateFinalizers` when generating a C# binding, C# finalizer methods are (indeed) generated. The generator also (typically) generates code in C# constructors so that the mapping between native memory addresses and managed instances can be recovered by using the static concurrent dictionary, `NativeToManagedMap`. This mapping is removed from the dictionary if the class' `Dispose` method is called. However, if Dispose is not called, the static dictionary holds a dangling reference to the mapped instance, preventing it from ever being finalized and collected by the garbage collector. This typically results in a memory leak of both managed and unmanaged memory.

#### Proposed resolution

##### WeakReferences
- If  `Options.GenerateFinalizers` is set to `true`, this PR uses the class `System.WeakReference<T>` to wrap any reference normally held by  `NativeToManagedMap`. Consequently, as long as an instance is known via a "strong" reference in the client program, the instance can be recovered from `NativeToManagedMap` as expected. When there are no more strong references in the client program to an instance, the `WeakReference<T>` does not prevent the garbage collector from collecting the instance held by `NativeToManagedMap`. If/when the instance is collected, the garbage collector runs the instance's finalizer. The finalizer will in turn call the `Dispose(isDisposing:false)` overload which in turn removes the `WeakReference<T>` from `NativeToManagedMap` and frees any owned native memory.

- To simplify code generation - particularly in the context of multiple inheritance and template instantiations, this PR generates two accessor methods whenever it generates `NativeToManagedMap`. If we're generating finalizers, we generate the following (type prefixes omitted for readability):
  
    ```c#
    internal static readonly ConcurrentDictionary<
      IntPtr, WeakReference<TManaged>> NativeToManagedMap = 
        new ConcurrentDictionary<IntPtr, WeakReference<TManaged>>();
    
    internal static void __RecordNativeToManagedMapping(
             IntPtr native, TManaged managed)
    {
        NativeToManagedMap[native] = new 
                      WeakReference<TManaged>(managed);
    }
    
    internal static bool __TryGetNativeToManagedMapping(
             IntPtr native, out TManaged managed)
    {
        managed = default;
        return NativeToManagedMap.TryGetValue(native, out var wr) 
               && wr.TryGetTarget(out managed);
    }
    ```
    where `TManaged` is the actual (literal) managed type used (as before) when declaring `NativeToManagedMap`. 
    
    If we're not generating finalizers, these accessor methods are generated as you'd expect - without the use of `WeakReference<T>`:

    ```c#
    internal static readonly ConcurrentDictionary<
      IntPtr, TManaged> NativeToManagedMap = 
        new ConcurrentDictionary<IntPtr, TManaged>();
      
    internal static void __RecordNativeToManagedMapping(
             IntPtr native, TManaged)
    {
        NativeToManagedMap[native] = managed;
    }
    
    internal static bool __TryGetNativeToManagedMapping(
             IntPtr native, out TManaged managed)
    {
        return NativeToManagedMap.TryGetValue(native, out managed);
    }
    ```
    The two accessor methods replace direct manipulation of `NativeToManagedMap` wherever we used to set or get the mapping. 

##### GenerateFinalizersFilter

Particularly in the context of testing, I found it useful to be able to create finalizers for some but not all classes. Toward that end, this PR adds a filter and an internal method to `CppSharp.DriverOptions`:

```c#
public Func<Class, bool> GenerateFinalizersFilter = 
                         (@class) => true;
                         
internal bool GenerateFinalizerFor(Class @class) =>
         GenerateFinalizers && GenerateFinalizersFilter(@class);
```

The intent was to preserve backwards compatibility: setting `GenerateFinalizers` to `true` will enable finalizers for all classes unless you also set a custom filter via `GenerateFinalizersFilter`.

In this PR, the method `GenerateFinalizerFor` is evaluated during code generation instead of the simple bool `GenerateFinalizers` throughout code generation (both CLI and CSharp).

#### Test Cases

This PR includes two test cases in CSharp.Tests: `TestFinalizerGetsCalledWhenNotDisposed` and `TestFinalizerNotCalledWhenDisposed`. The tests take advantage of the new partial method support for Dispose by adding a partial class and partial method which allow the test to hook a callback when `DisposePartial(bool)` is called.

