### PR TITLE
Do not rename property names in GetterSetterToPropertyPass

### DIFF
--- a/src/Generator/Passes/GetterSetterToPropertyPass.cs
+++ b/src/Generator/Passes/GetterSetterToPropertyPass.cs
@@ -299,14 +299,7 @@ namespace CppSharp.Passes
                 (string.Compare(name, firstWord, StringComparison.InvariantCultureIgnoreCase) != 0) &&
                 !char.IsNumber(name[3]))
             {
-                if (name.Length == 4)
-                {
-                    return char.ToLowerInvariant(
-                        name[3]).ToString(CultureInfo.InvariantCulture);
-                }
-                return char.ToLowerInvariant(
-                    name[3]).ToString(CultureInfo.InvariantCulture) +
-                                name.Substring(4);
+                return name.Substring(3);
             }
             return name;
         }
@@ -321,7 +314,6 @@ namespace CppSharp.Passes
                 return nameBuilder.ToString();
 
             nameBuilder.TrimUnderscores();
-            nameBuilder[0] = char.ToLowerInvariant(nameBuilder[0]);
             return nameBuilder.ToString();
         }
 


### PR DESCRIPTION
Currently, the GetterSetterToPropertyPass will lower-case a property name unconditionally, e.g. `int GetABCTest();` gets converted to `aBCTest`. The default RenamePass will uppercase the first letter again, and the property is correctly named `ABCTest`. 

We have added a custom RenamePass to our project that expects to work on the original name of properties, e.g. `ABCTest` from the example above, so we can differentiate properties that start with a lower or uppercase letter.

This PR _should_ not change any behavior for people using the default RenamePass setup. We tested the change on our codebase with the custom RenamePass disabled and this change does not seem to make a difference.

Maybe there are other ways to test if this does not break anything apart from the tests?