### PR TITLE
Fix disabling NativeToManaged map for classes with vtable

### DIFF
--- a/src/Generator/Generators/CSharp/CSharpSources.cs
+++ b/src/Generator/Generators/CSharp/CSharpSources.cs
@@ -2399,22 +2399,16 @@ internal static{(@new ? " new" : string.Empty)} {printedClass} __GetOrCreateInst
                         NewLine();
                     }
 
-                    if (HasVirtualTables(@class))
+                    // __GetInstance doesn't work without a ManagedToNativeMap, so don't generate it
+                    if (HasVirtualTables(@class) && generateNativeToManaged)
                     {
                         @new = @class.HasBase && HasVirtualTables(@class.Bases.First().Class);
 
                         WriteLines($@"
 internal static{(@new ? " new" : string.Empty)} {printedClass} __GetInstance({TypePrinter.IntPtrType} native)
-{{");
-
-                        if (generateNativeToManaged)
-                        {
-                            WriteLines($@"
+{{
     if (!{Helpers.TryGetNativeToManagedMappingIdentifier}(native, out var managed))
-        throw new global::System.Exception(""No managed instance was found"");");
-                        }
-
-                        WriteLines($@"
+        throw new global::System.Exception(""No managed instance was found"");
     var result = ({printedClass})managed;
     if (result.{Helpers.OwnsNativeInstanceIdentifier})
         result.SetupVTables();


### PR DESCRIPTION
This is an ugly change to make it work, but it's not perfect.

Changes:
* Do not generate `__GetInstance` method, doesn't work without a NativeToManaged map
* Do not generate much of the vtable interop call code, because that one doesn't work without `__GetInstance`
* Throw an exception if people try to inherit from a class with disabled NativeToManaged class (see explanation in code)

Two things I don't like, but don't really have time right now to properly fix:
* We should seal the class instead of throwing an exception in the constructor, but it seems like this would require lots of changes
* We should just get rid of all calls to SetupVTable() instead of gutting the method, but again, requires lots of work

Hint: View pull request with whitespace ignored, it's mostly just indention changes