### PR TITLE
Fix ParseHeader() can only report the last file's error in non unityBuild mode

### DIFF
--- a/src/CppParser/Parser.cpp
+++ b/src/CppParser/Parser.cpp
@@ -5017,9 +5017,16 @@ ParserResult* ClangParser::ParseHeader(CppParserOptions* Opts)
         Parser parser(Opts);
 
         if (i < Headers.size() - 1)
-            delete parser.Parse({ Headers[i] });
-        else
+        {
             res = parser.Parse({ Headers[i] });
+            if (res && res->kind != ParserResultKind::Success)
+                return res;
+            delete res;
+        }
+        else
+        {
+            res = parser.Parse({ Headers[i] });
+        }
     }
 
     return res;


### PR DESCRIPTION
```
        if (i < Headers.size() - 1)
            // Before modified, the ParseResult is just deleted without checking whether it has any error.
            delete parser.Parse({ Headers[i] });
        else
            res = parser.Parse({ Headers[i] });
```
Change to: if any file has non success ParseResult, just stop parsing and return the result.