### PR TITLE
Introduce `GenerateFreeStandingFunctionsClassName` option

### DIFF
--- a/src/Generator/Generators/CLI/CLIHeaders.cs
+++ b/src/Generator/Generators/CLI/CLIHeaders.cs
@@ -219,7 +219,7 @@ namespace CppSharp.Generators.CLI
         {
             PushBlock(BlockKind.FunctionsClass, decl);
 
-            WriteLine("public ref class {0}", TranslationUnit.FileNameWithoutExtension);
+            WriteLine("public ref class {0}", Options.GenerateFreeStandingFunctionsClassName(TranslationUnit));
             WriteLine("{");
             WriteLine("public:");
             Indent();

--- a/src/Generator/Generators/CLI/CLISources.cs
+++ b/src/Generator/Generators/CLI/CLISources.cs
@@ -909,7 +909,7 @@ namespace CppSharp.Generators.CLI
             GenerateDeclarationCommon(function);
 
             var classSig = string.Format("{0}::{1}", QualifiedIdentifier(@namespace),
-                TranslationUnit.FileNameWithoutExtension);
+                Options.GenerateFreeStandingFunctionsClassName(TranslationUnit));
 
             Write("{0} {1}::{2}(", function.ReturnType, classSig,
                 function.Name);

--- a/src/Generator/Generators/CLI/CLITypePrinter.cs
+++ b/src/Generator/Generators/CLI/CLITypePrinter.cs
@@ -329,7 +329,7 @@ namespace CppSharp.Generators.CLI
             var result = string.Join("::", names);
             var translationUnit = decl.Namespace as TranslationUnit;
             if (translationUnit != null && translationUnit.HasFunctions &&
-                rootNamespace == translationUnit.FileNameWithoutExtension)
+                rootNamespace == Options.GenerateFreeStandingFunctionsClassName(translationUnit))
                 return "::" + result;
             return result;
         }

--- a/src/Generator/Generators/CSharp/CSharpSources.cs
+++ b/src/Generator/Generators/CSharp/CSharpSources.cs
@@ -250,8 +250,7 @@ namespace CppSharp.Generators.CSharp
             if (!context.Functions.Any(f => f.IsGenerated) && !hasGlobalVariables)
                 return;
 
-            var parentName = SafeIdentifier(Context.Options.GenerateFreeStandingFunctionsClassName?.Invoke(context.TranslationUnit)
-                                            ?? context.TranslationUnit.FileNameWithoutExtension);
+            var parentName = SafeIdentifier(Context.Options.GenerateFreeStandingFunctionsClassName(context.TranslationUnit));
             var isStruct = EnumerateClasses()
                 .ToList()
                 .FindAll(cls => cls.IsValueType && cls.Name == parentName && context.QualifiedLogicalName == cls.Namespace.QualifiedLogicalName)

--- a/src/Generator/Generators/CSharp/CSharpSources.cs
+++ b/src/Generator/Generators/CSharp/CSharpSources.cs
@@ -250,7 +250,8 @@ namespace CppSharp.Generators.CSharp
             if (!context.Functions.Any(f => f.IsGenerated) && !hasGlobalVariables)
                 return;
 
-            var parentName = SafeIdentifier(context.TranslationUnit.FileNameWithoutExtension);
+            var parentName = SafeIdentifier(Context.Options.GenerateFreeStandingFunctionsClassName?.Invoke(context.TranslationUnit)
+                                            ?? context.TranslationUnit.FileNameWithoutExtension);
             var isStruct = EnumerateClasses()
                 .ToList()
                 .FindAll(cls => cls.IsValueType && cls.Name == parentName && context.QualifiedLogicalName == cls.Namespace.QualifiedLogicalName)

--- a/src/Generator/Generators/CSharp/CSharpTypePrinter.cs
+++ b/src/Generator/Generators/CSharp/CSharpTypePrinter.cs
@@ -575,7 +575,7 @@ $"[{Context.TargetInfo.LongDoubleWidth}]");
             }
 
             if (decl is Variable && !(decl.Namespace is Class))
