### PR TITLE
Test CustomAllocator debugging configuration fix.

### DIFF
--- a/tests/dotnet/NamespacesDerived/NamespacesDerived.h
+++ b/tests/dotnet/NamespacesDerived/NamespacesDerived.h
@@ -103,6 +103,10 @@ class CustomAllocator
 public:
     typedef T value_type;
 
+    // Suppress some windows Debug errors with constructors.
+    CustomAllocator() noexcept {};
+    template <class U> CustomAllocator(const CustomAllocator<U>&) noexcept {};
+
     T* allocate(size_t cnt, const void* = 0) { return 0; }
     void deallocate(T* p, size_t cnt) {}
     bool operator==(const CustomAllocator&) { return true; }


### PR DESCRIPTION
On Windows 2022 "vector" module deconstructor of the `vector` is the following:
```C++
    _CONSTEXPR20 ~vector() noexcept {
        _Tidy();
#if _ITERATOR_DEBUG_LEVEL != 0
        auto&& _Alproxy = _GET_PROXY_ALLOCATOR(_Alty, _Getal());
        _Delete_plain_internal(_Alproxy, _STD exchange(_Mypair._Myval2._Myproxy, nullptr));
#endif // _ITERATOR_DEBUG_LEVEL != 0
    }
```

When debugging configuration is enabled, internals here report an error for NamespacesDerived.Native.

A fix is to add Constructor and Copy Constructor to the NamespacesDerived.h `CustomAllocator`. Windows manual seems to want even more to be defined, but I leave it here. https://learn.microsoft.com/en-us/cpp/standard-library/allocators?view=msvc-170