### PR TITLE
Fix ParseHeader() only reporting last file's error in non-unityBuildMode

### DIFF
--- a/src/CppParser/Parser.cpp
+++ b/src/CppParser/Parser.cpp
@@ -5059,9 +5059,16 @@ ParserResult* ClangParser::ParseHeader(CppParserOptions* Opts)
         Parser parser(Opts);
 
         if (i < Headers.size() - 1)
-            delete parser.Parse({ Headers[i] });
-        else
+        {
             res = parser.Parse({ Headers[i] });
+            if (res->kind != ParserResultKind::Success)
+                return res;
+            delete res;
+        }
+        else
+        {
+            res = parser.Parse({ Headers[i] });
+        }
     }
 
     return res;


### PR DESCRIPTION
Modify ClangParser::ParseHeader() to stop parsing and return immediately if any file has a non-success ParseResult.