### PR TITLE
Fix Value Type Out Parameters

### DIFF
--- a/src/Generator/Generators/CSharp/CSharpMarshal.cs
+++ b/src/Generator/Generators/CSharp/CSharpMarshal.cs
@@ -634,17 +634,20 @@ namespace CppSharp.Generators.CSharp
             {
                 if (Context.Parameter.Usage == ParameterUsage.Out)
                 {
-                    var qualifiedIdentifier = (@class.OriginalClass ?? @class).Visit(typePrinter);
-                    Context.Before.WriteLine("var {0} = new {1}.{2}();",
-                        arg, qualifiedIdentifier, Helpers.InternalStruct);
+                    Context.Before.WriteLine("fixed ({0}.{1}* {2} = &{3}.{4})",
+                        Context.Parameter.QualifiedType, Helpers.InternalStruct,
+                        arg, Context.Parameter.Name, Helpers.InstanceIdentifier);
+                    Context.Before.WriteOpenBraceAndIndent();
+                    Context.Return.Write($"new {typePrinter.IntPtrType}({arg})");
+                    Context.Cleanup.UnindentAndWriteCloseBrace();
                 }
                 else
                 {
                     Context.Before.WriteLine("var {0} = {1}.{2};",
                         arg, Context.Parameter.Name, Helpers.InstanceIdentifier);
+                    Context.Return.Write($"new {typePrinter.IntPtrType}(&{arg})");
                 }
 
-                Context.Return.Write($"new {typePrinter.IntPtrType}(&{arg})");
                 return true;
             }
 

--- a/src/Generator/Generators/CSharp/CSharpSources.cs
+++ b/src/Generator/Generators/CSharp/CSharpSources.cs
@@ -413,7 +413,7 @@ namespace CppSharp.Generators.CSharp
                 if (@class.IsValueType)
                 {
                     WriteLine($"private {@class.Name}.{Helpers.InternalStruct} {Helpers.InstanceField};");
-                    WriteLine($"internal {@class.Name}.{Helpers.InternalStruct} {Helpers.InstanceIdentifier} => {Helpers.InstanceField};");
+                    WriteLine($"internal ref {@class.Name}.{Helpers.InternalStruct} {Helpers.InstanceIdentifier} => ref {Helpers.InstanceField};");
                 }
                 else
                 {

--- a/tests/dotnet/CSharp/CSharp.Tests.cs
+++ b/tests/dotnet/CSharp/CSharp.Tests.cs
@@ -1995,4 +1995,11 @@ public unsafe class CSharpTests
         Assert.IsTrue(CSharp.CSharp.PointerToClass.IsDefaultInstance);
         Assert.IsTrue(CSharp.CSharp.PointerToClass.IsValid);
     }
+
+    [Test]
+    public void TestValueTypeOutParameter()
+    {
+	    CSharp.CSharp.ValueTypeOutParameter(out var unionTest);
+	    Assert.AreEqual(2, unionTest.A);
+    }
 }

--- a/tests/dotnet/CSharp/CSharp.cpp
+++ b/tests/dotnet/CSharp/CSharp.cpp
@@ -1791,3 +1791,8 @@ bool PointerTester::IsValid()
 }
 
 PointerTester* PointerToClass = &internalPointerTesterInstance;
+
+void ValueTypeOutParameter(UnionTester* tester)
+{
+    tester->a = 2;
+}

--- a/tests/dotnet/CSharp/CSharp.h
+++ b/tests/dotnet/CSharp/CSharp.h
@@ -1603,3 +1603,10 @@ public:
 };
 
 DLL_API extern PointerTester* PointerToClass;
+
+union DLL_API UnionTester {
+    float a;
+    int b;
+};
+
+void DLL_API ValueTypeOutParameter(CS_OUT UnionTester* tester);


### PR DESCRIPTION
Currently, using value types as out parameters generates the following incorrect code:

Given
```c++
union MyCoolUnion
{
    int a;
    float b;
};

int DLL_API DoCoolThing(CS_OUT MyCoolUnion* myCoolUnion);
```
the following code is generated:
```cs
public static void DoCoolThing(out global::Test.MyCoolUnion myCoolUnion)
{
    myCoolUnion = new global::Test.MyCoolUnion();
    var ____arg0 = new global::Test.MyCoolUnion.__Internal();
    var __arg0 = new __IntPtr(&____arg0);
    __Internal.DoCoolThing(__arg0);
}
```

This does not use the out parameter's internal value, but a newly created one, leaving the out parameter unchanged.

Following this PR the following code is generated:
```cs
public static void DoCoolThing(out global::Test.MyCoolUnion myCoolUnion)
{
    myCoolUnion = new global::Test.MyCoolUnion();
    fixed (global::Test.MyCoolUnion.__Internal* ____arg0 = &myCoolUnion.__Instance)
    {
    var __arg0 = new __IntPtr(____arg0);
    testerB = new global::Test.MyCoolUnion();
    __Internal.DoCoolThing(__arg0);
    }
}
```

Considerations:
- [ ] The indentation is broken, the insides of the `fixed` statements are not being indented. I hope this is either 1. negligible or 2. easily fixable with greater understanding of the library.
- [ ] Instead of using `fixed` a local could be used and the result later copied into the out parameter. I assume this would be more expensive, as it'd require an extra copy of a potentially very large structure. (If this is a big concern, it should probably be benchmarked)
- [ ] The line `Context.Return.Write($"new {typePrinter.IntPtrType}(&{arg})");` is duplicated once, with only the `&` being omitted. I'm currently not seeing a clean solution, but there might be one.