### PR TITLE
Ensure cross compiler is in the environment before building

### DIFF
--- a/.github/workflows/llvm.yml
+++ b/.github/workflows/llvm.yml
@@ -27,6 +27,9 @@ jobs:
       - uses: actions/checkout@v4
       - uses: lukka/get-cmake@latest
 
+      - name: Install Aarch64 GCC for cross compile
+        run: sudo apt update && sudo apt install -y g++-aarch64-linux-gnu gcc-aarch64-linux-gnu
+
       - name: Clone LLVM
         shell: bash
         run: build/build.sh clone_llvm


### PR DESCRIPTION
Install Aarch64 GCC before running cross compile steps. Uses naive `apt-get` method as opposed to larger caching solution like [cache-apt-pkgs-action](https://github.com/awalsh128/cache-apt-pkgs-action), but let's ensure this works before making things more complicated.