### PR TITLE
Fixed a bug causing the header file to be included twice

### DIFF
--- a/src/Generator/Generators/C/CppHeaders.cs
+++ b/src/Generator/Generators/C/CppHeaders.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 using CppSharp.AST;
 using CppSharp.AST.Extensions;
@@ -87,7 +88,8 @@ namespace CppSharp.Generators.Cpp
                 if (typeRef.Include.TranslationUnit == unit)
                     continue;
 
-                if (typeRef.Include.File == unit.FileName)
+                var filename = Context.Options.GenerateName != null ? $"{Context.Options.GenerateName(TranslationUnit)}{Path.GetExtension(TranslationUnit.FileName)}" : TranslationUnit.FileName;
+                if (typeRef.Include.File == filename)
                     continue;
 
                 var include = typeRef.Include;

--- a/src/Generator/Generators/C/CppSources.cs
+++ b/src/Generator/Generators/C/CppSources.cs
@@ -64,7 +64,8 @@ namespace CppSharp.Generators.Cpp
 
             foreach (var typeRef in typeReferenceCollector.TypeReferences)
             {
-                if (typeRef.Include.File == unit.FileName)
+                var filename = Context.Options.GenerateName != null ? $"{Context.Options.GenerateName(TranslationUnit)}{Path.GetExtension(TranslationUnit.FileName)}" : TranslationUnit.FileName;
+                if (typeRef.Include.File == filename)
                     continue;
 
                 var include = typeRef.Include;

--- a/src/Generator/Generators/CLI/CLIHeaders.cs
+++ b/src/Generator/Generators/CLI/CLIHeaders.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 using CppSharp.AST;
 using CppSharp.AST.Extensions;
@@ -61,7 +62,8 @@ namespace CppSharp.Generators.CLI
                 if (typeRef.Include.TranslationUnit == TranslationUnit)
                     continue;
 
-                if (typeRef.Include.File == TranslationUnit.FileName)
+                var filename = Context.Options.GenerateName != null ? $"{Context.Options.GenerateName(TranslationUnit)}{Path.GetExtension(TranslationUnit.FileName)}" : TranslationUnit.FileName;
+                if (typeRef.Include.File == filename)
                     continue;
 
                 var include = typeRef.Include;

--- a/src/Generator/Generators/CLI/CLISources.cs
+++ b/src/Generator/Generators/CLI/CLISources.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Globalization;
+using System.IO;
 using System.Linq;
 using CppSharp.AST;
 using CppSharp.AST.Extensions;
@@ -61,7 +62,8 @@ namespace CppSharp.Generators.CLI
 
             foreach (var typeRef in typeReferenceCollector.TypeReferences)
             {
-                if (typeRef.Include.File == TranslationUnit.FileName)
+                var filename = Context.Options.GenerateName != null ? $"{Context.Options.GenerateName(TranslationUnit)}{Path.GetExtension(TranslationUnit.FileName)}" : TranslationUnit.FileName;
+                if (typeRef.Include.File == filename)
                     continue;
 
                 var include = typeRef.Include;


### PR DESCRIPTION
bug:
in C and CLI generator
when customizing the generated file name using the Options.GenerateName
the header file will be included twice in the generated .cpp file

reproduce:
add this line to the Setup(Driver driver) function in the CLI.Gen.cs
```
driver.Options.GenerateName = file => file.FileNameWithoutExtension + "_wrapper";
```
the output file CLI_wrapper.cpp will look like this
```
...
#include "CLI_wrapper.h"
#include "CLI_wrapper.h"
...
```