### PR TITLE
Provide `TypePrinter`s with more context

### DIFF
--- a/src/Generator/Generators/CSharp/CSharpMarshal.cs
+++ b/src/Generator/Generators/CSharp/CSharpMarshal.cs
@@ -826,10 +826,14 @@ namespace CppSharp.Generators.CSharp
             Context.Parameter = new Parameter
             {
                 Name = Context.ArgName,
-                QualifiedType = field.QualifiedType
+                QualifiedType = field.QualifiedType,
             };
 
-            return field.Type.Visit(this, field.QualifiedType.Qualifiers);
+            Context.Field = field;
+            var ret = field.Type.Visit(this, field.QualifiedType.Qualifiers);
+            Context.Field = null;
+
+            return ret;
         }
 
         public override bool VisitProperty(Property property)
@@ -843,7 +847,11 @@ namespace CppSharp.Generators.CSharp
                 QualifiedType = property.QualifiedType
             };
 
-            return base.VisitProperty(property);
+            Context.Property = property;
+            var ret = base.VisitProperty(property);
+            Context.Property = null;
+
+            return ret;
         }
 
         public override bool VisitEnumDecl(Enumeration @enum)

--- a/src/Generator/Generators/CSharp/CSharpTypePrinter.cs
+++ b/src/Generator/Generators/CSharp/CSharpTypePrinter.cs
@@ -272,7 +272,7 @@ namespace CppSharp.Generators.CSharp
                     Kind = ContextKind,
                     MarshalKind = MarshalKind,
                     Type = typedef,
-                    Parameter = Parameter
+                    Parameter = Parameter,
                 };
 
                 return typeMap.CSharpSignatureType(typePrinterContext).ToString();
@@ -698,7 +698,9 @@ $"[{Context.TargetInfo.LongDoubleWidth}]");
         public override TypePrinterResult VisitFieldDecl(Field field)
         {
             PushMarshalKind(MarshalKind.NativeField);
+            Field = field;
             var fieldTypePrinted = field.QualifiedType.Visit(this);
+            Field = null;
             PopMarshalKind();
 
             var returnTypePrinter = new TypePrinterResult();

--- a/src/Generator/Generators/ITypePrinter.cs
+++ b/src/Generator/Generators/ITypePrinter.cs
@@ -36,6 +36,14 @@ namespace CppSharp.AST
         public MarshalKind MarshalKind;
         public Declaration Declaration;
         public Parameter Parameter;
+        public Property Property;
+        private Field field;
+        public Field Field
+        {
+            get => field ?? Property.Field;
+            set => field = value;
+        }
+        public Method Method;
         public Type Type;
 
         public TypePrinterContext() : this(TypePrinterContextKind.Normal)

--- a/src/Generator/Generators/Marshal.cs
+++ b/src/Generator/Generators/Marshal.cs
@@ -29,7 +29,6 @@ namespace CppSharp.Generators
 
         public string ArgName { get; set; }
         public int ParameterIndex { get; set; }
-        public Function Function { get; set; }
 
         public uint Indentation { get; }
     }

--- a/src/Generator/Generators/TypePrinter.cs
+++ b/src/Generator/Generators/TypePrinter.cs
@@ -85,6 +85,17 @@ namespace CppSharp.Generators
 
         public Parameter Parameter;
 
+        private Field field;
+        public Field Field
+        {
+            get => field ?? Property.Field;
+            set => field = value;
+        }
+
+        public Property Property;
+
+        public Function Function;
+
         #region Dummy implementations
 
         public virtual string ToString(CppSharp.AST.Type type)

--- a/src/Generator/Passes/ValidateOperatorsPass.cs
+++ b/src/Generator/Passes/ValidateOperatorsPass.cs
@@ -95,7 +95,8 @@ namespace CppSharp.Passes
                                         new TypePrinterContext
                                         {
                                             Parameter = parameter,
-                                            Type = type
+                                            Type = type,
+                                            Method = @operator,
                                         });
                                     var cilType = mappedTo as CILType;
                                     if (cilType?.Type == typeof(int))


### PR DESCRIPTION
I am absolutely uncertain about this pull request, the underlying mechanisms for this library functionality is still an enigma to me.

What I seek to achieve:
I am still working on the SDL3 bindings. Some of the classes in SDL3 contain fields which are of primitive types (`uint32_t`) but actually represent enum types. C enums being weakly typed bla bla bla. I would like to map these specific fields (which I hand pick) to the corresponding enum types. For this purpose I think `TypeMapper`s are the tool of choice. I have already established similar functionality for function parameters of primitive types that represent enums. I simply collect all `Parameter`s and their corresponding `Type` in a dictionary and check that when marshalling.

Trying to replicate this same approach for fields has presented me with the problem that the context that is provided to a `TypeMapper` is not able to decide whether it's a field that should be mapped. There is very minimal information given, no ability to derive a corresponding class or anything of that sort.

Modifying the library to make what I desire work is fairly trivial. I check for the property in `CSharpSignatureType` (not the field!) and for the field in the marshalling methods (it's the only thing that's provided respectively).

Alternative approaches I've considered:
- Changing the field's type in `PreProcess` and dealing with the marshalling properly via a `TypeMapper` for the enum
    - Causes a stack overflow for some reason
- Changing the property's and internal classes field type in `PostProcess`
    - I can't seem to be able to find the inner `__Internal` class

Now, the considerations for this pull request:
- The `Parameter` field does not actually seem to represent a concrete method parameter, it can be different things for different contexts. Sometimes it's not set at all, other times there's a degenerate version newly created from a different `Parameter` that has a different naming scheme. So all in all I feel like this PR is not line with the original design intent here (because I currently don't think I understand it).
- While I only require `Field` on `TypePrinter` and `Property` on `TypePrinterContext` I have also decided to include both of them in both classes, as well as an additional `Method` field that could be helpful when trying to recreate the desired functionality for return types.
- `TypePrinterContext`'s `Field` property goes unset.
- `Variable` is another often-seen class that could be considered for addition. I have decided to exclude it because I cannot see a direct use for it.

I actually hope that what I seek to accomplish can be accomplished using existing library mechanisms, I guess this would've been more fit for an issue asking for help, but I think it might be worth presenting the code here for consideration anyways.

If this PR were to be considered for merging it would definitely require a second closer look by someone with a deeper understanding of the library. It's highly probably that I missed spots for potentially providing the new fields and other times I have provided them needlessly at the very least.

To conclude here's a minimal example that demonstrates what I seek to achieve:
```cpp
#include <cstdint>

typedef enum {
    A = 0, B = 1, C = 2
} MyEnum;

class MyClass {
public:
    uint32_t member_enum;
    uint32_t member_normal;
};
```
I want `member_enum` to have type `MyEnum` on the C# side and `member_normal` to remain as `uint32_t`/`uint`.