### PR TITLE
CSharpSources: Dereference pointer variables

### DIFF
--- a/src/Generator/Generators/CSharp/CSharpSources.cs
+++ b/src/Generator/Generators/CSharp/CSharpSources.cs
@@ -1285,6 +1285,17 @@ internal static bool {Helpers.TryGetNativeToManagedMappingIdentifier}(IntPtr nat
             };
             ctx.PushMarshalKind(MarshalKind.ReturnVariableArray);
 
+            if (var.Type.Desugar().IsPointer())
+            {
+                var pointerType = var.Type.Desugar() as PointerType;
+                while (pointerType != null && !pointerType.Pointee.Desugar().IsPrimitiveType(PrimitiveType.Char))
+                {
+                    ptr = $"*{ptr}";
+                    pointerType = pointerType.Pointee.Desugar() as PointerType;
+                }
+                ptr = $"(IntPtr*)({ptr})";
+            }
+
             var arrayType = var.Type.Desugar() as ArrayType;
             var isRefTypeArray = arrayType != null && var.Namespace is Class context && context.IsRefType;
             var elementType = arrayType?.Type.Desugar();

--- a/tests/dotnet/CSharp/CSharp.Tests.cs
+++ b/tests/dotnet/CSharp/CSharp.Tests.cs
@@ -1988,4 +1988,11 @@ public unsafe class CSharpTests
         Assert.That(RuleOfThreeTester.CopyConstructorCalls, Is.EqualTo(0));
         Assert.That(RuleOfThreeTester.CopyAssignmentCalls, Is.EqualTo(0));
     }
+
+    [Test]
+    public void TestPointerToClass()
+    {
+        Assert.IsTrue(CSharp.CSharp.PointerToClass.IsDefaultInstance);
+        Assert.IsTrue(CSharp.CSharp.PointerToClass.IsValid);
+    }
 }

--- a/tests/dotnet/CSharp/CSharp.cpp
+++ b/tests/dotnet/CSharp/CSharp.cpp
@@ -1772,3 +1772,22 @@ void CallCallByValueInterfacePointer(CallByValueInterface* interface)
     RuleOfThreeTester value;
     interface->CallByPointer(&value);
 }
+
+static PointerTester internalPointerTesterInstance;
+
+PointerTester::PointerTester()
+{
+    a = 0;
+}
+
+bool PointerTester::IsDefaultInstance()
+{
+    return this == &internalPointerTesterInstance;
+}
+
+bool PointerTester::IsValid()
+{
+    return a == 0;
+}
+
+PointerTester* PointerToClass = &internalPointerTesterInstance;

--- a/tests/dotnet/CSharp/CSharp.h
+++ b/tests/dotnet/CSharp/CSharp.h
@@ -1592,3 +1592,14 @@ struct DLL_API CallByValueInterface {
 void DLL_API CallCallByValueInterfaceValue(CallByValueInterface*);
 void DLL_API CallCallByValueInterfaceReference(CallByValueInterface*);
 void DLL_API CallCallByValueInterfacePointer(CallByValueInterface*);
+
+class DLL_API PointerTester
+{
+    int a;
+public:
+    PointerTester();
+    bool IsDefaultInstance();
+    bool IsValid();
+};
+
+DLL_API extern PointerTester* PointerToClass;


### PR DESCRIPTION
Dereference pointers when generating getters for pointer variables. Otherwise, the managed instance would point to the pointer itself rather than the native instance's address.