### PR TITLE
CSharpExpressionPrinter: Recurse into operands

### DIFF
--- a/src/Generator/Generators/CSharp/CSharpExpressionPrinter.cs
+++ b/src/Generator/Generators/CSharp/CSharpExpressionPrinter.cs
@@ -61,13 +61,8 @@ namespace CppSharp.Generators.CSharp
                 case StatementClass.BinaryOperator:
                     var binaryOperator = (BinaryOperatorObsolete)expr;
 
-                    var lhsResult = binaryOperator.LHS.String;
-                    if (binaryOperator.LHS.Declaration is Enumeration.Item)
-                        lhsResult = binaryOperator.LHS.Declaration.Visit(typePrinter).Type;
-
-                    var rhsResult = binaryOperator.RHS.String;
-                    if (binaryOperator.RHS.Declaration is Enumeration.Item)
-                        rhsResult = binaryOperator.RHS.Declaration.Visit(typePrinter).Type;
+                    var lhsResult = VisitExpression(binaryOperator.LHS);
+                    var rhsResult = VisitExpression(binaryOperator.RHS);
 
                     return $"{lhsResult} {binaryOperator.OpcodeStr} {rhsResult}";
                 case StatementClass.ConstructorReference:

--- a/tests/dotnet/Common/Common.cpp
+++ b/tests/dotnet/Common/Common.cpp
@@ -1278,3 +1278,7 @@ extern "C"
 void DLL_API FunctionWithFlagsAsDefaultParameter(int defaultParam)
 {
 }
+
+void DLL_API FunctionWithConstFlagsAsDefaultParameter(int defaultParam)
+{
+}

--- a/tests/dotnet/Common/Common.h
+++ b/tests/dotnet/Common/Common.h
@@ -1569,3 +1569,9 @@ extern "C"
 } // extern "C"
 
 void DLL_API FunctionWithFlagsAsDefaultParameter(int defaultParam = A | B);
+
+const int ConstFlag1 = 1;
+const int ConstFlag2 = 2;
+const int ConstFlag3 = 4;
+
+void DLL_API FunctionWithConstFlagsAsDefaultParameter(int defaultParam = ConstFlag1 | ConstFlag2 | ConstFlag3);


### PR DESCRIPTION
Recursively call `VisitExpression` on the LHS and RHS of a binary operator expression. This fixes the generation for complex default parameters involving things other than two enumeration members.