### PR TITLE
Add additional debug configuration for a better debugging experience

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -4,6 +4,7 @@
   <PropertyGroup>
     <RootDir>$(MSBuildThisFileDirectory)</RootDir>
     <Platforms>x86;x64</Platforms>
+    <Configurations>Debug;DebugOpt;Release</Configurations>
     <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>    
     <PackageLicenseExpression>MIT</PackageLicenseExpression>

--- a/build/Helpers.lua
+++ b/build/Helpers.lua
@@ -36,6 +36,7 @@ newoption {
   allowed = {
     { "Release",  "Release" },
     { "Debug",  "Debug" },
+    { "DebugOpt",  "DebugOpt" },
  }
 }
 
@@ -104,10 +105,15 @@ function SetupNativeProject()
 
   filter { "configurations:Debug" }
     defines { "DEBUG" }
+  
+  filter { "configurations:DebugOpt" }
+    defines { "DEBUG", "_ITERATOR_DEBUG_LEVEL=0" }
+    optimize "Debug"
+    runtime "Release"
 
   filter { "configurations:Release" }
     defines { "NDEBUG" }
-    optimize "On"
+    optimize "Full"
 
   -- Compiler-specific options
 

--- a/build/LLVM.lua
+++ b/build/LLVM.lua
@@ -38,6 +38,18 @@ function SetupLLVMIncludes()
   local c = filter()
 
   if LLVMDirPerConfiguration then
+    filter { "configurations:DebugOpt" }
+      includedirs
+      {
+        path.join(LLVMRootDirRelease, "include"),
+        path.join(LLVMRootDirRelease, "llvm/include"),
+        path.join(LLVMRootDirRelease, "lld/include"),
+        path.join(LLVMRootDirRelease, "clang/include"),
+        path.join(LLVMRootDirRelease, "clang/lib"),
+        path.join(LLVMRootDirRelease, "build/include"),
+        path.join(LLVMRootDirRelease, "build/clang/include"),
+      }
+
     filter { "configurations:Debug" }
       includedirs
       {
@@ -121,6 +133,9 @@ function SetupLLVMLibs()
   filter {}
 
   if LLVMDirPerConfiguration then
+    filter { "configurations:DebugOpt" }
+      libdirs { path.join(LLVMRootDirRelease, "build/lib") }
+
     filter { "configurations:Debug" }
       libdirs { path.join(LLVMRootDirDebug, "build/lib") }
 
@@ -129,6 +144,9 @@ function SetupLLVMLibs()
   else
     local LLVMBuildDir = get_llvm_build_dir()
     libdirs { path.join(LLVMBuildDir, "lib") }
+      
+    filter { "configurations:DebugOpt", "toolset:msc*" }
+      libdirs { path.join(LLVMBuildDir, "RelWithDebInfo/lib") }
 
     filter { "configurations:Debug", "toolset:msc*" }
       libdirs { path.join(LLVMBuildDir, "Debug/lib") }

--- a/build/build.sh
+++ b/build/build.sh
@@ -3,7 +3,7 @@ set -e
 builddir=$(cd "$(dirname "$0")"; pwd)
 platform=x64
 vs=vs2022
-configuration=Release
+configuration=DebugOpt
 build_only=false
 ci=false
 target_framework=

--- a/build/llvm/LLVM.lua
+++ b/build/llvm/LLVM.lua
@@ -137,6 +137,9 @@ function get_llvm_package_name(rev, conf, arch)
 end
 
 function get_llvm_configuration_name(debug)
+	if string.find(_OPTIONS["configuration"], "DebugOpt") then
+		return os.istarget("windows") and "RelWithDebInfo" or "Release"
+	end
 	if string.find(_OPTIONS["configuration"], "Debug") then
 		return "Debug"
 	end

--- a/tests/dotnet/CLI/Properties/launchSettings.json
+++ b/tests/dotnet/CLI/Properties/launchSettings.json
@@ -1,0 +1,8 @@
+{
+  "profiles": {
+    "CLI.Gen": {
+      "commandName": "Project",
+      "nativeDebugging": true
+    }
+  }
+}

--- a/tests/dotnet/CSharp/Properties/launchSettings.json
+++ b/tests/dotnet/CSharp/Properties/launchSettings.json
@@ -1,0 +1,8 @@
+{
+  "profiles": {
+    "CSharp.Gen": {
+      "commandName": "Project",
+      "nativeDebugging": true
+    }
+  }
+}

--- a/tests/dotnet/Common/Properties/launchSettings.json
+++ b/tests/dotnet/Common/Properties/launchSettings.json
@@ -1,0 +1,8 @@
+{
+  "profiles": {
+    "Common.Gen": {
+      "commandName": "Project",
+      "nativeDebugging": true
+    }
+  }
+}

--- a/tests/dotnet/Encodings/Properties/launchSettings.json
+++ b/tests/dotnet/Encodings/Properties/launchSettings.json
@@ -1,0 +1,8 @@
+{
+  "profiles": {
+    "Encodings.Gen": {
+      "commandName": "Project",
+      "nativeDebugging": true
+    }
+  }
+}

--- a/tests/dotnet/NamespacesDerived/Properties/launchSettings.json
+++ b/tests/dotnet/NamespacesDerived/Properties/launchSettings.json
@@ -1,0 +1,8 @@
+{
+  "profiles": {
+    "NamespacesDerived.Gen": {
+      "commandName": "Project",
+      "nativeDebugging": true
+    }
+  }
+}

--- a/tests/dotnet/StandardLib/Properties/launchSettings.json
+++ b/tests/dotnet/StandardLib/Properties/launchSettings.json
@@ -1,0 +1,8 @@
+{
+  "profiles": {
+    "StandardLib.Gen": {
+      "commandName": "Project",
+      "nativeDebugging": true
+    }
+  }
+}

--- a/tests/dotnet/VTables/Properties/launchSettings.json
+++ b/tests/dotnet/VTables/Properties/launchSettings.json
@@ -1,0 +1,8 @@
+{
+  "profiles": {
+    "VTables.Gen": {
+      "commandName": "Project",
+      "nativeDebugging": true
+    }
+  }
+}


### PR DESCRIPTION
I've added the DebugOpt config and set it as default for a better debugging experience.
This version enables some optimizations and uses `_ITERATOR_DEBUG_LEVEL=0` to remove many of the slowdowns of traditional debugging while still keeping the debuggability of the app intact.
It uses the release versions of llvm and crt.

Additionally I've enable native debugging when running *.Gen test projects from vs2022 by default