### PR TITLE
Call destructor on copied arguments when calling C# method from C++ (MS ABIs only)

### DIFF
--- a/src/Generator/Generators/CSharp/CSharpSources.cs
+++ b/src/Generator/Generators/CSharp/CSharpSources.cs
@@ -1934,7 +1934,7 @@ internal static bool {Helpers.TryGetNativeToManagedMappingIdentifier}(IntPtr nat
             }
             WriteLine(";");
 
-            // on Microsoft ABIs, the destructor on copy-by-value parameters are
+            // on Microsoft ABIs, the destructor on copy-by-value parameters is
             // called by the called function, not the caller, so we are generating
             // code to do that for classes that have a non-trivial destructor.
             if (Context.ParserOptions.IsMicrosoftAbi)
@@ -1954,13 +1954,7 @@ internal static bool {Helpers.TryGetNativeToManagedMappingIdentifier}(IntPtr nat
                         paramType.TryGetClass(out Class paramClass) && !(paramClass is ClassTemplateSpecialization) &&
                         paramClass.HasNonTrivialDestructor)
                     {
-                        Method dtor = paramClass.Destructors.FirstOrDefault();
-                        if (dtor != null)
-                        {
-                            // todo: virtual destructors?
-                            var nativeClass = TypePrinter.PrintNative(paramClass);
-                            WriteLine($"{nativeClass}.dtor({param.Name});");
-                        }
+                        WriteLine($"{Generator.GeneratedIdentifier("result")}{i}.Dispose(false, true);");
                     }
                 }
             }

--- a/src/Generator/Generators/CodeGenerator.cs
+++ b/src/Generator/Generators/CodeGenerator.cs
@@ -1292,7 +1292,7 @@ namespace CppSharp.Generators
         public static readonly string InstanceField = Generator.GeneratedIdentifier("instance");
         public static readonly string InstanceIdentifier = Generator.GeneratedIdentifier("Instance");
         public static readonly string PrimaryBaseOffsetIdentifier = Generator.GeneratedIdentifier("PrimaryBaseOffset");
-        public static readonly string ReturnIdentifier = Generator.GeneratedIdentifier("ret");
+        public static readonly string ReturnIdentifier = "___ret";
         public static readonly string DummyIdentifier = Generator.GeneratedIdentifier("dummy");
         public static readonly string TargetIdentifier = Generator.GeneratedIdentifier("target");
         public static readonly string SlotIdentifier = Generator.GeneratedIdentifier("slot");

--- a/tests/CSharp/CSharp.Tests.cs
+++ b/tests/CSharp/CSharp.Tests.cs
@@ -1925,4 +1925,56 @@ public unsafe class CSharpTests
         Assert.That(myclass, Is.Not.SameAs(backup));
     }
 
+
+    class CallByValueInterfaceImpl : CallByValueInterface
+    {
+        public override void CallByValue(RuleOfThreeTester value)
+        {
+        }
+        public override void CallByReference(RuleOfThreeTester value)
+        {
+        }
+        public override void CallByPointer(RuleOfThreeTester value)
+        {
+        }
+    }
+
+    [Test]
+    public void TestCallByValueCppToCSharpValue()
+    {
+        RuleOfThreeTester.Reset();
+        CallByValueInterface @interface = new CallByValueInterfaceImpl();
+        CSharp.CSharp.CallCallByValueInterfaceValue(@interface);
+
+        Assert.That(RuleOfThreeTester.ConstructorCalls, Is.EqualTo(1));
+        Assert.That(RuleOfThreeTester.DestructorCalls, Is.EqualTo(2));
+        Assert.That(RuleOfThreeTester.CopyConstructorCalls, Is.EqualTo(1));
+        Assert.That(RuleOfThreeTester.CopyAssignmentCalls, Is.EqualTo(0));
+    }
+
+    [Test]
+    public void TestCallByValueCppToCSharpReference()
+    {
+        RuleOfThreeTester.Reset();
+        CallByValueInterface @interface = new CallByValueInterfaceImpl();
+        CSharp.CSharp.CallCallByValueInterfaceReference(@interface);
+
+        Assert.That(RuleOfThreeTester.ConstructorCalls, Is.EqualTo(1));
+        Assert.That(RuleOfThreeTester.DestructorCalls, Is.EqualTo(1));
+        Assert.That(RuleOfThreeTester.CopyConstructorCalls, Is.EqualTo(0));
+        Assert.That(RuleOfThreeTester.CopyAssignmentCalls, Is.EqualTo(0));
+    }
+
+    [Test]
+    public void TestCallByValueCppToCSharpPointer()
+    {
+        RuleOfThreeTester.Reset();
+        CallByValueInterface @interface = new CallByValueInterfaceImpl();
+        CSharp.CSharp.CallCallByValueInterfacePointer(@interface);
+
+        Assert.That(RuleOfThreeTester.ConstructorCalls, Is.EqualTo(1));
+        Assert.That(RuleOfThreeTester.DestructorCalls, Is.EqualTo(1));
+        Assert.That(RuleOfThreeTester.CopyConstructorCalls, Is.EqualTo(0));
+        Assert.That(RuleOfThreeTester.CopyAssignmentCalls, Is.EqualTo(0));
+    }
 }

