### PR TITLE
Workaround parsing GNU system headers with GCC 11.0 version.

### DIFF
--- a/src/Parser/ParserOptions.cs
+++ b/src/Parser/ParserOptions.cs
@@ -240,9 +240,11 @@ namespace CppSharp.Parser
             GetUnixCompilerInfo(headersPath, out var compiler, out var longVersion, out var shortVersion);
 
             AddSystemIncludeDirs(BuiltinsDir);
-            AddArguments($"-fgnuc-version={longVersion}");
 
             var majorVersion = shortVersion.Split('.')[0];
+            // Workaround https://github.com/llvm/llvm-project/issues/53152, remove once bug is fixed.
+            AddArguments(int.Parse(majorVersion) >= 11 ? $"-fgnuc-version=10.1" : $"-fgnuc-version={longVersion}");
+
             string[] versions = { longVersion, shortVersion, majorVersion };
             string[] triples = { "x86_64-linux-gnu", "x86_64-pc-linux-gnu" };
             if (compiler == "gcc")


### PR DESCRIPTION
Closes https://github.com/mono/CppSharp/issues/1703.
