### PR TITLE
SymbolResolver: Use filename when path cannot be found

### DIFF
--- a/src/Runtime/SymbolResolver.cs
+++ b/src/Runtime/SymbolResolver.cs
@@ -1,5 +1,5 @@
 /* Copyright (c) 2013 Xamarin, Inc and contributors
- * 
+ *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the
  * "Software"), to deal in the Software without restriction, including
@@ -7,10 +7,10 @@
  * distribute, sublicense, and/or sell copies of the Software, and to
   * permit persons to whom the Software is furnished to do so, subject to
  * the following conditions:
- * 
+ *
  * The above copyright notice and this permission notice shall be
  * included in all copies or substantial portions of the Software.
- * 
+ *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
  * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
  * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
@@ -80,8 +80,8 @@ namespace CppSharp
                         break;
                     }
                 }
-                if (!File.Exists(attempted))
-                    continue;
+                if (attempted == null)
+                    attempted = filename;
 
                 var ptr = loadImage(attempted);
 


### PR DESCRIPTION
Uses bare filename to pass to `dlopen` when the full path cannot be detected. This helps on systems where library paths are not the same as $PATH.