--- a/tests/CSharp/CSharp.cpp
+++ b/tests/CSharp/CSharp.cpp
@@ -1691,3 +1691,59 @@ DLL_API int TestFunctionToInstanceMethodStruct(FTIStruct* bb, FTIStruct defaultV
 DLL_API int TestFunctionToInstanceMethodRefStruct(FTIStruct* bb, FTIStruct& defaultValue) { return defaultValue.a; }
 DLL_API int TestFunctionToInstanceMethodConstStruct(FTIStruct* bb, const FTIStruct defaultValue) { return defaultValue.a; }
 DLL_API int TestFunctionToInstanceMethodConstRefStruct(FTIStruct* bb, const FTIStruct& defaultValue) { return defaultValue.a; }
+
+int RuleOfThreeTester::constructorCalls = 0;
+int RuleOfThreeTester::destructorCalls = 0;
+int RuleOfThreeTester::copyConstructorCalls = 0;
+int RuleOfThreeTester::copyAssignmentCalls = 0;
+
+void RuleOfThreeTester::reset()
+{
+    constructorCalls = 0;
+    destructorCalls = 0;
+    copyConstructorCalls = 0;
+    copyAssignmentCalls = 0;
+}
+
+RuleOfThreeTester::RuleOfThreeTester()
+{
+    a = 0;
+    constructorCalls++;
+}
+
+RuleOfThreeTester::RuleOfThreeTester(const RuleOfThreeTester& other)
+{
+    a = other.a;
+    copyConstructorCalls++;
+}
+
+RuleOfThreeTester::~RuleOfThreeTester()
+{
+    destructorCalls++;
+}
+
+RuleOfThreeTester& RuleOfThreeTester::operator=(const RuleOfThreeTester& other)
+{
+    a = other.a;
+    copyAssignmentCalls++;
+    return *this;
+}
+
+// test if generated code correctly calls constructors and destructors when going from C++ to C#
+void CallCallByValueInterfaceValue(CallByValueInterface* interface)
+{
+    RuleOfThreeTester value;
+    interface->CallByValue(value);
+}
+
+void CallCallByValueInterfaceReference(CallByValueInterface* interface)
+{
+    RuleOfThreeTester value;
+    interface->CallByReference(value);
+}
+
+void CallCallByValueInterfacePointer(CallByValueInterface* interface)
+{
+    RuleOfThreeTester value;
+    interface->CallByPointer(&value);
+}

--- a/tests/CSharp/CSharp.h
+++ b/tests/CSharp/CSharp.h
@@ -1551,3 +1551,29 @@ DLL_API inline ClassWithIntValue* CreateCore(CS_IN_OUT ClassWithIntValue*& pClas
     pClass->value = 20;
     return nullptr;
 }
+
+
+struct DLL_API RuleOfThreeTester {
+    int a;
+    static int constructorCalls;
+    static int destructorCalls;
+    static int copyConstructorCalls;
+    static int copyAssignmentCalls;
+
+    static void reset();
+
+    RuleOfThreeTester();
+    ~RuleOfThreeTester();
+    RuleOfThreeTester(const RuleOfThreeTester& other);
+    RuleOfThreeTester& operator=(const RuleOfThreeTester& other);
+};
+
+struct DLL_API CallByValueInterface {
+    virtual void CallByValue(RuleOfThreeTester value) = 0;
+    virtual void CallByReference(RuleOfThreeTester& value) = 0;
+    virtual void CallByPointer(RuleOfThreeTester* value) = 0;
+};
+
+void DLL_API CallCallByValueInterfaceValue(CallByValueInterface*);
+void DLL_API CallCallByValueInterfaceReference(CallByValueInterface*);
+void DLL_API CallCallByValueInterfacePointer(CallByValueInterface*);


### PR DESCRIPTION
On Microsoft ABIs, the destructor on copy-by-value parameters is called by the called function, not the caller, so we should be generating code to do that for classes that have a non-trivial destructor.

That at least is my interpretation of why we got memory leaks because destructors were not called.
I hope I got the Microsoft ABI bit right and this is only needed there, CI will tell us hopefully.

See tests for example code.