### PR TITLE
Avoid ArgumentOutOfRangeException in ExpressionHelper.CheckForString

### DIFF
--- a/src/Generator/Passes/ExpressionHelper.cs
+++ b/src/Generator/Passes/ExpressionHelper.cs
@@ -427,8 +427,17 @@ namespace CppSharp.Internal
 
                 if (typeInSignature is CILType managed && managed.Type == typeof(string))
                 {
-                    result = result[result.IndexOf("\"")..];
-                    return true;
+                    // It is possible that "result" is not a string literal. See, for
+                    // example, the test case MoreVariablesWithInitializer in CSharp.h.
+                    // Test for presence of a quote first to avoid
+                    // ArgumentOutOfRangeException.
+                    var initialQuoteIndex = result.IndexOf("\"");
+                    if (initialQuoteIndex >= 0)
+                    { 
+                        result = result[initialQuoteIndex..];
+                        return true;
+                    }
+                    return false;
                 }
             }
             return false;

--- a/tests/CSharp/CSharp.Tests.cs
+++ b/tests/CSharp/CSharp.Tests.cs
@@ -935,6 +935,15 @@ public unsafe class CSharpTests
     }
 
     [Test]
+    public void TestIndirectVariableInitializer()
+    {
+        // The actual test is that the generator doesn't throw when generating
+        // IndependentStringVariable. If we're running the test, we must have
+        // generated CSharp.cs without crashing the generator.
+        Assert.That(MoreVariablesWithInitializer.DependentStringVariable, Is.EqualTo(MoreVariablesWithInitializer.IndependentStringVariable));
+    }
+
+    [Test]
     public void TestPointerPassedAsItsSecondaryBase()
     {
         using (QApplication application = new QApplication())

--- a/tests/CSharp/CSharp.h
+++ b/tests/CSharp/CSharp.h
@@ -1096,6 +1096,18 @@ public:
    static constexpr float FloatArray[2] { 0.5020f, 0.6020f };
 };
 
+// Try to precipitate an ArgumentOutOfRangeException in ExpressionHelper.CheckForString.
+//
+// Note that uncommenting DLL_API below results in different behavior in
+// ExpressionHelper.PrintExpression. In particular, ExpressionHelper.CheckForString is not
+// called and no ArgumentOutOfRangeException is generated.
+#define STRING_INITIALIZER "The quick brown fox"
+struct /*DLL_API*/ MoreVariablesWithInitializer
+{
+    static constexpr const char* IndependentStringVariable = STRING_INITIALIZER;
+    static constexpr const char* DependentStringVariable = IndependentStringVariable;
+};
+
 typedef void (*ALLCAPS_UNDERSCORES)(int i);
 
 class DLL_API TestString


### PR DESCRIPTION
#### Problem description

Consider the class:

``` c++
#define STRING_INITIALIZER "The quick brown fox"
struct /*DLL_API*/ MoreVariablesWithInitializer
{
    static constexpr const char* IndependentStringVariable = STRING_INITIALIZER;
    static constexpr const char* DependentStringVariable = IndependentStringVariable;
};
```

With `DLL_API` commented out on the class as above, when the variable `DependentStringVariable` is visited in `HandleVariableInitializerPass.VisitVariableDecl` we eventually call down to `ExpressionHelper.CheckForString` and at ExpressionHelper line 428 we execute: 

``` c#
if (typeInSignature is CILType managed && managed.Type == typeof(string))
{
    result = result[result.IndexOf("\"")..];
    return true;
}
```
At that point, `result` holds the (unquoted) string `IndependentStringVariable`. Consequently, `result.IndexOf("\"")` returns `-1` and the indexer throws an `ArgumentOutOfRangeException`.

If you uncomment `DLL_API`, `ExpressionHelper.CheckForString` is never called and generation proceeds as expected.

The difference between these two cases appears to be that in `ExpressionHelper.PrintExpression`, when we arrive at line 34 for variable `IndependentStringVariable`:

``` c#
if (expression.Declaration is Variable ||
    (!context.Options.MarshalCharAsManagedChar &&
    desugared.IsPrimitiveType(PrimitiveType.UChar)))
    return null;
```
In the `DLL_API` uncommented case, `expression.Declaration` above is a `Variable` so the method returns `null`. In the `DLL_API` commented-out case, `expression.Declaration` is `null`, so we drop through, eventually calling `ExpressionHelper.CheckForString` where we generate the `ArgumentOutOfRangeException` as described above.

Figuring out why `expression.Declaration` is `null` in one case but not in the other looked interesting, but above my pay grade. In any case, avoiding the `ArgumentOutOfRangeException` seems like a good thing no matter how we get there, so I changed the relevant portion of `CheckForString` to look like:

``` c#
if (typeInSignature is CILType managed && managed.Type == typeof(string))
{
    var initialQuoteIndex = result.IndexOf("\"");
    if (initialQuoteIndex >= 0)
    { 
        result = result[initialQuoteIndex..];
        return true;
    }
    return false;
}
```

This avoids the exception and the expected code is generated.

#### Test Case

The `MoreVariablesWithInitializer` appears in CSharp.h. The test case `TestIndirectVariableInitializer` simply verifies that `MoreVariablesWithInitializer` does, in fact, get generated.

