### PR TITLE
Fix crash on Linux by `DllImport`ing correct version of libdl

### DIFF
--- a/src/Runtime/SymbolResolver.cs
+++ b/src/Runtime/SymbolResolver.cs
@@ -118,10 +118,10 @@ namespace CppSharp
             return dlopen(path, RTLD_LAZY);
         }
 
-        [DllImport("dl", CharSet = CharSet.Ansi)]
+        [DllImport("dl.so.2", CharSet = CharSet.Ansi)]
         static extern IntPtr dlopen(string path, int flags);
 
-        [DllImport("dl", CharSet = CharSet.Ansi)]
+        [DllImport("dl.so.2", CharSet = CharSet.Ansi)]
         static extern IntPtr dlsym(IntPtr handle, string symbol);
 
         #endregion


### PR DESCRIPTION
CppSharp currently `DllImport`s the `dlopen` and `dlsym` functions from the library `"dl"`. This is incorrect however, as described in https://github.com/dotnet/runtime/issues/53291#issuecomment-853037480. Due to the way that `DllImport` searches for libraries, described [here](https://learn.microsoft.com/en-us/dotnet/standard/native-interop/native-library-loading), specifying the library name as just `"dl"` causes it to find `libdl.so`, which comes from the `libc6-dev` package, but not the correct version of the library, `libdl.so.2`. The reason this crashes is because `libc6-dev` is not guranteed to be installed everywhere, so on Linux installations where it isn't, such as mine, the `DllImport` fails and throws an exception.

This PR fixes the crash by naming the correct version of the library in the `DllImport`, which should always exist.