### PR TITLE
Use copy assignment operator when setting struct fields that have a copy assignment operator

### DIFF
--- a/src/Generator/AST/Utils.cs
+++ b/src/Generator/AST/Utils.cs
@@ -36,9 +36,6 @@ namespace CppSharp.AST
             if (method.IsDestructor)
                 return true;
 
-            if (method.OperatorKind == CXXOperatorKind.Equal)
-                return true;
-
             if (method.Access == AccessSpecifier.Private && !method.IsOverride && !method.IsExplicitlyGenerated)
                 return true;
 

--- a/src/Generator/AST/Utils.cs
+++ b/src/Generator/AST/Utils.cs
@@ -39,6 +39,10 @@ namespace CppSharp.AST
             if (method.Access == AccessSpecifier.Private && !method.IsOverride && !method.IsExplicitlyGenerated)
                 return true;
 
+            // operator= does not make sense on static classes, but might be generated anyway, so ignore here
+            if (method.OperatorKind == CXXOperatorKind.Equal && @class != null && @class.IsStatic)
+                return true;
+
             // Ignore copy constructor if a base class don't has or has a private copy constructor
             if (method.IsCopyConstructor)
             {

--- a/src/Generator/Generators/CSharp/CSharpSources.cs
+++ b/src/Generator/Generators/CSharp/CSharpSources.cs
@@ -1014,7 +1014,7 @@ internal static bool {Helpers.TryGetNativeToManagedMappingIdentifier}(IntPtr nat
                 if (field.Type.TryGetClass(out Class fieldClass) && !(fieldClass is ClassTemplateSpecialization))
                 {
                     var caop = fieldClass.Methods.FirstOrDefault(m => m.OperatorKind == CXXOperatorKind.Equal);
-                    if (caop != null)
+                    if (caop != null && caop.IsGenerated)
                     {
                         var fieldName = ((Class)field.Namespace).Layout.Fields.First(
                             f => f.FieldPtr == field.OriginalPtr).Name;
@@ -1026,7 +1026,6 @@ internal static bool {Helpers.TryGetNativeToManagedMappingIdentifier}(IntPtr nat
                             typeName.RemoveNamespace();
 
                         WriteLine($"{fieldClass}.__Internal.OperatorEqual(dest, src);");
-                        //UnindentAndWriteCloseBrace();
 
                         return;
                     }

--- a/src/Generator/Generators/CSharp/CSharpSources.cs
+++ b/src/Generator/Generators/CSharp/CSharpSources.cs
@@ -1011,7 +1011,7 @@ internal static bool {Helpers.TryGetNativeToManagedMappingIdentifier}(IntPtr nat
         {
             if (field.Type.IsClass() && !field.Type.IsPointer())
             {
-                if (field.Type.TryGetClass(out Class fieldClass))
+                if (field.Type.TryGetClass(out Class fieldClass) && !(fieldClass is ClassTemplateSpecialization))
                 {
                     var caop = fieldClass.Methods.FirstOrDefault(m => m.OperatorKind == CXXOperatorKind.Equal);
                     if (caop != null)

--- a/src/Generator/Generators/CSharp/CSharpSources.cs
+++ b/src/Generator/Generators/CSharp/CSharpSources.cs
@@ -1018,10 +1018,10 @@ internal static bool {Helpers.TryGetNativeToManagedMappingIdentifier}(IntPtr nat
                     {
                         var fieldName = ((Class)field.Namespace).Layout.Fields.First(
                             f => f.FieldPtr == field.OriginalPtr).Name;
-                        WriteLine($"var dest = new __IntPtr(&((__Internal*)__Instance)->{fieldName});");
+                        var typeName = TypePrinter.PrintNative(@class);
+                        WriteLine($"var dest = new __IntPtr(&(({typeName}*)__Instance)->{fieldName});");
                         WriteLine($"var src = value.{Helpers.InstanceIdentifier};");
 
-                        var typeName = TypePrinter.PrintNative(fieldClass);
                         if (IsInternalClassNested(fieldClass))
                             typeName.RemoveNamespace();
 

--- a/src/Generator/Passes/ValidateOperatorsPass.cs
+++ b/src/Generator/Passes/ValidateOperatorsPass.cs
@@ -55,6 +55,9 @@ namespace CppSharp.Passes
                 // The conversion operators can be overloaded
                 case CXXOperatorKind.Conversion:
                 case CXXOperatorKind.ExplicitConversion:
+
+                // Copy assignment operator is used internally
+                case CXXOperatorKind.Equal:
                     return true;
 
                 // The comparison operators can be overloaded if their return type is bool
@@ -127,7 +130,6 @@ namespace CppSharp.Passes
                 case CXXOperatorKind.PipePipe:
 
                 // These operators cannot be overloaded.
-                case CXXOperatorKind.Equal:
                 case CXXOperatorKind.Comma:
                 case CXXOperatorKind.ArrowStar:
                 case CXXOperatorKind.Arrow:


### PR DESCRIPTION
I thought there were tests for this, but they seem to be missing. Will take a look on Monday if I can find them.