### PR TITLE
getClangVersion is a constant

### DIFF
--- a/src/CppParser/CppParser.cpp
+++ b/src/CppParser/CppParser.cpp
@@ -19,7 +19,7 @@ namespace CppSharp { namespace CppParser {
 
     CppParserOptions::~CppParserOptions() {}
 
-    std::string CppParserOptions::getClangVersion()
+    const std::string& CppParserOptions::getClangVersion()
     {
         return clangVersion;
     }


### PR DESCRIPTION
Because getClangVersion never change and this avoid useless copies of strings