### PR TITLE
Fixes issue #1283

### DIFF
--- a/src/Generator/Passes/GetterSetterToPropertyPass.cs
+++ b/src/Generator/Passes/GetterSetterToPropertyPass.cs
@@ -40,7 +40,7 @@ namespace CppSharp.Passes
         }
 
         public GetterSetterToPropertyPass()
-            => VisitOptions.ResetFlags(VisitFlags.ClassTemplateSpecializations);
+            => VisitOptions.ResetFlags(VisitFlags.ClassBases | VisitFlags.ClassTemplateSpecializations);
 
         public override bool VisitClassDecl(Class @class)
         {


### PR DESCRIPTION
See #1283 .

`GetterSetterToPropertyPass` currently fails on the following code:

```c#
namespace foo {
class Dorld {
    virtual int UnkFunc1() = 0;
};
}

class Bar : public foo::Dorld {
public:
    virtual int UnkFunc1() override;
};
```

[Resulting output](https://gist.github.com/angryzor/5f00133280bce5e0cd523eb0d2562428)

The namespace is important. If `Bar` is declared inside the same namespace the bug is not triggered. However, my original code where I encountered this bug did have both classes in the same namespace, though they were in different header files.

The bug occurs when it tries to determine whether the property overrides a base property [here](https://github.com/mono/CppSharp/blob/3f923b1c640307fc19f0c83902c81bde1dc50b3a/src/Generator/Passes/GetterSetterToPropertyPass.cs#L215).

When `Bar` is outside the namespace, `Bar` gets processed before `Dorld`, so `Dorld` doesn't have the property created yet. The check fails and the property is not created on `Bar`. The property is then later created on `Dorld` when the pass finally visits `Dorld`.

When instead `Bar` is inside the namespace, `Dorld` is visited first and the code continues as expected.

Fixed by setting the `VisitFlags.ClassBases` flag on the pass.