### PR TITLE
__CreateInstance: return C# null when native is null

### DIFF
--- a/src/Generator/Generators/CSharp/CSharpSources.cs
+++ b/src/Generator/Generators/CSharp/CSharpSources.cs
@@ -2384,6 +2384,13 @@ internal static bool {Helpers.TryGetNativeToManagedMappingIdentifier}(IntPtr nat
                     @class.NeedsBase && !@class.BaseClass.IsInterface ? "new " : string.Empty,
                     printedClass, Helpers.CreateInstanceIdentifier, TypePrinter.IntPtrType);
                 WriteOpenBraceAndIndent();
+
+                if (@class.IsRefType)
+                {
+                    WriteLine($"if (native == {TypePrinter.IntPtrType}.Zero)");
+                    WriteLineIndent("return null;");
+                }
+
                 var suffix = @class.IsAbstract ? "Internal" : string.Empty;
                 var ctorCall = $"{printedClass.Type}{suffix}{printedClass.NameSuffix}";
                 WriteLine("return new {0}(native.ToPointer(), skipVTables);", ctorCall);


### PR DESCRIPTION
We already have a null check in `__GetOrCreateInstance`, which is used in almost all cases. `__CreateInstance` is used more often when NativeToManaged map is deactivated, so this is the reason why this did not show up as a problem before.