### PR TITLE
Write pragma to disable new keyword not required warnings

### DIFF
--- a/src/Generator/Generators/CSharp/CSharpSources.cs
+++ b/src/Generator/Generators/CSharp/CSharpSources.cs
@@ -84,6 +84,9 @@ namespace CppSharp.Generators.CSharp
 
             GenerateUsings();
 
+            WriteLine("#pragma warning disable CS0109 // Member does not hide an inherited member; new keyword is not required");
+            NewLine();
+
             if (!string.IsNullOrEmpty(Module.OutputNamespace))
             {
                 PushBlock(BlockKind.Namespace);


### PR DESCRIPTION
This warning is coming from the changed code around the ManagedToNative map.
It's a lazy solution, but it's a solution.

No problem if you don't want to merge this, but the warning is very annoying in Unity, so we will keep it in our branch.