### PR TITLE
Correctly convert `SCREAMING_SNAKE_CASE`

### DIFF
--- a/src/Generator.Tests/Passes/TestPasses.cs
+++ b/src/Generator.Tests/Passes/TestPasses.cs
@@ -121,7 +121,7 @@ namespace CppSharp.Generator.Tests.Passes
             Assert.That(@enum.Name, Is.EqualTo("ScreamingEnum"));
             Assert.That(enumItem.Name, Is.EqualTo("SnakeValue"));
 
-            AssertConversion("test_123", "Test123");
+            AssertConversion("test_123_123", "Test123_123");
             AssertConversion("SCREAMING", "Screaming");
             AssertConversion("Not_Screaming", "NotScreaming");
             AssertConversion("Still_Not___Screaming", "StillNot___Screaming");
@@ -131,11 +131,14 @@ namespace CppSharp.Generator.Tests.Passes
             AssertConversion("_d_", "_d_");
             AssertConversion("MyCool2d_string", "MyCool2dString");
             AssertConversion("MyCool2_d_String", "MyCool2D_String");
+            AssertConversion("MyCoolD_d_String", "MyCoolD_dString");
             AssertConversion("MyC_de_cool", "MyC_deCool");
             AssertConversion("m_d_d_d", "M_dD_d");
+            AssertConversion("m_d_d_d", "mD_dD", RenameCasePattern.LowerCamelCase);
             AssertConversion("__m_d_d_d", "__mD_dD");
             AssertConversion("mProperty", "MProperty");
             AssertConversion("mProperty", "mProperty", RenameCasePattern.LowerCamelCase);
+            AssertConversion("m_property", "mProperty", RenameCasePattern.LowerCamelCase);
 
             void AssertConversion(string input, string output, RenameCasePattern pattern = RenameCasePattern.UpperCamelCase)
                 => Assert.That(CaseRenamePass.ConvertCaseString(new Class { Name = input }, pattern),

--- a/src/Generator.Tests/Passes/TestPasses.cs
+++ b/src/Generator.Tests/Passes/TestPasses.cs
@@ -126,6 +126,7 @@ namespace CppSharp.Generator.Tests.Passes
             AssertConversion("Not_Screaming", "NotScreaming");
             AssertConversion("Still_Not___Screaming", "StillNot___Screaming");
             AssertConversion("Still_Not___screaming", "StillNot___screaming");
+            AssertConversion("still_not___screaming", "StillNot___screaming");
             AssertConversion("_D_", "_D_");
             AssertConversion("_d_", "_d_");
             AssertConversion("MyCool2d_string", "MyCool2dString");

--- a/src/Generator.Tests/Passes/TestPasses.cs
+++ b/src/Generator.Tests/Passes/TestPasses.cs
@@ -110,12 +110,35 @@ namespace CppSharp.Generator.Tests.Passes
 
             var method = c.Method("lowerCaseMethod");
             var property = c.Properties.Find(p => p.Name == "lowerCaseField");
+            var @enum = c.FindEnum("SCREAMING_ENUM");
+            var enumItem = @enum.Items.Find(i => i.Name == "snake_value");
 
             passBuilder.RenameDeclsUpperCase(RenameTargets.Any);
             passBuilder.RunPasses(pass => pass.VisitASTContext(AstContext));
 
             Assert.That(method.Name, Is.EqualTo("LowerCaseMethod"));
             Assert.That(property.Name, Is.EqualTo("LowerCaseField"));
+            Assert.That(@enum.Name, Is.EqualTo("ScreamingEnum"));
+            Assert.That(enumItem.Name, Is.EqualTo("SnakeValue"));
+
+            AssertConversion("test_123", "Test123");
+            AssertConversion("SCREAMING", "Screaming");
+            AssertConversion("Not_Screaming", "NotScreaming");
+            AssertConversion("Still_Not___Screaming", "StillNot___Screaming");
+            AssertConversion("Still_Not___screaming", "StillNot___screaming");
+            AssertConversion("_D_", "_D_");
+            AssertConversion("_d_", "_d_");
+            AssertConversion("MyCool2d_string", "MyCool2dString");
+            AssertConversion("MyCool2_d_String", "MyCool2D_String");
+            AssertConversion("MyC_de_cool", "MyC_deCool");
+            AssertConversion("m_d_d_d", "M_dD_d");
+            AssertConversion("__m_d_d_d", "__mD_dD");
+            AssertConversion("mProperty", "MProperty");
+            AssertConversion("mProperty", "mProperty", RenameCasePattern.LowerCamelCase);
+
+            void AssertConversion(string input, string output, RenameCasePattern pattern = RenameCasePattern.UpperCamelCase)
+                => Assert.That(CaseRenamePass.ConvertCaseString(new Class { Name = input }, pattern),
+                    Is.EqualTo(output));
 
             Type.TypePrinterDelegate -= TypePrinterDelegate;
         }

