### PR TITLE
Value types may generate `Dispose`

### DIFF
--- a/tests/dotnet/CSharp/CSharp.Tests.cs
+++ b/tests/dotnet/CSharp/CSharp.Tests.cs
@@ -2034,6 +2034,7 @@ public unsafe class CSharpTests
         test.CharPtrMember = "test2";
         Assert.AreEqual("test", test.StringMember);
         Assert.AreEqual("test2", test.CharPtrMember);
+        test.Dispose();
     }
 
     [Test]
@@ -2047,6 +2048,7 @@ public unsafe class CSharpTests
         test.CharPtrMember = "test2";
         Assert.AreEqual("test", test.StringMember);
         Assert.AreEqual("test2", test.CharPtrMember);
+        test.Dispose();
     }
 
     [Test]
@@ -2059,5 +2061,6 @@ public unsafe class CSharpTests
         test.CharPtrMember = "test2";
         Assert.AreEqual("test", test.StringMember);
         Assert.AreEqual("test2", test.CharPtrMember);
+        test.Dispose();
     }
 }


### PR DESCRIPTION
C# structs really are something. Fixes #1785

Finally, you can now use value types correctly. Good luck, but you can!

I've tried looking into #1786 by using something similar to the `__ownsNativeInstance`, but ultimately gave up, because either way you'll still have incredibly unintuitive behavior that you cannot at all prevent and the time investment does not seem worth it.