### PR TITLE
Fix Package Packing

### DIFF
--- a/.github/workflows/llvm.yml
+++ b/.github/workflows/llvm.yml
@@ -22,7 +22,7 @@ jobs:
       ACTIONS_ALLOW_UNSECURE_COMMANDS: true
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: lukka/get-cmake@latest
 
       - name: Clone LLVM

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -24,7 +24,7 @@ jobs:
       DOTNET_CLI_TELEMETRY_OPTOUT: true
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
         with:
           fetch-depth: '0'
 
@@ -63,7 +63,7 @@ jobs:
         shell: bash
         run: build/build.sh prepack -platform $PLATFORM
 
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         with:
           name: intermediate
           path: |
@@ -82,7 +82,7 @@ jobs:
       DOTNET_CLI_TELEMETRY_OPTOUT: true
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
         with:
           fetch-depth: '0'
 
@@ -102,7 +102,7 @@ jobs:
         run: build/build.sh pack
 
       - name: Upload package
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: CppSharp.nupkg
           path: |

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -52,7 +52,7 @@
   </PropertyGroup>
 
   <Target Name="prepack" DependsOnTargets="Build" Condition="'$(IsPackable)' == 'true' AND '$(Platform)' == 'x64'">
-    <Copy SourceFiles="$(TargetDir)ref\$(TargetFileName)" DestinationFolder="$(PackageDir)ref\$(GlobalTargetFramework)" Condition="'$(ProduceReferenceAssembly)' == 'true' AND '$(RID)' == 'win-x64'" />
+    <Copy SourceFiles="$(TargetDir)$(TargetFileName)" DestinationFolder="$(PackageDir)ref\$(GlobalTargetFramework)" Condition="'$(ProduceReferenceAssembly)' == 'true' AND '$(RID)' == 'win-x64'" />
     <Copy SourceFiles="$(TargetPath)" DestinationFolder="$(PackageDir)runtimes\$(RID)\lib\$(GlobalTargetFramework)" />
   </Target>
 </Project>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -52,6 +52,7 @@
   </PropertyGroup>
 
   <Target Name="prepack" DependsOnTargets="Build" Condition="'$(IsPackable)' == 'true' AND '$(Platform)' == 'x64'">
+    <Copy SourceFiles="$(TargetDir)ref\$(TargetFileName)" DestinationFolder="$(PackageDir)ref\$(GlobalTargetFramework)" Condition="'$(ProduceReferenceAssembly)' == 'true' AND '$(RID)' == 'win-x64'" />
     <Copy SourceFiles="$(TargetPath)" DestinationFolder="$(PackageDir)runtimes\$(RID)\lib\$(GlobalTargetFramework)" />
   </Target>
 </Project>


### PR DESCRIPTION
Fixes #1773.

The `ref` folder is missing from the latest nuget package, leading to none of the DLLs being available.

[This change](https://github.com/mono/CppSharp/commit/0e1e46836d234bd59916586cf9090ceaf2b327d6#diff-9da24614831c308827a1ae533ffea392c97638c261dd42bd0f5226baa136d16eL55) stopped the dlls from being copied to the ref folder.

The following warning is also present in the previous build's logs [here](https://github.com/mono/CppSharp/actions/runs/6560441820/job/17818399543) under `Create package`:
```
C:\Program Files\dotnet\sdk\6.0.414\Sdks\NuGet.Build.Tasks.Pack\build\NuGet.Build.Tasks.Pack.targets(221,5): warning NU5128: Some target frameworks declared in the dependencies group of the nuspec and the lib/ref folder do not have exact matches in the other location. Consult the list of actions below: [D:\a\CppSharp\CppSharp\src\Package\CppSharp.Package.csproj]
C:\Program Files\dotnet\sdk\6.0.414\Sdks\NuGet.Build.Tasks.Pack\build\NuGet.Build.Tasks.Pack.targets(221,5): warning NU5128: - Add lib or ref assemblies for the net6.0 target framework [D:\a\CppSharp\CppSharp\src\Package\CppSharp.Package.csproj]
```
This warning is no longer present after this fix.

I've also taken the liberty of bumping the version number of a few GH actions in order to fix another CI warning seen [here](https://github.com/mono/CppSharp/actions/runs/6560441820).