-                names.Push(decl.TranslationUnit.FileNameWithoutExtension);
+                names.Push(Options.GenerateFreeStandingFunctionsClassName(decl.TranslationUnit));
 
             while (!(ctx is TranslationUnit))
             {

--- a/src/Generator/Options.cs
+++ b/src/Generator/Options.cs
@@ -176,8 +176,7 @@ namespace CppSharp
         /// By default the classes in which free standing functions are contained are named like the header they are in
         /// this options allows you to customize this behavior.
         /// </summary>
-        /// <remarks>C# only.</remarks>
-        public Func<TranslationUnit, string> GenerateFreeStandingFunctionsClassName;
+        public Func<TranslationUnit, string> GenerateFreeStandingFunctionsClassName = tu => tu.FileNameWithoutExtension;
 
         /// <summary>
         /// Set this option to the kind of comments that you want generated

--- a/src/Generator/Options.cs
+++ b/src/Generator/Options.cs
@@ -173,6 +173,13 @@ namespace CppSharp
         public Func<TranslationUnit, string> GenerateName;
 
         /// <summary>
+        /// By default the classes in which free standing functions are contained are named like the header they are in
+        /// this options allows you to customize this behavior.
+        /// </summary>
+        /// <remarks>C# only.</remarks>
+        public Func<TranslationUnit, string> GenerateFreeStandingFunctionsClassName;
+
+        /// <summary>
         /// Set this option to the kind of comments that you want generated
         /// in the source code. This overrides the default kind set by the
         /// target generator.

--- a/src/Generator/Passes/MoveFunctionToClassPass.cs
+++ b/src/Generator/Passes/MoveFunctionToClassPass.cs
@@ -57,7 +57,8 @@ namespace CppSharp.Passes
             }
             else
             {
-                string name = (function.Namespace as TranslationUnit)?.FileNameWithoutExtension ??
+                var tu = function.Namespace as TranslationUnit;
+                string name = tu != null ? Options.GenerateFreeStandingFunctionsClassName(tu) :
                     function.Namespace.Name;
                 @class = ASTContext.FindClass(
                     name, ignoreCase: true).FirstOrDefault(

--- a/tests/dotnet/CLI/CLI.Gen.cs
+++ b/tests/dotnet/CLI/CLI.Gen.cs
@@ -68,6 +68,7 @@ namespace CppSharp.Tests
         {
             driver.Options.GenerateFinalizers = true;
             driver.Options.GenerateObjectOverrides = true;
+            driver.Options.GenerateFreeStandingFunctionsClassName = tu => tu.FileNameWithoutExtension + "Cool";
             base.Setup(driver);
         }
 

--- a/tests/dotnet/CLI/CLI.Tests.cs
+++ b/tests/dotnet/CLI/CLI.Tests.cs
@@ -78,7 +78,7 @@ public class CLITests
         byte[] bytes2 = Encoding.ASCII.GetBytes("TestMulti2");
         sbyte[] sbytes2 = Array.ConvertAll(bytes2, q => Convert.ToSByte(q));
 
-        string s = CLI.CLI.MultipleConstantArraysParamsTestMethod(sbytes, sbytes2);
+        string s = CLI.CLICool.MultipleConstantArraysParamsTestMethod(sbytes, sbytes2);
         Assert.AreEqual("TestMultiTestMulti2", s);
     }
 
@@ -88,7 +88,7 @@ public class CLITests
         byte[] bytes = Encoding.ASCII.GetBytes("TestMultipleConstantArraysParamsTestMethodLongerSourceArray");
         sbyte[] sbytes = Array.ConvertAll(bytes, q => Convert.ToSByte(q));
 
-        Assert.Throws<InvalidOperationException>(() => CLI.CLI.MultipleConstantArraysParamsTestMethod(sbytes, new sbyte[] { }));
+        Assert.Throws<InvalidOperationException>(() => CLI.CLICool.MultipleConstantArraysParamsTestMethod(sbytes, new sbyte[] { }));
     }
 
     [Test]
@@ -110,7 +110,7 @@ public class CLITests
             Assert.AreEqual(10, val.NestedUnion.SzText.Length);
             Assert.AreEqual("TestUnions", val.NestedUnion.SzText);
 
-            string ret = CLI.CLI.StructWithNestedUnionTestMethod(val);
+            string ret = CLI.CLICool.StructWithNestedUnionTestMethod(val);
 
             Assert.AreEqual("TestUnions", ret);
         }
@@ -146,7 +146,7 @@ public class CLITests
             Assert.AreEqual(10, unionWithNestedStruct.NestedStruct.SzText.Length);
             Assert.AreEqual("TestUnions", unionWithNestedStruct.NestedStruct.SzText);
 
