### PR TITLE
Fix non-void returning functions with value-type out parameters

### DIFF
--- a/src/Generator/Generators/CSharp/CSharpMarshal.cs
+++ b/src/Generator/Generators/CSharp/CSharpMarshal.cs
@@ -637,9 +637,9 @@ namespace CppSharp.Generators.CSharp
                     Context.Before.WriteLine("fixed ({0}.{1}* {2} = &{3}.{4})",
                         Context.Parameter.QualifiedType, Helpers.InternalStruct,
                         arg, Context.Parameter.Name, Helpers.InstanceIdentifier);
+                    Context.HasCodeBlock = true;
                     Context.Before.WriteOpenBraceAndIndent();
                     Context.Return.Write($"new {typePrinter.IntPtrType}({arg})");
-                    Context.Cleanup.UnindentAndWriteCloseBrace();
                 }
                 else
                 {

--- a/tests/dotnet/CSharp/CSharp.Tests.cs
+++ b/tests/dotnet/CSharp/CSharp.Tests.cs
@@ -1999,7 +1999,7 @@ public unsafe class CSharpTests
     [Test]
     public void TestValueTypeOutParameter()
     {
-        CSharp.CSharp.ValueTypeOutParameter(out var unionTestA, out var unionTestB);
+        Assert.AreEqual(2, CSharp.CSharp.ValueTypeOutParameter(out var unionTestA, out var unionTestB));
         Assert.AreEqual(2, unionTestA.A);
         Assert.AreEqual(2, unionTestB.B);
     }

--- a/tests/dotnet/CSharp/CSharp.cpp
+++ b/tests/dotnet/CSharp/CSharp.cpp
@@ -1792,8 +1792,9 @@ bool PointerTester::IsValid()
 
 PointerTester* PointerToClass = &internalPointerTesterInstance;
 
-void ValueTypeOutParameter(UnionTester* testerA, UnionTester* testerB)
+int ValueTypeOutParameter(UnionTester* testerA, UnionTester* testerB)
 {
     testerA->a = 2;
     testerB->b = 2;
+    return 2;
 }

--- a/tests/dotnet/CSharp/CSharp.h
+++ b/tests/dotnet/CSharp/CSharp.h
@@ -1609,4 +1609,4 @@ union DLL_API UnionTester {
     int b;
 };
 
-void DLL_API ValueTypeOutParameter(CS_OUT UnionTester* testerA, CS_OUT UnionTester* testerB);
+int DLL_API ValueTypeOutParameter(CS_OUT UnionTester* testerA, CS_OUT UnionTester* testerB);


### PR DESCRIPTION
I'm really sorry for yet another PR, but I managed to miss this in the original PR that fixed value-type out parameters..

Previously the return was generated outside of the `fixed` scopes, while trying to use a variable declared within them.

On the bright side, this also fixes the indentation!