--- a/src/Generator/Passes/RenamePass.cs
+++ b/src/Generator/Passes/RenamePass.cs
@@ -410,8 +410,12 @@ namespace CppSharp.Passes
                 char? next = i < decl.Name.Length - 1 ? decl.Name[i + 1] : null;
 
                 if (c == '_'
-                    && next != null && i - 1 != startIndex
+                    && next != null
+                    // Prevent two capitals in a row caused by later uppercasing of first char.
+                    && (i - 1 != startIndex || pattern == RenameCasePattern.LowerCamelCase)
+                    // Ignore multiple underscores in a row.
                     && prev != '_' && next != '_'
+                    // Don't join digits.
                     && (IsLetter(prev) || IsLetter(next))
                     && !justHadSeparator)
                 {
@@ -423,7 +427,7 @@ namespace CppSharp.Passes
                 // CamelCase separator.
                 justHadSeparator = IsLower(prev) && IsUpper(c);
 
-                sb.Append(!IsUpper(prev) ? c : char.ToLowerInvariant(c));
+                sb.Append(IsUpper(prev) ? char.ToLowerInvariant(c) : c);
 
                 // Nullable helper functions.
                 bool IsLetter(char? ch) => IsUpper(ch) || IsLower(ch);

--- a/tests/dotnet/Native/Passes.h
+++ b/tests/dotnet/Native/Passes.h
@@ -24,6 +24,10 @@ struct TestRename
 {
   int lowerCaseMethod();
   int lowerCaseField;
+  enum SCREAMING_ENUM
+  {
+    snake_value
+  };
 };
 
 /// <summary>A simple test.</summary>


### PR DESCRIPTION
The problem of normalizing casings is a very interesting one.
I've decided to reimplement the function, partly to make it more readable as well.

It's trivial to implement a function that converts consistent input to consistent output, the issue lies with converting nonsensical input (weird casings and case exceptions) to sensible output, especially while acting purely locally.

These are the test cases that would be different for the original implementation:
| Test Value  | Original Implementation | New Implementation |
| ------------- | ------------- | ------------- | 
| `SCREAMING`  | `SCREAMING` | `Screaming` |
| `Still_Not___Screaming`  | `StillNotScreaming` | `Still_Not___Screaming` |
| `Still_Not___screaming`  | `StillNot_screaming` | `Still_Not___screaming` |
| `still_not___screaming`  | `StillNotScreaming` | `StillNot___screaming` |
| `_D_`  | `D_` | `_D_` |
| `_d_`  | `D` | `_d_` |
| `MyCool2d_string`  | `MyCool2d_string` | `MyCool2dString` |
| `MyCool2_d_String`  | `MyCool2_dString` | `MyCool2D_String` |
| `MyC_de_cool`  | `MyC_de_cool` | `MyC_deCool` |
| `m_d_d_d`  | `MDDD` | `M_dD_d` |
| `m_d_d_d` (`LowerCamelCase`)  | `mDDD` | `mD_dD` |
| `__m_d_d_d` | `MDDD` | `__mD_dD` |

The questions of design are:
- **How to deal with leading underscores?** I've decided to keep them because I consider them not as much part of the name's case itself, but rather a prefix.
- **How to deal with multiple underscores?** I've decided to ignore them, as I wouldn't imagine them simply indicating casing.
- **Policy on preventing more capitals in a row than before** I have decided to strictly enforce this, while the previous implementation did not do so, this is notable for the `MDDD` test case. I recognize that the previous handling of this case was superior, however, this case is highly synthetic (in general the test cases are not solely intended to represent real world scenarios, but to capture design decisions made).

In conclusion I believe the new implementation is generally more stable, consistent and sensible in realistic edge cases.