-            string ret = CLI.CLI.UnionWithNestedStructTestMethod(unionWithNestedStruct);
+            string ret = CLI.CLICool.UnionWithNestedStructTestMethod(unionWithNestedStruct);
 
             Assert.AreEqual("TestUnions", ret);
         }
@@ -172,7 +172,7 @@ public class CLITests
 
                 Assert.AreEqual(2, unionWithNestedStructArray.NestedStructs.Length);
 
-                string ret = CLI.CLI.UnionWithNestedStructArrayTestMethod(unionWithNestedStructArray);
+                string ret = CLI.CLICool.UnionWithNestedStructArrayTestMethod(unionWithNestedStructArray);
 
                 Assert.AreEqual("TestUnion1TestUnion2", ret);
             }

--- a/tests/dotnet/CSharp/CSharp.Gen.cs
+++ b/tests/dotnet/CSharp/CSharp.Gen.cs
@@ -26,6 +26,8 @@ namespace CppSharp.Tests
 
             driver.ParserOptions.UnityBuild = true;
             driver.ParserOptions.AddSupportedFunctionTemplates("FunctionTemplate");
+
+            driver.Options.GenerateFreeStandingFunctionsClassName = t => t.FileNameWithoutExtension + "Cool";
         }
 
         public override void SetupPasses(Driver driver)

--- a/tests/dotnet/CSharp/CSharp.Tests.cs
+++ b/tests/dotnet/CSharp/CSharp.Tests.cs
@@ -85,9 +85,9 @@ public unsafe class CSharpTests
         {
         }
 
-        CSharp.CSharp.FunctionInsideInlineNamespace();
-        CSharp.CSharp.TakeMappedEnum(TestFlag.Flag1);
-        using (CSharpTemplates.SpecialiseReturnOnly())
+        CSharp.CSharpCool.FunctionInsideInlineNamespace();
+        CSharp.CSharpCool.TakeMappedEnum(TestFlag.Flag1);
+        using (CSharpTemplatesCool.SpecialiseReturnOnly())
         {
         }
 
@@ -127,16 +127,16 @@ public unsafe class CSharpTests
     [Ignore("https://github.com/mono/CppSharp/issues/1518")]
     public void TestReturnCharPointer()
     {
-        Assert.That(new IntPtr(CSharp.CSharp.ReturnCharPointer()), Is.EqualTo(IntPtr.Zero));
+        Assert.That(new IntPtr(CSharp.CSharpCool.ReturnCharPointer()), Is.EqualTo(IntPtr.Zero));
         const char z = 'z';
-        Assert.That(*CSharp.CSharp.TakeConstCharRef(z), Is.EqualTo(z));
+        Assert.That(*CSharp.CSharpCool.TakeConstCharRef(z), Is.EqualTo(z));
     }
 
     [Test]
     public void TestTakeCharPointer()
     {
         char c = 'c';
-        Assert.That(*CSharp.CSharp.TakeCharPointer(&c), Is.EqualTo(c));
+        Assert.That(*CSharp.CSharpCool.TakeCharPointer(&c), Is.EqualTo(c));
     }
 
     [Test]
@@ -346,16 +346,16 @@ public unsafe class CSharpTests
             methodsWithDefaultValues.DefaultOverloadedImplicitCtor();
             methodsWithDefaultValues.DefaultWithParamNamedSameAsMethod(5);
             Assert.That(methodsWithDefaultValues.DefaultIntAssignedAnEnumWithBinaryOperatorAndFlags(), Is.EqualTo((int)(Bar.Items.Item1 | Bar.Items.Item2)));
-            Assert.That(methodsWithDefaultValues.DefaultWithConstantFlags(), Is.EqualTo(CSharp.CSharp.ConstFlag1 | CSharp.CSharp.ConstFlag2 | CSharp.CSharp.ConstFlag3));
+            Assert.That(methodsWithDefaultValues.DefaultWithConstantFlags(), Is.EqualTo(CSharp.CSharpCool.ConstFlag1 | CSharp.CSharpCool.ConstFlag2 | CSharp.CSharpCool.ConstFlag3));
             Assert.IsTrue(methodsWithDefaultValues.DefaultWithPointerToEnum());
