### PR TITLE
Implement ClassTemplatePartialSpecialization::Parameters

### DIFF
--- a/src/CppParser/AST.cpp
+++ b/src/CppParser/AST.cpp
@@ -793,6 +793,8 @@ ClassTemplatePartialSpecialization::ClassTemplatePartialSpecialization()
 
 ClassTemplatePartialSpecialization::~ClassTemplatePartialSpecialization() {}
 
+DEF_VECTOR(ClassTemplatePartialSpecialization, Declaration*, Parameters)
+
 FunctionTemplate::FunctionTemplate() : Template(DeclarationKind::FunctionTemplate) {}
 
 FunctionTemplate::~FunctionTemplate() {}

--- a/src/CppParser/Decl.h
+++ b/src/CppParser/Decl.h
@@ -715,6 +715,7 @@ namespace CppSharp
             public:
                 ClassTemplatePartialSpecialization();
                 ~ClassTemplatePartialSpecialization();
+                VECTOR(Declaration *, Parameters)
             };
 
             class CS_API FunctionTemplate : public Template


### PR DESCRIPTION
Closes #1801

1. I only added `Parameters` field.
2. Extracted the `headers.zip` to the build directory
3. Rebuild the whole solution

Still no new bindings are being generated.