### PR TITLE
Couldn't remove modules without translation units

### DIFF
--- a/src/Generator/Driver.cs
+++ b/src/Generator/Driver.cs
@@ -417,12 +417,12 @@ namespace CppSharp
             }
 
             new CleanUnitPass { Context = driver.Context }.VisitASTContext(driver.Context.ASTContext);
-            foreach (var module in options.Modules.Where(
-                         m => m != options.SystemModule && !m.Units.GetGenerated().Any()))
+            options.Modules.RemoveAll(m =>
             {
-                Diagnostics.Message($"Removing module {module} because no translation units are generated...");
-                options.Modules.Remove(module);
-            }
+                bool result = m != options.SystemModule && !m.Units.GetGenerated().Any();
+                if (result) Diagnostics.Message($"Removing module {m} because no translation units are generated...");
+                return result;
+            });
 
             if (!options.Quiet)
                 Diagnostics.Message("Processing code...");


### PR DESCRIPTION
I do not know I'm first to encounter this, however, loop that removes modules without translation units, could not have worked.

In C# Enumerator prohibits editing the collection so you cannot remove modules from `options.Module` while iterating `options.Module`.
![CppSharp_Enumeration_bug00](https://github.com/user-attachments/assets/d67ed500-8583-43ff-a355-b3fb6c6c5df6)
![CppSharp_Enumeration_bug01](https://github.com/user-attachments/assets/1e5d9432-adcf-4175-b84d-be7d82e36b93)

Chose `RemoveAll` for its simplicity. Not necessary optimal solution although it might be.