-            Assert.AreEqual(CSharp.CSharp.DefaultSmallPODInstance.__Instance, methodsWithDefaultValues.DefaultWithNonPrimitiveType().__Instance);
+            Assert.AreEqual(CSharp.CSharpCool.DefaultSmallPODInstance.__Instance, methodsWithDefaultValues.DefaultWithNonPrimitiveType().__Instance);
         }
     }
 
     [Test]
     public void TestGenerationOfAnotherUnitInSameFile()
     {
-        AnotherUnit.FunctionInAnotherUnit();
+        AnotherUnitCool.FunctionInAnotherUnit();
     }
 
     [Test]
@@ -710,9 +710,9 @@ public unsafe class CSharpTests
     public void TestReferenceToArrayWithConstSize()
     {
         int[] incorrectlySizedArray = { 1 };
-        Assert.Catch<ArgumentOutOfRangeException>(() => CSharp.CSharp.PassConstantArrayRef(incorrectlySizedArray));
+        Assert.Catch<ArgumentOutOfRangeException>(() => CSharp.CSharpCool.PassConstantArrayRef(incorrectlySizedArray));
         int[] array = { 1, 2 };
-        var result = CSharp.CSharp.PassConstantArrayRef(array);
+        var result = CSharp.CSharpCool.PassConstantArrayRef(array);
         Assert.That(result, Is.EqualTo(array[0]));
     }
 
@@ -782,9 +782,9 @@ public unsafe class CSharpTests
     [Test]
     public void TestStdStringConstant()
     {
-        Assert.That(CSharp.HasFreeConstant.AnotherUnit.STD_STRING_CONSTANT, Is.EqualTo("test"));
+        Assert.That(CSharp.HasFreeConstant.AnotherUnitCool.STD_STRING_CONSTANT, Is.EqualTo("test"));
         // check a second time to ensure it hasn't been improperly freed
-        Assert.That(CSharp.HasFreeConstant.AnotherUnit.STD_STRING_CONSTANT, Is.EqualTo("test"));
+        Assert.That(CSharp.HasFreeConstant.AnotherUnitCool.STD_STRING_CONSTANT, Is.EqualTo("test"));
     }
 
     [Test]
