### PR TITLE
Resolve "Error finding an LLVM build" (#1831)

### DIFF
--- a/build/LLVM.lua
+++ b/build/LLVM.lua
@@ -9,6 +9,11 @@ local LLVMRootDirRelease = ""
 
 require "llvm/LLVM"
 
+newoption {
+  trigger = "vs",
+  description = "Override Visual Studio version with particular version"
+}
+
 function SearchLLVM()
   LLVMRootDirDebug = builddir .. "/llvm/" .. get_llvm_package_name(nil, "Debug")
   LLVMRootDirRelease = builddir .. "/llvm/" .. get_llvm_package_name()
@@ -20,7 +25,7 @@ function SearchLLVM()
   elseif os.isdir(LLVMRootDir) then
     print("Using LLVM build: " .. LLVMRootDir)
   else
-    error("Error finding an LLVM build")
+    error("Error finding an LLVM build. Tried: " .. LLVMRootDirDebug .. " and " .. LLVMRootDirRelease)
   end
 end
 

--- a/build/build.sh
+++ b/build/build.sh
@@ -129,22 +129,22 @@ download_premake()
 
 download_llvm()
 {
-  "$builddir/premake.sh" --file="$builddir/llvm/LLVM.lua" download_llvm --os=$os --arch=$platform --configuration=$configuration
+  "$builddir/premake.sh" --file="$builddir/llvm/LLVM.lua" download_llvm --vs=$vs --os=$os --arch=$platform --configuration=$configuration
 }
 
 clone_llvm()
 {
-  "$builddir/premake.sh" --file="$builddir/llvm/LLVM.lua" clone_llvm --os=$os --arch=$platform --configuration=$configuration
+  "$builddir/premake.sh" --file="$builddir/llvm/LLVM.lua" clone_llvm --vs=$vs --os=$os --arch=$platform --configuration=$configuration
 }
 
 build_llvm()
 {
-  "$builddir/premake.sh" --file="$builddir/llvm/LLVM.lua" build_llvm --os=$os --arch=$platform --configuration=$configuration
+  "$builddir/premake.sh" --file="$builddir/llvm/LLVM.lua" build_llvm --vs=$vs --os=$os --arch=$platform --configuration=$configuration
 }
 
 package_llvm()
 {
-  "$builddir/premake.sh" --file="$builddir/llvm/LLVM.lua" package_llvm --os=$os --arch=$platform --configuration=$configuration
+  "$builddir/premake.sh" --file="$builddir/llvm/LLVM.lua" package_llvm --vs=$vs --os=$os --arch=$platform --configuration=$configuration
 }
 
 detect_os()

--- a/build/llvm/LLVM.lua
+++ b/build/llvm/LLVM.lua
@@ -52,6 +52,10 @@ function clone_llvm()
 end
 
 function get_vs_version()
+  if _OPTIONS["vs"] then
+    return _OPTIONS["vs"]
+  end
+
   local function map_msvc_to_vs_version(major, minor)
 	if major == "19" and minor >= "30" then return "vs2022"
     elseif major == "19" and minor >= "20" then return "vs2019"


### PR DESCRIPTION
Pass through Visual Studio version from build.sh into build/LLVM.lua, so that the downloaded version is consistent with build.sh's view rather than the host command prompt's view.

This should fix #1831.

Questions (1st time I've written any premake...):
 * Does this only need to go to premakes with `--file=LLVM.lua`?
 * Should the `newoption` exist? Premake didn't seem to need it. 
 * Should the `newoption` have a list of supported versions? Seems like build.sh is responsible for validation here, but I'm not sure