@@ -842,10 +842,10 @@ public unsafe class CSharpTests
         }
 
         foreach (var (type, offsets) in new (Type, uint[])[] {
-            (typeof(ClassCustomTypeAlignment), CSharp.CSharp.ClassCustomTypeAlignmentOffsets),
-            (typeof(ClassCustomObjectAlignment), CSharp.CSharp.ClassCustomObjectAlignmentOffsets),
-            (typeof(ClassMicrosoftObjectAlignment), CSharp.CSharp.ClassMicrosoftObjectAlignmentOffsets),
-            (typeof(StructWithEmbeddedArrayOfStructObjectAlignment), CSharp.CSharp.StructWithEmbeddedArrayOfStructObjectAlignmentOffsets),
+            (typeof(ClassCustomTypeAlignment), CSharp.CSharpCool.ClassCustomTypeAlignmentOffsets),
+            (typeof(ClassCustomObjectAlignment), CSharp.CSharpCool.ClassCustomObjectAlignmentOffsets),
+            (typeof(ClassMicrosoftObjectAlignment), CSharp.CSharpCool.ClassMicrosoftObjectAlignmentOffsets),
+            (typeof(StructWithEmbeddedArrayOfStructObjectAlignment), CSharp.CSharpCool.StructWithEmbeddedArrayOfStructObjectAlignmentOffsets),
         })
         {
             var internalType = type.GetNestedType("__Internal");
@@ -884,10 +884,10 @@ public unsafe class CSharpTests
     [Test]
     public void TestConstantArray()
     {
-        Assert.That(CSharp.CSharp.VariableWithFixedPrimitiveArray[0], Is.EqualTo(5));
-        Assert.That(CSharp.CSharp.VariableWithFixedPrimitiveArray[1], Is.EqualTo(10));
-        Assert.That(CSharp.CSharp.VariableWithVariablePrimitiveArray[0], Is.EqualTo(15));
-        Assert.That(CSharp.CSharp.VariableWithVariablePrimitiveArray[1], Is.EqualTo(20));
+        Assert.That(CSharp.CSharpCool.VariableWithFixedPrimitiveArray[0], Is.EqualTo(5));
+        Assert.That(CSharp.CSharpCool.VariableWithFixedPrimitiveArray[1], Is.EqualTo(10));
+        Assert.That(CSharp.CSharpCool.VariableWithVariablePrimitiveArray[0], Is.EqualTo(15));
+        Assert.That(CSharp.CSharpCool.VariableWithVariablePrimitiveArray[1], Is.EqualTo(20));
     }
 
     [Test]
@@ -1489,17 +1489,17 @@ public unsafe class CSharpTests
     [Test]
     public void TestGenerationOfIncompleteClasses()
     {
-        var incompleteStruct = CSharp.CSharp.CreateIncompleteStruct();
+        var incompleteStruct = CSharp.CSharpCool.CreateIncompleteStruct();
         Assert.IsNotNull(incompleteStruct);
-        Assert.DoesNotThrow(() => CSharp.CSharp.UseIncompleteStruct(incompleteStruct));
+        Assert.DoesNotThrow(() => CSharp.CSharpCool.UseIncompleteStruct(incompleteStruct));
     }
 
     [Test]
     public void TestForwardDeclaredStruct()
     {
-        using (var forwardDeclaredStruct = CSharp.CSharp.CreateForwardDeclaredStruct(10))
+        using (var forwardDeclaredStruct = CSharp.CSharpCool.CreateForwardDeclaredStruct(10))
         {
-            var i = CSharp.CSharp.UseForwardDeclaredStruct(forwardDeclaredStruct);
+            var i = CSharp.CSharpCool.UseForwardDeclaredStruct(forwardDeclaredStruct);
             Assert.AreEqual(forwardDeclaredStruct.I, i);
         }
     }
@@ -1507,8 +1507,8 @@ public unsafe class CSharpTests
     [Test, Ignore("The Linux CI (alone) failes to generate these functions.")]
     public void TestDuplicateDeclaredIncompleteStruct()
     {
-        //var duplicateDeclaredIncompleteStruct = CSharp.CSharp.CreateDuplicateDeclaredStruct(10);
-        //var i = CSharp.CSharp.UseDuplicateDeclaredStruct(duplicateDeclaredIncompleteStruct);
+        //var duplicateDeclaredIncompleteStruct = CSharp.CSharpCool.CreateDuplicateDeclaredStruct(10);
+        //var i = CSharp.CSharpCool.UseDuplicateDeclaredStruct(duplicateDeclaredIncompleteStruct);
         //Assert.AreEqual(10, i);
     }
 
@@ -1684,7 +1684,7 @@ public unsafe class CSharpTests
     public void TestFuncWithTypedefedFuncPtrAsParam()
     {
         TypedefedFuncPtr function = (a, b) => 5;
-        Assert.That(CSharp.CSharp.FuncWithTypedefedFuncPtrAsParam(function), Is.EqualTo(5));
+        Assert.That(CSharp.CSharpCool.FuncWithTypedefedFuncPtrAsParam(function), Is.EqualTo(5));
     }
 
     [Test]
@@ -1769,14 +1769,14 @@ public unsafe class CSharpTests
     [Test]
     public void TestConstCharStarRef()
     {
-        Assert.That(CSharp.CSharp.TakeConstCharStarRef("Test"), Is.EqualTo("Test"));
+        Assert.That(CSharp.CSharpCool.TakeConstCharStarRef("Test"), Is.EqualTo("Test"));
     }
 
     [Test]
     public void TestRValueReferenceToPointer()
     {
         int value = 5;
-        IntPtr intPtr = CSharp.CSharp.RValueReferenceToPointer((IntPtr*)&value);
+        IntPtr intPtr = CSharp.CSharpCool.RValueReferenceToPointer((IntPtr*)&value);
         Assert.That((int)intPtr, Is.EqualTo(value));
     }
 
@@ -1785,7 +1785,7 @@ public unsafe class CSharpTests
     {
         using (Foo foo = new Foo { A = 25 })
         {
-            Foo returnedFoo = CSharp.CSharp.TakeReturnReferenceToPointer(foo);
+            Foo returnedFoo = CSharp.CSharpCool.TakeReturnReferenceToPointer(foo);
             Assert.That(returnedFoo.A, Is.EqualTo(foo.A));
             using (Qux qux = new Qux())
             {
@@ -1832,7 +1832,7 @@ public unsafe class CSharpTests
     [Test]
     public void TestTypemapTypedefParam()
     {
-        Assert.That(CSharp.CSharp.TakeTypemapTypedefParam(false), Is.False);
+        Assert.That(CSharp.CSharpCool.TakeTypemapTypedefParam(false), Is.False);
     }
 
     [Test]
@@ -1866,13 +1866,13 @@ public unsafe class CSharpTests
         foreach (var @string in strings)
         {
             var cs = @string;
-            Assert.That(CSharp.CSharp.TestCSharpString(cs, out var @out), Is.EqualTo(cs));
+            Assert.That(CSharp.CSharpCool.TestCSharpString(cs, out var @out), Is.EqualTo(cs));
             Assert.That(@out, Is.EqualTo(cs));
-            Assert.That(CSharp.CSharp.TestCSharpStringWide(cs, out var outWide), Is.EqualTo(cs));
+            Assert.That(CSharp.CSharpCool.TestCSharpStringWide(cs, out var outWide), Is.EqualTo(cs));
             Assert.That(outWide, Is.EqualTo(cs));
-            Assert.That(CSharp.CSharp.TestCSharpString16(cs, out var out16), Is.EqualTo(cs));
+            Assert.That(CSharp.CSharpCool.TestCSharpString16(cs, out var out16), Is.EqualTo(cs));
             Assert.That(out16, Is.EqualTo(cs));
-            Assert.That(CSharp.CSharp.TestCSharpString32(cs, out var out32), Is.EqualTo(cs));
+            Assert.That(CSharp.CSharpCool.TestCSharpString32(cs, out var out32), Is.EqualTo(cs));
             Assert.That(out32, Is.EqualTo(cs));
         }
     }
@@ -1890,11 +1890,11 @@ public unsafe class CSharpTests
     [Test]
     public void TestFunctionToStaticMethod()
     {
-        Assert.That(CSharp.CSharp.TestFunctionToStaticMethod(new FTIStruct()).A, Is.EqualTo(6));
-        Assert.That(CSharp.CSharp.TestFunctionToStaticMethodStruct(new FTIStruct(), new FTIStruct() { A = 6 }), Is.EqualTo(6));
-        Assert.That(CSharp.CSharp.TestFunctionToStaticMethodRefStruct(new FTIStruct(), new FTIStruct() { A = 6 }), Is.EqualTo(6));
-        Assert.That(CSharp.CSharp.TestFunctionToStaticMethodConstStruct(new FTIStruct(), new FTIStruct() { A = 6 }), Is.EqualTo(6));
-        Assert.That(CSharp.CSharp.TestFunctionToStaticMethodConstRefStruct(new FTIStruct(), new FTIStruct() { A = 6 }), Is.EqualTo(6));
+        Assert.That(CSharp.CSharpCool.TestFunctionToStaticMethod(new FTIStruct()).A, Is.EqualTo(6));
+        Assert.That(CSharp.CSharpCool.TestFunctionToStaticMethodStruct(new FTIStruct(), new FTIStruct() { A = 6 }), Is.EqualTo(6));
+        Assert.That(CSharp.CSharpCool.TestFunctionToStaticMethodRefStruct(new FTIStruct(), new FTIStruct() { A = 6 }), Is.EqualTo(6));
+        Assert.That(CSharp.CSharpCool.TestFunctionToStaticMethodConstStruct(new FTIStruct(), new FTIStruct() { A = 6 }), Is.EqualTo(6));
+        Assert.That(CSharp.CSharpCool.TestFunctionToStaticMethodConstRefStruct(new FTIStruct(), new FTIStruct() { A = 6 }), Is.EqualTo(6));
     }
 
     [Test]
@@ -1914,9 +1914,9 @@ public unsafe class CSharpTests
     [Test]
     public void TestFunctionTemplate()
     {
-        Assert.That(CSharpTemplates.FunctionTemplate(5.0), Is.EqualTo(5 + 4.2));
-        Assert.That(CSharpTemplates.FunctionTemplate(6f), Is.EqualTo(6 + 4.1f));
-        Assert.That(CSharpTemplates.FunctionTemplate(7), Is.EqualTo(7 + 4));
+        Assert.That(CSharpTemplatesCool.FunctionTemplate(5.0), Is.EqualTo(5 + 4.2));
+        Assert.That(CSharpTemplatesCool.FunctionTemplate(6f), Is.EqualTo(6 + 4.1f));
+        Assert.That(CSharpTemplatesCool.FunctionTemplate(7), Is.EqualTo(7 + 4));
     }
 
     [Test]
@@ -1926,11 +1926,11 @@ public unsafe class CSharpTests
         var backup = myclass;
         myclass.Value = 7;
 
-        CSharp.CSharp.ModifyCore(ref myclass);
+        CSharp.CSharpCool.ModifyCore(ref myclass);
         Assert.That(myclass.Value, Is.EqualTo(10));
         Assert.That(myclass, Is.SameAs(myclass));
 
-        CSharp.CSharp.CreateCore(ref myclass);
+        CSharp.CSharpCool.CreateCore(ref myclass);
         Assert.That(myclass.Value, Is.EqualTo(20));
         Assert.That(myclass, Is.Not.SameAs(backup));
     }
@@ -1954,7 +1954,7 @@ public unsafe class CSharpTests
     {
         RuleOfThreeTester.Reset();
         CallByValueInterface @interface = new CallByValueInterfaceImpl();
-        CSharp.CSharp.CallCallByValueInterfaceValue(@interface);
+        CSharp.CSharpCool.CallCallByValueInterfaceValue(@interface);
 
         Assert.That(RuleOfThreeTester.ConstructorCalls, Is.EqualTo(1));
         Assert.That(RuleOfThreeTester.DestructorCalls, Is.EqualTo(2));
@@ -1967,7 +1967,7 @@ public unsafe class CSharpTests
     {
         RuleOfThreeTester.Reset();
         CallByValueInterface @interface = new CallByValueInterfaceImpl();
-        CSharp.CSharp.CallCallByValueInterfaceReference(@interface);
+        CSharp.CSharpCool.CallCallByValueInterfaceReference(@interface);
 
         Assert.That(RuleOfThreeTester.ConstructorCalls, Is.EqualTo(1));
         Assert.That(RuleOfThreeTester.DestructorCalls, Is.EqualTo(1));
@@ -1980,7 +1980,7 @@ public unsafe class CSharpTests
     {
         RuleOfThreeTester.Reset();
         CallByValueInterface @interface = new CallByValueInterfaceImpl();
-        CSharp.CSharp.CallCallByValueInterfacePointer(@interface);
+        CSharp.CSharpCool.CallCallByValueInterfacePointer(@interface);
 
         Assert.That(RuleOfThreeTester.ConstructorCalls, Is.EqualTo(1));
         Assert.That(RuleOfThreeTester.DestructorCalls, Is.EqualTo(1));
@@ -1991,14 +1991,14 @@ public unsafe class CSharpTests
     [Test]
     public void TestPointerToClass()
     {
-        Assert.IsTrue(CSharp.CSharp.PointerToClass.IsDefaultInstance);
-        Assert.IsTrue(CSharp.CSharp.PointerToClass.IsValid);
+        Assert.IsTrue(CSharp.CSharpCool.PointerToClass.IsDefaultInstance);
+        Assert.IsTrue(CSharp.CSharpCool.PointerToClass.IsValid);
     }
 
     [Test]
     public void TestValueTypeOutParameter()
     {
-        Assert.AreEqual(2, CSharp.CSharp.ValueTypeOutParameter(out var unionTestA, out var unionTestB));
+        Assert.AreEqual(2, CSharp.CSharpCool.ValueTypeOutParameter(out var unionTestA, out var unionTestB));
         Assert.AreEqual(2, unionTestA.A);
         Assert.AreEqual(2, unionTestB.B);
     }


### PR DESCRIPTION
I am currently writing some code to generate bindings for SDL3 using CppSharp and am faced with the following issue:
I would like to call functions like `SDL.Init(...)`. By default this would be `SDL_init.Init(...)` as `SDL_init.h` is the header that that free-standing function is in. Additionally, I would also like to avoid having all bindings be generated in a single file, as IDEs tend to not like files of over 50kloc. If I do generate a single file, I can cause all classes that are generated to share the name I want by iterating over all TUs and adjusting their `FilePath`. However, if I do enable `GenerationOutputMode.FilePerUnit` that causes all files to overwrite one another.

Conceivably, it should be possible to generate all files with the same name in separate folders, then rename them accordingly and move them around as an additional build step, but that seems.. overcomplicated.

All in all I think this justifies the introduction of an extra option exactly for this use case.
I remember hearing that the library seeks to avoid adding new options, due to them already being overabundant, so if you think that this addition is not worthy of being introduced in CppSharp proper then I'd totally be understanding!